### PR TITLE
Merge Config params correctly (fixes #10)

### DIFF
--- a/lib/util/config.js
+++ b/lib/util/config.js
@@ -10,7 +10,7 @@
 // ------------------------------------------------------------------------------
 var assert = require('assert'),
 	https = require('https'),
-	merge = require('lodash.merge'),
+	merge = require('merge-options'),
 	version = require('../../package.json').version;
 
 // ------------------------------------------------------------------------------
@@ -142,9 +142,11 @@ function Config(params) {
 
 	// Ensure that we don't accidentally assign over Config methods
 	assert(!params.hasOwnProperty('extend'), 'Config params may not override Config methods');
+	assert(!params.hasOwnProperty('_params'), 'Config params may not override Config methods');
 
 	// Set the given params or default value if params property is missing
-	merge(this, defaults, params);
+	this._params = merge(defaults, params);
+	Object.assign(this, this._params);
 
 	// Freeze the object so that configuration options cannot be modified
 	Object.freeze(this);
@@ -156,8 +158,9 @@ function Config(params) {
  * @returns {Config} The extended configuration
  */
 Config.prototype.extend = function(params) {
-	var newParams = merge({}, this, params);
+	var newParams = merge({}, this._params, params);
 	delete newParams.extend;
+	delete newParams._params;
 	return new Config(newParams);
 };
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "http-status": "^0.2.2",
     "jsonwebtoken": "^5.7.0",
-    "lodash.merge": "^4.3.5",
+    "merge-options": "0.0.64",
     "node-uuid": "^1.4.7",
     "request": "^2.74.0"
   },

--- a/tests/lib/util/config-test.js
+++ b/tests/lib/util/config-test.js
@@ -13,6 +13,7 @@
 // ------------------------------------------------------------------------------
 
 var assert = require('chai').assert,
+	Readable = require('stream').Readable,
 	Config = require('../../../lib/util/config');
 
 // ------------------------------------------------------------------------------
@@ -152,6 +153,43 @@ describe('Config', function() {
 
 			assert.deepPropertyVal(newConfig, 'request.qs.fields', 'id,name,type');
 			assert.notDeepProperty(originalConfig, 'request.qs');
+		});
+
+		it('should not clone stream objects', function() {
+
+			var stream = new Readable();
+
+			var originalConfig = new Config({
+				clientID: 'id',
+				clientSecret: 'secret',
+				request: {
+					strictSSL: true
+				}
+			});
+
+			var newConfig = originalConfig.extend({
+				request: {
+					formData: {
+						value: stream,
+						options: { filename: 'unused' }
+					}
+				}
+			});
+
+			assert.deepProperty(newConfig, 'request.formData.value');
+			assert.strictEqual(newConfig.request.formData.value, stream);
+		});
+
+		it('should retain properties set by a previous extension', function() {
+
+			var doubleExtendedConfig = config.extend({
+				clientID: 'newID'
+			}).extend({
+				clientSecret: 'newSecret'
+			});
+
+			assert.propertyVal(doubleExtendedConfig, 'clientID', 'newID');
+			assert.propertyVal(doubleExtendedConfig, 'clientSecret', 'newSecret');
 		});
 
 	});


### PR DESCRIPTION
Incorrect merging of Config param objects for an upload from a
stream resulted in the stream object being cloned.  The cloned
stream would never receive the callback to hook up the file
descriptor (or other resource), so it could never start sending
bytes, causing the upload to time out.

/cc: @djordan