### PR TITLE
Fix options passing style for creation methods

### DIFF
--- a/lib/managers/tasks.js
+++ b/lib/managers/tasks.js
@@ -56,13 +56,7 @@ Tasks.prototype.create = function(fileID, options, callback) {
 			}
 		};
 
-	if (options && options.message) {
-		params.body.message = options.message;
-	}
-
-	if (options && options.dueAt) {
-		params.body.due_at = options.dueAt;
-	}
+	Object.assign(params.body, options);
 
 	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
 };

--- a/lib/managers/web-links.js
+++ b/lib/managers/web-links.js
@@ -55,13 +55,7 @@ WebLinks.prototype.create = function(url, parentID, options, callback) {
 			}
 		};
 
-	if (options && options.name) {
-		params.body.name = options.name;
-	}
-
-	if (options && options.description) {
-		params.body.description = options.description;
-	}
+	Object.assign(params.body, options);
 
 	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
 };

--- a/tests/lib/managers/tasks-test.js
+++ b/tests/lib/managers/tasks-test.js
@@ -86,7 +86,7 @@ describe('Tasks', function() {
 
 			sandbox.stub(boxClientFake, 'defaultResponseHandler');
 			sandbox.mock(boxClientFake).expects('post').withArgs(BASE_PATH, expectedParams);
-			tasks.create(FILE_ID, {message: message, dueAt: dueAt});
+			tasks.create(FILE_ID, {message: message, due_at: dueAt});
 		});
 
 		it('should make POST request with message to create a task when just a message is passed', function() {
@@ -102,7 +102,7 @@ describe('Tasks', function() {
 
 			sandbox.stub(boxClientFake, 'defaultResponseHandler');
 			sandbox.mock(boxClientFake).expects('post').withArgs(BASE_PATH, expectedParams);
-			tasks.create(FILE_ID, {dueAt: dueAt});
+			tasks.create(FILE_ID, {due_at: dueAt});
 		});
 
 		it('should make POST request with mandatory parameters to create a task when neither optional parameter is passed', function() {


### PR DESCRIPTION
Rather than whitelisting allowed options, we should by default pass
any options to the API, so we don't block newly added options on an
SDK update.

/cc @djordan 