### PR TITLE
Add query string params to folder delete

### DIFF
--- a/docs/folders.md
+++ b/docs/folders.md
@@ -117,10 +117,10 @@ client.folders.update('12345', {name: 'New Name'}, callback);
 Delete a Folder
 ---------------
 
-A folder can be deleted with the [`folders.delete(folderID, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#delete) method.
+A folder can be deleted with the [`folders.delete(folderID, qs, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#delete) method.
 
 ```js
-client.folders.delete('12345', callback);
+client.folders.delete('12345', {recursive: true}, callback);
 ```
 
 

--- a/lib/managers/folders.js
+++ b/lib/managers/folders.js
@@ -185,13 +185,18 @@ Folders.prototype.move = function(folderID, newParentID, callback) {
  * Method: DELETE
  *
  * @param {string} folderID - Box ID of the folder being requested
+ * @param {?Object} qs - Optional query string params, can be left null in most cases
  * @param {Function} callback - Empty response body passed if successful.
  * @returns {void}
  */
-Folders.prototype.delete = function(folderID, callback) {
+Folders.prototype.delete = function(folderID, qs, callback) {
+
+	var params = {
+		qs: qs
+	};
 
 	var apiPath = urlPath(BASE_PATH, folderID);
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	this.client.del(apiPath, params, this.client.defaultResponseHandler(callback));
 };
 
 /**

--- a/tests/lib/managers/folders-test.js
+++ b/tests/lib/managers/folders-test.js
@@ -195,13 +195,13 @@ describe('Folders', function() {
 	describe('delete()', function() {
 		it('should make DELETE request to update folder info when called', function() {
 			sandbox.stub(boxClientFake, 'defaultResponseHandler');
-			sandbox.mock(boxClientFake).expects('del').withArgs('/folders/1234', null);
-			folders.delete(FOLDER_ID);
+			sandbox.mock(boxClientFake).expects('del').withArgs('/folders/1234', testParamsWithQs);
+			folders.delete(FOLDER_ID, testQS);
 		});
 		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
 			sandbox.mock(boxClientFake).expects('defaultResponseHandler').returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/folders/1234', null).yieldsAsync();
-			folders.delete(FOLDER_ID, done);
+			sandbox.stub(boxClientFake, 'del').withArgs('/folders/1234', testParamsWithQs).yieldsAsync();
+			folders.delete(FOLDER_ID, testQS, done);
 		});
 	});
 


### PR DESCRIPTION
Per https://docs.box.com/reference#delete-a-folder folder deletion
can take an optional `recursive` parameter in the query string, so
the folders.delete() method must take qs as an argument.

Review: @djordan 
