### PR TITLE
Typo in Get Group Membership function description

### DIFF
--- a/lib/managers/users.js
+++ b/lib/managers/users.js
@@ -133,7 +133,7 @@ Users.prototype.removeEmailAlias = function(userID, aliasID, callback) {
 };
 
 /**
- * Retreieve a list of group memberships for the user, which show which groups
+ * Retrieve a list of group memberships for the user, which show which groups
  * the user belongs to.  This ability is restricted to group admins.
  *
  * API Endpoint: '/users/:userID/memberships'


### PR DESCRIPTION
Just a small typo I've noticed.