### PR TITLE
Fix metadata search

### DIFF
--- a/lib/managers/search.js
+++ b/lib/managers/search.js
@@ -5,6 +5,12 @@
 'use strict';
 
 // -----------------------------------------------------------------------------
+// Requirements
+// -----------------------------------------------------------------------------
+
+var urlPath = require('../util/url-path');
+
+// -----------------------------------------------------------------------------
 // Typedefs
 // -----------------------------------------------------------------------------
 
@@ -75,12 +81,25 @@ Search.prototype = {
 	 * @returns {void}
 	 */
 	query: function(searchString, options, callback) {
-		var qs = options || {};
+
+		var apiPath = urlPath(API_PATHS_SEARCH),
+			qs = options || {};
+
 		qs.query = searchString;
+
+		if (qs.mdfilters) {
+			if (Array.isArray(qs.mdfilters)) {
+				qs.mdfilters = JSON.stringify(qs.mdfilters);
+			} else {
+				setImmediate(() => callback(new Error('Invalid mdfilters parameter: must be a valid array')));
+				return;
+			}
+		}
+
 		var params = {
 			qs: qs
 		};
-		this.client.get(API_PATHS_SEARCH, params, this.client.defaultResponseHandler(callback));
+		this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
 	}
 
 };

--- a/tests/lib/managers/search-test.js
+++ b/tests/lib/managers/search-test.js
@@ -6,7 +6,8 @@
 // ------------------------------------------------------------------------------
 // Requirements
 // ------------------------------------------------------------------------------
-var sinon = require('sinon'),
+var assert = require('chai').assert,
+	sinon = require('sinon'),
 	mockery = require('mockery'),
 	leche = require('leche');
 
@@ -31,7 +32,10 @@ describe('Search', function() {
 
 	before(function() {
 		// Enable Mockery
-		mockery.enable({ useCleanCache: true });
+		mockery.enable({
+			useCleanCache: true,
+			warnOnUnregistered: false
+		});
 		// Register Mocks
 		mockery.registerAllowable(MODULE_FILE_PATH);
 	});
@@ -60,9 +64,63 @@ describe('Search', function() {
 				fakeParamsWithQs = {qs: fakeQs};
 
 			fakeParamsWithQs.qs.search = searchQuery;
-			sandbox.mock(boxClientFake).expects('get').withArgs('/search', fakeParamsWithQs);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').yields();
+			sandbox.mock(boxClientFake).expects('get').withArgs('/search', fakeParamsWithQs).yieldsAsync();
+			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
 			search.query(searchQuery, fakeQs, done);
+		});
+
+		it('should call defaultResponseHandler to wrap callback when called', function(done) {
+			var searchQuery = 'fakeQuery',
+				fakeQs = { fakeQsKey: 'fakeQsValue' },
+				fakeParamsWithQs = {qs: fakeQs};
+
+			fakeParamsWithQs.qs.search = searchQuery;
+			sandbox.stub(boxClientFake, 'get').yieldsAsync();
+			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
+			search.query(searchQuery, fakeQs, done);
+		});
+
+		it('should properly encode metadata filters when called with mdfilters option', function(done) {
+
+			var options = {
+				mdfilters: [
+					{
+						templateKey: 'MyTemplate',
+						scope: 'enterprise',
+						filters: {}
+					}
+				]
+			};
+
+			var expectedParams = {
+				qs: {
+					mdfilters: '[{"templateKey":"MyTemplate","scope":"enterprise","filters":{}}]',
+					query: ''
+				}
+			};
+
+			sandbox.mock(boxClientFake).expects('get').withArgs('/search', expectedParams).yieldsAsync();
+			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
+			search.query('', options, done);
+		});
+
+		it('should call callback with error when mdfilters is invalid', function(done) {
+
+			var options = {
+				mdfilters: {
+					templateKey: 'MyTemplate',
+					scope: 'enterprise',
+					filters: {}
+				}
+			};
+
+
+			sandbox.mock(boxClientFake).expects('get').never();
+			search.query('', options, function(err) {
+
+				assert.instanceOf(err, Error);
+				done();
+			});
 		});
 
 	});


### PR DESCRIPTION
Due to an encoding error, metadata search was not workig correctly.
Rather than just letting querystring encode the parameter, it must
be JSON-encoded first.

Fixes #90 

/cc @djordan 