### PR TITLE
Added full-featured upload support

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -88,6 +88,16 @@ target.docs = function() {
 	nodeCLI.exec('jsdoc', '-r', '-d ./ ', JS_DIR);
 };
 
+target.jsdoc = function() {
+	echo('Generating documentation');
+	nodeCLI.exec('jsdoc', '-r', '-d jsdoc ', JS_DIR);
+};
+
+target.jsdocprivate = function() {
+	echo('Generating documentation');
+	nodeCLI.exec('jsdoc', '-r', '-p', '-d jsdoc ', JS_DIR);
+};
+
 target.patch = function() {
 	release('patch');
 };

--- a/lib/managers/files.js
+++ b/lib/managers/files.js
@@ -12,7 +12,12 @@
 
 var urlPath = require('../util/url-path'),
 	errors = require('../util/errors'),
-	httpStatusCodes = require('http-status');
+	httpStatusCodes = require('http-status'),
+	fs = require('fs'),
+	path = require('path'),
+	dateFormat = require('dateformat'),
+	nodeSHA1 = require('node-sha1'),
+	stream = require('stream');
 
 // ------------------------------------------------------------------------------
 // Private
@@ -22,21 +27,111 @@ var urlPath = require('../util/url-path'),
 var BASE_PATH = '/files';
 
 /**
+ * Return the file metadata for a local file, including name, size, content_created_at, and content_modified_at.
+ *
+ * @param {string} filePath - The path of the file
+ * @param {Function} callback - Passed the file metadata object
+ * @returns {void}
+ * @private
+ */
+function getMetadataForFile(filePath, callback) {
+	fs.stat(filePath, (err, stats) => {
+		if (err) {
+			callback(err);
+			return;
+		}
+
+		callback(null, {
+			name: path.basename(filePath),
+			size: stats.size,
+			content_created_at: dateFormat(stats.birthtime, 'isoDateTime'),
+			content_modified_at: dateFormat(stats.mtime, 'isoDateTime')
+		});
+	});
+}
+
+/**
+ * Return the file metadata for upload content.  If the content is a string or Buffer it returns the size.
+ * If the content is a stream created by fs.createReadStream(), it returns the file's name, size,
+ * content_created_at, and content_modified_at.  The size takes into account the start and end
+ * options on fs.createReadStream().
+ *
+ * @param {string|Buffer|Stream} content - The upload content (string, Buffer, or read stream)
+ * @param {Function} callback - Passed the file metadata object
+ * @returns {void}
+ * @private
+ */
+function getMetadataForContent(content, callback) {
+	// Copied logic from FormData._trackLength() in form_data.js:75
+	if (Buffer.isBuffer(content)) {
+		// For a Buffer, we only know the size.
+		callback(null, {size: content.length});
+		return;
+	} else if (typeof content === 'string') {
+		// For a string, we only know the size.
+		callback(null, {size: Buffer.byteLength(content)});
+		return;
+	} else if (content instanceof stream && content.hasOwnProperty('fd') && content.path) {
+		// For a stream created by fs.createReadStream(), stat the underlying file.
+		getMetadataForFile(content.path, (err, metadata) => {
+			if (err) {
+				callback(err);
+				return;
+			}
+
+			// Take the stream's start and end options into account.
+			// TODO: There may be a bug in Node fs.createReadStream
+			// It doesn't respect the `end` option unless there is a `start` option.
+			// https://github.com/joyent/node/issues/7819
+			// Fix it when node fixes it (by using the commented out line instead)
+			// if (content.end != undefined && content.end != Infinity) {
+			if (content.end !== undefined && content.end !== Infinity && content.start !== undefined) {
+				// Note: content.end is *inclusive*
+				metadata.size = (content.end + 1) - (content.start ? content.start : 0);
+			} else {
+				metadata.size = metadata.size - (content.start ? content.start : 0);
+			}
+
+			callback(null, metadata);
+		});
+		return;
+	}
+
+	// Unknown content type
+	callback(null, {});
+}
+
+/**
+ * Returns the SHA1 hash for upload content.
+ *
+ * @param {string|Buffer|Stream} content - The upload content (string, Buffer, or read stream)
+ * @param {Function} callback - Passed the SHA1 hash
+ * @returns {void}
+ * @private
+ */
+function getSHA1ForContent(content, callback) {
+	nodeSHA1(content, callback);
+}
+
+/**
  * Returns the multipart form value for file upload metadata.
- * @param {string} parentFolderID - the ID of the parent folder to upload to
- * @param {string} filename - the file name that the uploaded file should have
+ * @param {?string} parentFolderID - the ID of the parent folder to upload to
+ * @param {Object} fileData - the file data that the uploaded file should have (filename, mod dates, size, etc)
  * @returns {Object} - the form value expected by the API for the 'metadata' key
  * @private
  */
-function createFileMetadataFormData(parentFolderID, filename) {
+function createFileMetadataFormData(parentFolderID, fileData) {
 	// Although the filename and parent folder ID can be specified without using a
 	// metadata form field, Platform has recommended that we use the metadata form
 	// field to specify these parameters (one benefit is that UTF-8 characters can
 	// be specified in the filename).
-	return JSON.stringify({
-		name: filename,
-		parent: { id: parentFolderID }
-	});
+	let metadata = Object.assign({}, fileData);
+
+	if (parentFolderID) {
+		metadata.parent = {id: parentFolderID};
+	}
+
+	return JSON.stringify(metadata);
 }
 
 /**
@@ -428,7 +523,7 @@ Files.prototype.uploadFile = function(parentFolderID, filename, content, callbac
 	var apiPath = urlPath(BASE_PATH, '/content'),
 		multipartFormData = {
 			content: createFileContentFormData(content),
-			metadata: createFileMetadataFormData(parentFolderID, filename)
+			metadata: createFileMetadataFormData(parentFolderID, { name: filename })
 		};
 
 	this.client.upload(apiPath, null, multipartFormData, this.client.defaultResponseHandler(callback));
@@ -455,6 +550,315 @@ Files.prototype.uploadNewFileVersion = function(fileID, content, callback) {
 		};
 
 	this.client.upload(apiPath, null, multipartFormData, this.client.defaultResponseHandler(callback));
+};
+
+/**
+ * Upload a file, using the pre-flight upload API to validate the upload so that
+ * the content isn't uploaded if the file can't be created.  Uses the Box Accelerator network, if available,
+ * to speed up uploads of large files.
+ *
+ * @param {string} parentFolderID - The id of the parent folder to upload to
+ * @param {Object} fileAttributes - File name, size, create date, etc.
+ * @param {string|Buffer|Stream} content - The upload content (string, Buffer, or read stream)
+ * @param {Object} options - Upload options
+ * @param {boolean} [options.usePreflight=true] - Call the pre-flight upload API before uploading the file. This
+ * avoids uploading the file in the case of errors (e.g. storage_limit_exceeded, access_denied_insufficient_permissions, etc.)
+ * @param {boolean} [options.useAccelerator=true] - Use Box Accelerator, if available. Requires the 'usePreflight' option
+ * @param {Function} callback - Passed the file info of the uploaded file
+ * @returns {void}
+ * @private
+ */
+Files.prototype.uploadFileWithPreflight = function(parentFolderID, fileAttributes, content, options, callback) {
+	options = Object.assign({
+		usePreflight: true,
+		useAccelerator: true
+	}, options);
+
+	if (options.usePreflight) {
+		// Call the pre-flight upload API
+		this.preflightUploadFile(parentFolderID, fileAttributes, null, (err, uploadData) => {
+			if (err) {
+				callback(err);
+				return;
+			}
+
+			// Get the upload URL to use (may use a Box Accelerator node, if appropriate)
+			const uploadURL = (options.useAccelerator) ? uploadData.upload_url : null;
+
+			// Upload the file
+			this.uploadFileUsingUploadURL(parentFolderID, fileAttributes, content, uploadURL, callback);
+		});
+		return;
+	}
+	// Just upload the file directly
+	this.uploadFileUsingUploadURL(parentFolderID, fileAttributes, content, null, callback);
+};
+
+/**
+ * Upload a new file version, using the pre-flight upload API to validate the upload so that
+ * the content isn't uploaded if the file version can't be created.  Uses the Box Accelerator network, if available,
+ * to speed up uploads of large files.
+
+ * @param {string} fileID - The id of the file to upload a new version of
+ * @param {Object} fileAttributes - File name, size, create date, etc.
+ * @param {string|Buffer|Stream} content - The upload content (string, Buffer, or read stream)
+ * @param {Object} options - Upload options
+ * @param {boolean} [options.usePreflight=true] - Call the pre-flight upload API before uploading the file. This
+ * avoids uploading the file in the case of errors (e.g. storage_limit_exceeded, access_denied_insufficient_permissions, etc.)
+ * @param {boolean} [options.useAccelerator=true] - Use Box Accelerator, if available. Requires the 'usePreflight' option
+ * @param {Function} callback - Passed the file info of the uploaded file
+ * @returns {void}
+ * @private
+ */
+Files.prototype.uploadNewFileVersionWithPreflight = function(fileID, fileAttributes, content, options, callback) {
+	options = Object.assign({
+		usePreflight: true,
+		useAccelerator: true
+	}, options);
+
+	if (options.usePreflight) {
+		// Call the pre-flight upload API
+		this.preflightUploadNewFileVersion(fileID, fileAttributes, null, (err, uploadData) => {
+			if (err) {
+				callback(err);
+				return;
+			}
+			// Get the upload URL to use (may use a Box Accelerator node, if appropriate)
+			const uploadURL = (options.useAccelerator) ? uploadData.upload_url : null;
+
+			// Upload the new version
+			this.uploadNewFileVersionUsingUploadURL(fileID, fileAttributes, content, uploadURL, callback);
+		});
+		return;
+	}
+	// Just upload the new version directly
+	this.uploadNewFileVersionUsingUploadURL(fileID, fileAttributes, content, null, callback);
+};
+
+/**
+ * Upload a file, using a specific upload URL.
+ *
+ * @param {string} parentFolderID - The id of the parent folder to upload to
+ * @param {Object} fileAttributes - File name, size, create date, etc.
+ * @param {string|Buffer|Stream} content - The upload content (string, Buffer, or read stream)
+ * @param {?string} uploadURL - The upload URL to use
+ * @param {Function} callback - Passed the file info of the uploaded file
+ * @returns {void}
+ * @private
+ */
+Files.prototype.uploadFileUsingUploadURL = function(parentFolderID, fileAttributes, content, uploadURL, callback) {
+	uploadURL = uploadURL || urlPath(BASE_PATH, '/content');
+
+	let params = Object.assign({}, fileAttributes);
+	params.parent = {id: parentFolderID};
+
+	const multipartFormData = {
+		content: createFileContentFormData(content),
+		metadata: createFileMetadataFormData(parentFolderID, fileAttributes)
+	};
+
+	this.client.upload(uploadURL, null, multipartFormData, this.client.defaultResponseHandler(callback));
+};
+
+/**
+ * Upload a new file version, using a specific upload URL.
+
+ * @param {string} fileID - The id of the file to upload a new version of
+ * @param {Object} fileAttributes - File name, size, create date, etc.
+ * @param {string|Buffer|Stream} content - The upload content (string, Buffer, or read stream)
+ * @param {?string} uploadURL - The upload URL to use
+ * @param {Function} callback - Passed the file info of the uploaded file
+ * @returns {void}
+ * @private
+ */
+Files.prototype.uploadNewFileVersionUsingUploadURL = function(fileID, fileAttributes, content, uploadURL, callback) {
+	uploadURL = uploadURL || urlPath(BASE_PATH, fileID, '/content');
+
+	const multipartFormData = {
+		content: createFileContentFormData(content),
+		metadata: createFileMetadataFormData(null, fileAttributes)
+	};
+
+	this.client.upload(uploadURL, null, multipartFormData, this.client.defaultResponseHandler(callback));
+};
+
+/**
+ * Upload a file, automatically passing the file metadata, including the name, size,
+ * creation date, and modification date.  Uses the pre-flight upload API to validate the upload so that
+ * the content isn't uploaded if the file can't be created.  Uses the Box Accelerator network, if available,
+ * to speed up uploads of large files. Includes options to create a new file version if the file already exists
+ * and to avoid uploading identical files.
+ *
+ * @param {string} parentFolderID - The id of the parent folder to upload to
+ * @param {?Object} fileAttributes - You can override the attributes from the file's metadata (e.g. set 'name'
+ * to use a different file name)
+ * @param {string} fileAttributes.name - For files, defaults to the file's 'basename'.  Required option for strings and Buffers
+ * @param {int} fileAttributes.size - Defaults to the size of the string, Buffer, or file
+ * @param {string} fileAttributes.content_created_at - For files, defaults to the file's 'birthtime'
+ * @param {string} fileAttributes.content_modified_at - For files, defaults to the file's 'mtime'
+ * @param {string|Buffer|Stream} content - The upload content (string, Buffer, or read stream)
+ * @param {?Object} options - Upload options
+ * @param {boolean} [options.createNewVersion=false] - Create a new version of the file if a file with that name already exists
+ * @param {boolean} [options.skipDuplicates=true] - Don't upload the file if the existing file has the same SHA-1
+ * @param {boolean} [options.preserveTimestamps=true] - Preserve the file's creation date, and modification date.
+ * If false, the file's timestamps will be set to the upload time
+ * @param {boolean} [options.usePreflight=true] - Call the pre-flight upload API before uploading the file. This
+ * avoids uploading the file in the case of errors (e.g. storage_limit_exceeded, access_denied_insufficient_permissions, etc.)
+ * @param {boolean} [options.useAccelerator=true] - Use Box Accelerator, if available. Requires the 'usePreflight' option
+ * @param {Function} callback - Passed the file info of the uploaded file
+ * @returns {void}
+ */
+Files.prototype.uploadFileWithOptions = function(parentFolderID, fileAttributes, content, options, callback) {
+	options = Object.assign({
+		createNewVersion: false,
+		skipDuplicates: true,
+		preserveTimestamps: true,
+		usePreflight: true,
+		useAccelerator: true
+	}, options);
+
+	// Get the metadata
+	getMetadataForContent(content, (err, fileData) => {
+		if (err) {
+			// Error getting the metadata
+			callback(err);
+			return;
+		}
+
+		if (!options.preserveTimestamps) {
+			delete fileData.content_created_at;
+			delete fileData.content_modified_at;
+		}
+
+		// Merge in additional attributes or overrides from fileAttributes
+		if (fileAttributes) {
+			Object.assign(fileData, fileAttributes);
+		}
+
+		// Ensure that we have a filename
+		if (!fileData.name) {
+			const err5 = new Error('Must specify file name for upload content');
+			// TODO: Set err.type
+			callback(err5);
+			return;
+		}
+
+		// Try uploading the file (with pre-flight check and accelerator)
+		this.uploadFileWithPreflight(parentFolderID, fileData, content, options, (err2, file) => {
+			if (err2) {
+				// Check if the upload failed due to an existing file of the same name
+				if (options.createNewVersion &&
+					err2.response &&
+					err2.response.body &&
+					err2.response.body.code === 'item_name_in_use' &&
+					err2.response.body.context_info &&
+					err2.response.body.context_info.conflicts &&
+					// Can only updload a new version if the existing item is a file
+					err2.response.body.context_info.conflicts.type === 'file' &&
+					err2.response.body.context_info.conflicts.id) {
+					// Get info about the existing file
+					const {id, sha1} = err2.response.body.context_info.conflicts;
+
+					// Check if the file is a duplicate
+					if (options.skipDuplicates) {
+						getSHA1ForContent(content, (err3, existingSHA1) => {
+							if (err3) {
+								// Error getting the SHA-1
+								callback(err3);
+								return;
+							}
+
+							if (sha1 === existingSHA1) {
+								// Don't upload the file.
+								const err4 = new Error('File not uploaded - existing file has same SHA-1');
+								// TODO: Set err.type
+								callback(err4);
+								// TODO: Instead of returning an error, we could return the data from the existing item
+								// callback(null, err.response.body.context_info.conflicts)
+								return;
+							}
+
+							// Not a duplicate - upload the new version
+							// TODO: Use etag to avoid possible race condition (existing file might have changed in the meanwhile)
+							this.uploadNewFileVersionWithPreflight(id, fileData, content, options, callback);
+						});
+						return;
+					}
+
+					// Upload the new version
+					// TODO: Use etag to avoid possible race condition (existing file might have changed in the meanwhile)
+					this.uploadNewFileVersionWithPreflight(id, fileData, content, options, callback);
+					return;
+				}
+
+				// There was some other error uploading the file
+				callback(err2, file);
+				return;
+			}
+
+			// The initial upload succeeded
+			callback(null, file);
+		});
+	});
+};
+
+/**
+ * Upload a new file version, automatically passing the file metadata, including the name, size,
+ * creation date, and modification date.  Uses the pre-flight upload API to validate the upload so that
+ * the content isn't uploaded if the file version can't be created.  Uses the Box Accelerator network, if available,
+ * to speed up uploads of large files. Includes option to update the name of the file on Box.
+
+ * @param {string} fileID - The id of the file to upload a new version of
+ * @param {?Object} fileAttributes - You can override the attributes from the file's metadata (e.g. set 'name'
+ * to use a different file name)
+ * @param {string} fileAttributes.name - For files, defaults to the file's 'basename'.
+ * @param {int} fileAttributes.size - Defaults to the size of the string, Buffer, or file
+ * @param {string} fileAttributes.content_created_at - For files, defaults to the file's 'birthtime'
+ * @param {string} fileAttributes.content_modified_at - For files, defaults to the file's 'mtime'
+ * @param {string|Buffer|Stream} content - The upload content (string, Buffer, or read stream)
+ * @param {?Object} options - Upload options
+ * @param {boolean} [options.updateName=false] - Update the name of the file on Box to the name of the uploaded file
+ * @param {boolean} [options.preserveTimestamps=true] - Preserve the file's creation date, and modification date.
+ * If false, the file's timestamps will be set to the upload time
+ * @param {boolean} [options.usePreflight=true] - Call the pre-flight upload API before uploading the file. This
+ * avoids uploading the file in the case of errors (e.g. storage_limit_exceeded, access_denied_insufficient_permissions, etc.)
+ * @param {boolean} [options.useAccelerator=true] - Use Box Accelerator, if available. Requires the 'usePreflight' option
+ * @param {Function} callback - Passed the file info of the uploaded file
+ * @returns {void}
+ */
+Files.prototype.uploadNewFileVersionWithOptions = function(fileID, fileAttributes, content, options, callback) {
+	options = Object.assign({
+		updateName: false,
+		preserveTimestamps: true,
+		usePreflight: true,
+		useAccelerator: true
+	}, options);
+
+	// Get the metadata
+	getMetadataForContent(content, (err, fileData) => {
+		if (err) {
+			// Error getting the metadata
+			callback(err);
+			return;
+		}
+
+		if (!options.updateName) {
+			delete fileData.name;
+		}
+
+		if (!options.preserveTimestamps) {
+			delete fileData.content_created_at;
+			delete fileData.content_modified_at;
+		}
+
+		// Merge in additional attributes or overrides from fileAttributes
+		if (fileAttributes) {
+			Object.assign(fileData, fileAttributes);
+		}
+
+		// Upload the file (with pre-flight check and accelerator)
+		this.uploadNewFileVersionWithPreflight(fileID, fileData, content, options, callback);
+	});
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "description": "A Box SDK for Node.js",
   "license": "Apache-2.0",
   "repository": {
-	  "type": "git",
-	  "url": "https://github.com/box/box-node-sdk.git"
+    "type": "git",
+    "url": "https://github.com/box/box-node-sdk.git"
   },
   "engines": {
     "node": ">= 4.0.0"
@@ -15,16 +15,20 @@
   "scripts": {
     "test": "node Makefile.js",
     "lint": "node Makefile.js lint",
-    "docs": "node Makefile.js docs",
+	"docs": "node Makefile.js docs",
+	"jsdoc": "node Makefile.js jsdoc",
+	"jsdoc-private": "node Makefile.js jsdocprivate",
     "deps": "npm prune && npm install",
     "patch": "node Makefile.js patch",
     "minor": "node Makefile.js minor",
     "major": "node Makefile.js major"
   },
   "dependencies": {
+    "dateformat": "^1.0.12",
     "http-status": "^0.2.2",
     "jsonwebtoken": "^5.7.0",
     "lodash.merge": "^4.3.5",
+    "node-sha1": "^1.0.1",
     "node-uuid": "^1.4.7",
     "request": "^2.70.0"
   },

--- a/tests/lib/managers/files-test.js
+++ b/tests/lib/managers/files-test.js
@@ -47,6 +47,11 @@ describe('Files', function() {
 		mockery.registerAllowable('util');
 		mockery.registerAllowable('../util/url-path');
 		mockery.registerAllowable('../util/errors');
+		mockery.registerAllowable('fs');
+		mockery.registerAllowable('path');
+		mockery.registerAllowable('dateformat');
+		mockery.registerAllowable('node-sha1');
+		mockery.registerAllowable('stream');
 		// Setup File Under Test
 		mockery.registerAllowable(MODULE_FILE_PATH);
 		Files = require(MODULE_FILE_PATH);


### PR DESCRIPTION
+ New methods:
- Files.uploadFileWithOptions()
- Files.uploadNewFileVersionWithOptions()
+ Automatically passes file metadata, including name, size, and
timestamps
+ Option to call pre-flight upload API before uploading
+ Option to use Box Accelerator, if available
+ Option to upload new file version if file already exists
+ Option to skip upload if the existing file has the same SHA-1
+ Option to preserve file timestamps