### PR TITLE
Remove unnecessary arguments from delete methods

### DIFF
--- a/docs/collaborations.md
+++ b/docs/collaborations.md
@@ -53,10 +53,10 @@ client.collaborations.update('56473', {role: client.collaborationRoles.PREVIEWER
 Remove a Collaboration
 ----------------------
 
-A collaboration can be removed by calling [`collaborations.delete(collaborationID, qs, callback)`](http://opensource.box.com/box-node-sdk/Collaborations.html#delete).
+A collaboration can be removed by calling [`collaborations.delete(collaborationID, callback)`](http://opensource.box.com/box-node-sdk/Collaborations.html#delete).
 
 ```js
-client.collaborations.delete('56473', null, callback);
+client.collaborations.delete('56473', callback);
 ```
 
 Get a Collaboration's Information

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -68,9 +68,9 @@ Delete a Comment
 ----------------
 
 A comment can be deleted with the
-[`comments.delete(commentID, qs, callback)`](http://opensource.box.com/box-node-sdk/Comments.html#delete)
+[`comments.delete(commentID, callback)`](http://opensource.box.com/box-node-sdk/Comments.html#delete)
 method.
 
 ```js
-client.comments.delete('45678', null, callback);
+client.comments.delete('45678', callback);
 ```

--- a/docs/files.md
+++ b/docs/files.md
@@ -103,11 +103,11 @@ Delete a File
 -------------
 
 Calling the
-[`files.delete(fileID, qs, callback)`](http://opensource.box.com/box-node-sdk/Files.html#delete)
+[`files.delete(fileID, callback)`](http://opensource.box.com/box-node-sdk/Files.html#delete)
 method will move the file to the user's trash.
 
 ```js
-client.files.delete('12345', null, callback);
+client.files.delete('12345', callback);
 ```
 
 Upload a New Version of a File

--- a/docs/folders.md
+++ b/docs/folders.md
@@ -19,8 +19,8 @@ group, and perform other common folder operations (move, copy, delete, etc.).
 Get a Folder's Information
 --------------------------
 
-Folder information can be retrieved by calling the 
-[`folders.get(folderID, queryString, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#get) method. Use the `queryString` parameter to specify the desired fields. Requesting information for only the fields you need can improve performance and reduce the size of the network request. 
+Folder information can be retrieved by calling the
+[`folders.get(folderID, queryString, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#get) method. Use the `queryString` parameter to specify the desired fields. Requesting information for only the fields you need can improve performance and reduce the size of the network request.
 
 ```js
 client.folders.get(
@@ -30,7 +30,7 @@ client.folders.get(
 );
 ```
 
-The user's root folder can be accessed by calling the 
+The user's root folder can be accessed by calling the
 [`folders.get(folderID, queryString, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#get) method with the `folderID` value of 0.
 
 ```js

--- a/lib/managers/collaborations.js
+++ b/lib/managers/collaborations.js
@@ -203,17 +203,13 @@ Collaborations.prototype.createWithGroupID = function(groupID, folderID, role, c
  * Method: DELETE
  *
  * @param {string} collaborationID - Box ID of the collaboration being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
  * @param {Function} callback - Empty response body passed if successful.
  * @returns {void}
  */
-Collaborations.prototype.delete = function(collaborationID, qs, callback) {
-	var params = {
-		qs: qs
-	};
+Collaborations.prototype.delete = function(collaborationID, callback) {
 
 	var apiPath = urlPath(BASE_PATH, collaborationID);
-	this.client.del(apiPath, params, this.client.defaultResponseHandler(callback));
+	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
 };
 
 

--- a/lib/managers/comments.js
+++ b/lib/managers/comments.js
@@ -127,17 +127,13 @@ Comments.prototype.update = function(commentID, options, callback) {
  * Method: DELETE
  *
  * @param {string} commentID - Box ID of the comment being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
  * @param {Function} callback - Empty response body passed if successful.
  * @returns {void}
  */
-Comments.prototype.delete = function(commentID, qs, callback) {
-	var params = {
-		qs: qs
-	};
+Comments.prototype.delete = function(commentID, callback) {
 
 	var apiPath = urlPath(BASE_PATH, commentID);
-	this.client.del(apiPath, params, this.client.defaultResponseHandler(callback));
+	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
 };
 
 

--- a/lib/managers/files.js
+++ b/lib/managers/files.js
@@ -332,17 +332,13 @@ Files.prototype.copy = function(fileID, newParentID, callback) {
  * Method: DELETE
  *
  * @param {string} fileID - Box ID of the file being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
  * @param {Function} callback - Empty response body passed if successful.
  * @returns {void}
  */
-Files.prototype.delete = function(fileID, qs, callback) {
-	var params = {
-		qs: qs
-	};
+Files.prototype.delete = function(fileID, callback) {
 
 	var apiPath = urlPath(BASE_PATH, fileID);
-	this.client.del(apiPath, params, this.client.defaultResponseHandler(callback));
+	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
 };
 
 /**

--- a/lib/managers/folders.js
+++ b/lib/managers/folders.js
@@ -142,7 +142,7 @@ Folders.prototype.copy = function(folderID, newParentID, callback) {
  * Method: PUT
  *
  * @param {string} folderID - The Box ID of the folder being requested
- * @param {?Object} options - Additional options can be passed with the request via form body. Can be left null in most cases.
+ * @param {?Object} options - Folder fields to update
  * @param {Function} callback - Passed the updated folder information if it was acquired successfully
  * @returns {void}
  */
@@ -185,17 +185,13 @@ Folders.prototype.move = function(folderID, newParentID, callback) {
  * Method: DELETE
  *
  * @param {string} folderID - Box ID of the folder being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
  * @param {Function} callback - Empty response body passed if successful.
  * @returns {void}
  */
-Folders.prototype.delete = function(folderID, qs, callback) {
-	var params = {
-		qs: qs
-	};
+Folders.prototype.delete = function(folderID, callback) {
 
 	var apiPath = urlPath(BASE_PATH, folderID);
-	this.client.del(apiPath, params, this.client.defaultResponseHandler(callback));
+	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
 };
 
 

--- a/lib/managers/users.js
+++ b/lib/managers/users.js
@@ -64,7 +64,7 @@ Users.prototype.get = function(id, qs, callback) {
  * Method: PUT
  *
  * @param {string} id - The ID of the user to update
- * @param {?Object} options - Additional options can be passed with the request via form body. Can be left null in most cases.
+ * @param {?Object} options - User fields to update
  * @param {Function} callback - Passed the updated user information if it was acquired successfully
  * @returns {void}
  */

--- a/tests/lib/managers/collaborations-test.js
+++ b/tests/lib/managers/collaborations-test.js
@@ -302,13 +302,13 @@ describe('Collaborations', function() {
 	describe('delete()', function() {
 		it('should make DELETE request to update collaboration info when called', function() {
 			sandbox.stub(boxClientFake, 'defaultResponseHandler');
-			sandbox.mock(boxClientFake).expects('del').withArgs('/collaborations/1234', testParamsWithQs);
-			collaborations.delete(COLLABORATION_ID, testQS);
+			sandbox.mock(boxClientFake).expects('del').withArgs('/collaborations/1234', null);
+			collaborations.delete(COLLABORATION_ID);
 		});
 		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
 			sandbox.mock(boxClientFake).expects('defaultResponseHandler').returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/collaborations/1234', testParamsWithQs).yieldsAsync();
-			collaborations.delete(COLLABORATION_ID, testQS, done);
+			sandbox.stub(boxClientFake, 'del').withArgs('/collaborations/1234', null).yieldsAsync();
+			collaborations.delete(COLLABORATION_ID, done);
 		});
 	});
 

--- a/tests/lib/managers/comments-test.js
+++ b/tests/lib/managers/comments-test.js
@@ -156,13 +156,13 @@ describe('Comments', function() {
 	describe('delete()', function() {
 		it('should make DELETE request to delete the comment when called', function() {
 			sandbox.stub(boxClientFake, 'defaultResponseHandler');
-			sandbox.mock(boxClientFake).expects('del').withArgs('/comments/1234', testParamsWithQs);
-			comments.delete(COMMENT_ID, testQS);
+			sandbox.mock(boxClientFake).expects('del').withArgs('/comments/1234', null);
+			comments.delete(COMMENT_ID);
 		});
 		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
 			sandbox.mock(boxClientFake).expects('defaultResponseHandler').returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/comments/1234', testParamsWithQs).yieldsAsync();
-			comments.delete(COMMENT_ID, testQS, done);
+			sandbox.stub(boxClientFake, 'del').withArgs('/comments/1234', null).yieldsAsync();
+			comments.delete(COMMENT_ID, done);
 		});
 	});
 

--- a/tests/lib/managers/files-test.js
+++ b/tests/lib/managers/files-test.js
@@ -326,13 +326,13 @@ describe('Files', function() {
 	describe('delete()', function() {
 		it('should make DELETE request to update file info when called', function() {
 			sandbox.stub(boxClientFake, 'defaultResponseHandler');
-			sandbox.mock(boxClientFake).expects('del').withArgs('/files/1234', testParamsWithQs);
-			files.delete(FILE_ID, testQS);
+			sandbox.mock(boxClientFake).expects('del').withArgs('/files/1234', null);
+			files.delete(FILE_ID);
 		});
 		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
 			sandbox.mock(boxClientFake).expects('defaultResponseHandler').returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/files/1234', testParamsWithQs).yieldsAsync();
-			files.delete(FILE_ID, testQS, done);
+			sandbox.stub(boxClientFake, 'del').withArgs('/files/1234', null).yieldsAsync();
+			files.delete(FILE_ID, done);
 		});
 	});
 

--- a/tests/lib/managers/folders-test.js
+++ b/tests/lib/managers/folders-test.js
@@ -195,13 +195,13 @@ describe('Folders', function() {
 	describe('delete()', function() {
 		it('should make DELETE request to update folder info when called', function() {
 			sandbox.stub(boxClientFake, 'defaultResponseHandler');
-			sandbox.mock(boxClientFake).expects('del').withArgs('/folders/1234', testParamsWithQs);
-			folders.delete(FOLDER_ID, testQS);
+			sandbox.mock(boxClientFake).expects('del').withArgs('/folders/1234', null);
+			folders.delete(FOLDER_ID);
 		});
 		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
 			sandbox.mock(boxClientFake).expects('defaultResponseHandler').returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/folders/1234', testParamsWithQs).yieldsAsync();
-			folders.delete(FOLDER_ID, testQS, done);
+			sandbox.stub(boxClientFake, 'del').withArgs('/folders/1234', null).yieldsAsync();
+			folders.delete(FOLDER_ID, done);
 		});
 	});
 


### PR DESCRIPTION
Delete methods don't take any query string parameters, so we can remove that argument from the method signature.

Review: @djordan
