### PR TITLE
Expired Auth Code

### DIFF
--- a/lib/token-manager.js
+++ b/lib/token-manager.js
@@ -314,6 +314,7 @@ TokenManager.prototype = {
 			subject: id,
 			issuer: this.config.clientID,
 			jwtid: uuid.v4(),
+			noTimestamp: true,
 			expiresIn: this.config.appAuth.expirationTime,
 			headers: {
 				kid: this.config.appAuth.keyID


### PR DESCRIPTION
Hello,

Great work on this SDK. We're using the app-auth client and I've been having an issue where I'm getting the error ` Error: Expired Auth: Auth code or refresh token has expired`. I've had a look around and the problem was originating for the token request https://api.box.com/oauth2/token. Not entirely sure why but it appears to be due to the iat (issued at time) parameter in the claims of the JWT assertion.

After adding the noTimestamp flag the assertion no longer contains the iat parameter and I don't have any issues. Maybe you could shed some light onto why this is the case but as it's an optional parameter anyhow I don't see the need for it.

Cheers,
Gary