### PR TITLE
Fix the form order in multipart upload request

### DIFF
--- a/lib/managers/files.js
+++ b/lib/managers/files.js
@@ -427,8 +427,8 @@ Files.prototype.preflightUploadNewFileVersion = function(fileID, fileData, qs, c
 Files.prototype.uploadFile = function(parentFolderID, filename, content, callback) {
 	var apiPath = urlPath(BASE_PATH, '/content'),
 		multipartFormData = {
-			content: createFileContentFormData(content),
-			metadata: createFileMetadataFormData(parentFolderID, filename)
+			attributes: createFileMetadataFormData(parentFolderID, filename),
+			content: createFileContentFormData(content)
 		};
 
 	this.client.upload(apiPath, null, multipartFormData, this.client.defaultResponseHandler(callback));

--- a/tests/lib/managers/files-test.js
+++ b/tests/lib/managers/files-test.js
@@ -410,7 +410,7 @@ describe('Files', function() {
 
 		it('should call BoxClient.upload() with the correct non-callback params', function() {
 			var expectedFormData = {
-				metadata: JSON.stringify({
+				attributes: JSON.stringify({
 					name: FILENAME,
 					parent: { id: PARENT_FOLDER_ID }
 				}),


### PR DESCRIPTION
According to https://docs.box.com/reference#upload-a-file, 
1) the file bytes should come after the JSON for best performance.
2) the field name for metadata changed to "attributes".