### PR TITLE
Move search API to manager for consistency.

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -1,0 +1,13 @@
+Search
+======
+
+* [Search a Folder and Its Children](#search-a-folder-and-its-children)
+
+Search a Folder and Its Children
+--------------------------------
+
+To get a list of items matching a search query, call the [`search.query(searchQuery, queryString, callback)`](http://opensource.box.com/box-node-sdk/Search.html#query) method.
+
+```js
+client.search.query('keyword search string', queryString, callback);
+```

--- a/lib/box-client.js
+++ b/lib/box-client.js
@@ -38,7 +38,8 @@ var Users = require('./managers/users'),
 	SharedItems = require('./managers/shared-items'),
 	Metadata = require('./managers/metadata'),
 	Collections = require('./managers/collections'),
-	Events = require('./managers/events');
+	Events = require('./managers/events'),
+	Search = require('./managers/search');
 
 // ------------------------------------------------------------------------------
 // Private
@@ -52,8 +53,6 @@ var HEADER_AUTHORIZATION = 'Authorization',
 	HEADER_BOXAPI = 'BoxApi',
 	// The XFF header label - Used to give the API better information for uploads, rate-limiting, etc.
 	HEADER_XFF = 'X-Forwarded-For',
-	// API Paths
-	API_PATHS_SEARCH = '/search',
 	// Range of SUCCESS http status codes
 	HTTP_STATUS_CODE_SUCCESS_BLOCK_RANGE = [200, 299];
 
@@ -215,6 +214,7 @@ function BoxClient(apiSession, config, requestManager) {
 	this.metadata = new Metadata(this);
 	this.collections = new Collections(this);
 	this.events = new Events(this);
+	this.search = new Search(this);
 }
 
 /**
@@ -607,25 +607,8 @@ BoxClient.prototype.plug = function(name, plugin, options) {
 
 
 // ------------------------------------------------------------------------------
-// Public - API Resource Endpoints
+// Public
 // ------------------------------------------------------------------------------
-
-/**
- * Searches Box for the given query.
- *
- * @param {string} query - The query to search for
- * @param {?Object} qs - Optional additional querystring to add to the request. Can be left null in most cases.
- * @param {APIRequest~Callback} callback - passed the new comment data if it was posted successfully
- * @returns {void}
- */
-BoxClient.prototype.search = function(query, qs, callback) {
-	qs = qs || {};
-	qs.query = query;
-	var params = {
-		qs: qs
-	};
-	this.get(API_PATHS_SEARCH, params, this.defaultResponseHandler(callback));
-};
 
 /**
  * @module box-node-sdk/lib/box-client

--- a/lib/managers/search.js
+++ b/lib/managers/search.js
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Manager for the Box Search Resource
+ * @author djordan
+ */
+
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+
+// ------------------------------------------------------------------------------
+// Private
+// ------------------------------------------------------------------------------
+var API_PATHS_SEARCH = '/search';
+
+// ------------------------------------------------------------------------------
+// Public
+// ------------------------------------------------------------------------------
+
+/**
+ * Simple manager for interacting with the search endpoints and actions.
+ *
+ * @constructor
+ * @param {BoxClient} client - The Box API Client that is responsible for making calls to the API
+ * @returns {void}
+ */
+function Search(client) {
+	this.client = client;
+}
+
+
+Search.prototype = {
+
+	/**
+	 * Searches Box for the given query.
+	 *
+	 * @param {string} query - The query to search for
+	 * @param {?Object} qs - Optional additional querystring to add to the request. Can be left null in most cases.
+	 * @param {APIRequest~Callback} callback - passed the new comment data if it was posted successfully
+	 * @returns {void}
+	 */
+	query: function(query, qs, callback) {
+		qs = qs || {};
+		qs.query = query;
+		var params = {
+			qs: qs
+		};
+		this.client.get(API_PATHS_SEARCH, params, this.client.defaultResponseHandler(callback));
+	}
+
+};
+
+module.exports = Search;

--- a/tests/lib/box-client-test.js
+++ b/tests/lib/box-client-test.js
@@ -527,18 +527,6 @@ describe('box-client', function() {
 
 	});
 
-	describe('search()', function() {
-
-		it('should make GET request to search the API and propagate results when called', function(done) {
-			var query = 'fakeQuery';
-
-			fakeParamsWithQs.qs.search = query;
-			sandbox.mock(basicClient).expects('get').withArgs('/search', fakeParamsWithQs).yieldsAsync(null, fakeOKResponse);
-			basicClient.search(query, fakeQs, done);
-		});
-
-	});
-
 	describe('plug()', function() {
 
 		var PLUGIN_API_ROOT = 'http://www.foobar.com',

--- a/tests/lib/managers/search-test.js
+++ b/tests/lib/managers/search-test.js
@@ -1,0 +1,71 @@
+/**
+ * @fileoverview Search Manager Tests
+ * @author djordan
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+var sinon = require('sinon'),
+	mockery = require('mockery'),
+	leche = require('leche');
+
+var BoxClient = require('../../../lib/box-client');
+
+
+// ------------------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------------------
+var sandbox = sinon.sandbox.create(),
+	boxClientFake = leche.fake(BoxClient.prototype),
+	SearchManager,
+	search,
+	MODULE_FILE_PATH = '../../../lib/managers/search';
+
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+describe('Search', function() {
+
+	before(function() {
+		// Enable Mockery
+		mockery.enable({ useCleanCache: true });
+		// Register Mocks
+		mockery.registerAllowable(MODULE_FILE_PATH);
+	});
+
+	beforeEach(function() {
+		// Setup File Under Test
+		SearchManager = require(MODULE_FILE_PATH);
+		search = new SearchManager(boxClientFake);
+	});
+
+	afterEach(function() {
+		sandbox.verifyAndRestore();
+		mockery.resetCache();
+	});
+
+	after(function() {
+		mockery.deregisterAll();
+		mockery.disable();
+	});
+
+	describe('search()', function() {
+
+		it('should make GET request to search the API and propagate results when called', function(done) {
+			var searchQuery = 'fakeQuery',
+				fakeQs = { fakeQsKey: 'fakeQsValue' },
+				fakeParamsWithQs = {qs: fakeQs};
+
+			fakeParamsWithQs.qs.search = searchQuery;
+			sandbox.mock(boxClientFake).expects('get').withArgs('/search', fakeParamsWithQs);
+			sandbox.stub(boxClientFake, 'defaultResponseHandler').yields();
+			search.query(searchQuery, fakeQs, done);
+		});
+
+	});
+
+});


### PR DESCRIPTION
This moves the search API off of the box-client and into its own manager so that it's consistent with our other endpoints.

@mattwiller: Please review.
