### PR TITLE
Add better error messages to sample app

### DIFF
--- a/examples/app-auth/index.js
+++ b/examples/app-auth/index.js
@@ -6,6 +6,7 @@ var express = require('express'),
 	session = require('express-session'),
 	path = require('path'),
 	fs = require('fs'),
+	util = require('util'),
 	multipart = require('express-formidable').parse,
 	bodyParser = require('body-parser'),
 	BoxSDK = require('box-node-sdk');
@@ -100,7 +101,8 @@ app.post('/login', function(req, res) {
 
 		if (err) {
 			res.render('login', {
-				error: 'An error occurred during login - ' + err.message
+				error: 'An error occurred during login - ' + err.message,
+				errorDetails: util.inspect(err)
 			});
 			return;
 		}
@@ -141,7 +143,8 @@ app.post('/signup', function(req, res) {
 
 		if (err) {
 			res.render('signup', {
-				error: 'An error occurred during signup - ' + err.message
+				error: 'An error occurred during signup - ' + err.message,
+				errorDetails: util.inspect(err)
 			});
 			return;
 		}
@@ -167,6 +170,7 @@ app.get('/files', function(req, res) {
 
 		res.render('files', {
 			error: err,
+			errorDetails: util.inspect(err),
 			files: data ? data.entries: []
 		});
 	});

--- a/examples/app-auth/views/files.hbs
+++ b/examples/app-auth/views/files.hbs
@@ -1,5 +1,10 @@
 {{#if error}}
-	<div class="alert alert-danger" role="alert">{{error}}</div>
+	<div class="alert alert-danger" role="alert">
+		<strong>{{error}}</strong>
+		{{#if errorDetails}}
+			<div>{{erroDetails}}</div>
+		{{/if}}
+	</div>
 {{/if}}
 
 <h1>Upload a File</h1>

--- a/examples/app-auth/views/files.hbs
+++ b/examples/app-auth/views/files.hbs
@@ -2,7 +2,7 @@
 	<div class="alert alert-danger" role="alert">
 		<strong>{{error}}</strong>
 		{{#if errorDetails}}
-			<div>{{erroDetails}}</div>
+			<div>{{errorDetails}}</div>
 		{{/if}}
 	</div>
 {{/if}}

--- a/examples/app-auth/views/login.hbs
+++ b/examples/app-auth/views/login.hbs
@@ -2,7 +2,7 @@
 	<div class="alert alert-danger" role="alert">
 		<strong>{{error}}</strong>
 		{{#if errorDetails}}
-			<div>{{erroDetails}}</div>
+			<div>{{errorDetails}}</div>
 		{{/if}}
 	</div>
 {{/if}}

--- a/examples/app-auth/views/login.hbs
+++ b/examples/app-auth/views/login.hbs
@@ -1,5 +1,10 @@
 {{#if error}}
-	<div class="alert alert-danger" role="alert">{{error}}</div>
+	<div class="alert alert-danger" role="alert">
+		<strong>{{error}}</strong>
+		{{#if errorDetails}}
+			<div>{{erroDetails}}</div>
+		{{/if}}
+	</div>
 {{/if}}
 
 <form action="/login" method="post">

--- a/examples/app-auth/views/signup.hbs
+++ b/examples/app-auth/views/signup.hbs
@@ -1,5 +1,10 @@
 {{#if error}}
-	<div class="alert alert-danger" role="alert">{{error}}</div>
+	<div class="alert alert-danger" role="alert">
+		<strong>{{error}}</strong>
+		{{#if errorDetails}}
+			<div>{{erroDetails}}</div>
+		{{/if}}
+	</div>
 {{/if}}
 
 <form action="/signup" method="post">

--- a/examples/app-auth/views/signup.hbs
+++ b/examples/app-auth/views/signup.hbs
@@ -2,7 +2,7 @@
 	<div class="alert alert-danger" role="alert">
 		<strong>{{error}}</strong>
 		{{#if errorDetails}}
-			<div>{{erroDetails}}</div>
+			<div>{{errorDetails}}</div>
 		{{/if}}
 	</div>
 {{/if}}


### PR DESCRIPTION
Fixes #12.  Print the full error object out in the sample app so
users can debug more easily.

/cc: @djordan