### PR TITLE
Allow rename on copy

### DIFF
--- a/docs/files.md
+++ b/docs/files.md
@@ -124,6 +124,14 @@ method.
 client.files.copy('12345', '0', callback);
 ```
 
+An optional `name` parameter can also be passed to rename the file on copy.  This can be
+used to avoid a name conflict when there is already an item with the same name in the
+target folder.
+
+```js
+client.files.copy('12345', '0', {name: 'Renamed file.png'}, callback);
+```
+
 Delete a File
 -------------
 

--- a/docs/folders.md
+++ b/docs/folders.md
@@ -95,6 +95,13 @@ Call the [`folders.copy(sourceFolderID, destinationFolderID, callback)`](http://
 client.folders.copy('12345', '67890', callback);
 ```
 
+An optional `name` parameter can also be passed to rename the folder on copy.  This can be
+used to avoid a name conflict when there is already an item with the same name in the
+target folder.
+
+```js
+client.folders.copy('12345', '0', {name: 'Renamed folder'}, callback);
+```
 
 Move a Folder
 -------------

--- a/lib/managers/files.js
+++ b/lib/managers/files.js
@@ -312,16 +312,28 @@ Files.prototype.move = function(fileID, newParentID, callback) {
  *
  * @param {string} fileID - The Box ID of the file being requested
  * @param {string} newParentID - The Box ID for the new parent folder. '0' to copy to All Files.
+ * @param {?Object} options - Optional parameters for the copy operation, can be left null in most cases
+ * @param {string} [options.name] - A new name to use if there is an identically-named item in the new parent folder
  * @param {Function} callback - passed the new file info if call was successful
  * @returns {void}
  */
-Files.prototype.copy = function(fileID, newParentID, callback) {
+Files.prototype.copy = function(fileID, newParentID, options, callback) {
+
+	// @NOTE(mwiller) 2016-10-25: Shuffle arguments to maintain backward compatibility
+	//  This can be removed at the v2.0 update
+	if (typeof options === 'function') {
+		callback = options;
+		options = {};
+	}
+
+	options = options || {};
+
+	options.parent = {
+		id: newParentID
+	};
+
 	var params = {
-		body: {
-			parent: {
-				id: newParentID
-			}
-		}
+		body: options
 	};
 	var apiPath = urlPath(BASE_PATH, fileID, '/copy');
 	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));

--- a/lib/managers/folders.js
+++ b/lib/managers/folders.js
@@ -120,16 +120,28 @@ Folders.prototype.create = function(parentFolderID, name, callback) {
  *
  * @param {string} folderID - The Box ID of the folder being requested
  * @param {string} newParentID - The Box ID for the new parent folder. '0' to copy to All Files.
+ * @param {?Object} options - Optional parameters for the copy operation, can be left null in most cases
+ * @param {string} [options.name] - A new name to use if there is an identically-named item in the new parent folder
  * @param {Function} callback - passed the new folder info if call was successful
  * @returns {void}
  */
-Folders.prototype.copy = function(folderID, newParentID, callback) {
+Folders.prototype.copy = function(folderID, newParentID, options, callback) {
+
+	// @NOTE(mwiller) 2016-10-25: Shuffle arguments to maintain backward compatibility
+	//  This can be removed at the v2.0 update
+	if (typeof options === 'function') {
+		callback = options;
+		options = {};
+	}
+
+	options = options || {};
+
+	options.parent = {
+		id: newParentID
+	};
+
 	var params = {
-		body: {
-			parent: {
-				id: newParentID
-			}
-		}
+		body: options
 	};
 	var apiPath = urlPath(BASE_PATH, folderID, '/copy');
 	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));

--- a/tests/lib/managers/files-test.js
+++ b/tests/lib/managers/files-test.js
@@ -283,6 +283,17 @@ describe('Files', function() {
 			files.copy(FILE_ID, NEW_PARENT_ID);
 		});
 
+		it('should make POST request to copy the folder with optional parameters when passed', function() {
+
+			var name = 'rename on copy';
+
+			expectedParams.body.name = name;
+
+			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.mock(boxClientFake).expects('post').withArgs('/files/1234/copy', expectedParams);
+			files.copy(FILE_ID, NEW_PARENT_ID, {name});
+		});
+
 		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
 			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withExactArgs(done).returns(done);
 			sandbox.stub(boxClientFake, 'post').withArgs('/files/1234/copy').yieldsAsync();

--- a/tests/lib/managers/folders-test.js
+++ b/tests/lib/managers/folders-test.js
@@ -144,6 +144,17 @@ describe('Folders', function() {
 			folders.copy(FOLDER_ID, NEW_PARENT_ID);
 		});
 
+		it('should make POST request to copy the folder with optional parameters when passed', function() {
+
+			var name = 'rename on copy';
+
+			expectedParams.body.name = name;
+
+			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.mock(boxClientFake).expects('post').withArgs('/folders/1234/copy', expectedParams);
+			folders.copy(FOLDER_ID, NEW_PARENT_ID, {name});
+		});
+
 		it('should call the defaultResponseHandler wrapped callback when response is returned', function(done) {
 			var callbackMock = sandbox.mock().never();
 			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withExactArgs(callbackMock).returns(done);


### PR DESCRIPTION
Fixes #40.  When copying a file or folder, an optional parameter
can be passed to perform a rename when copying.  This commit adds a
new options argument to files.copy() and folders.copy() to support
such a parameter.

/cc: @djordan