### PR TITLE
Prevent event stream from infinite error when auth expires

### DIFF
--- a/lib/event-stream.js
+++ b/lib/event-stream.js
@@ -68,9 +68,14 @@ EventStream.prototype.getLongPollInfo = function() {
 
 		if (err) {
 			self.emit('error', err);
-			setTimeout(function() {
-				self.getLongPollInfo();
-			}, RETRY_DELAY);
+
+			// Only retry on resolvable errors
+			if (!err.authExpired) {
+				setTimeout(function() {
+					self.getLongPollInfo();
+				}, RETRY_DELAY);
+			}
+
 			return;
 		}
 

--- a/tests/lib/event-stream-test.js
+++ b/tests/lib/event-stream-test.js
@@ -131,6 +131,20 @@ describe('EventStream', function() {
 			sandbox.mock(eventStream).expects('getLongPollInfo');
 			clock.tick(1000);
 		});
+
+		it('should not retry getLongPollInfo() when API call fails with auth error', function() {
+
+			var apiError = new Error('API fail');
+			apiError.authExpired = true;
+			sandbox.stub(eventStream, 'doLongPoll');
+			sandbox.stub(eventStream, 'emit');
+			sandbox.stub(boxClientFake.events, 'getLongPollInfo').yields(apiError);
+
+			eventStream.getLongPollInfo();
+
+			sandbox.mock(eventStream).expects('getLongPollInfo').never();
+			clock.tick(1000);
+		});
 	});
 
 	describe('doLongPoll()', function() {


### PR DESCRIPTION
Fixes #16.  When auth expires (or is revoked), any open event
streams would enter an infinite retry loop, emitting error events
every second.  We should not retry on auth expiration errors, since
there's no possibility of automated recovery.  Users should note
the error (only emitted once now) and manually reopen a new stream
once auth is restored.

/cc: @djordan 