### PR TITLE
Make JWT iat parameter optional

### DIFF
--- a/lib/token-manager.js
+++ b/lib/token-manager.js
@@ -315,6 +315,7 @@ TokenManager.prototype = {
 			issuer: this.config.clientID,
 			jwtid: uuid.v4(),
 			expiresIn: this.config.appAuth.expirationTime,
+			noTimestamp: !this.config.appAuth.verifyTimestamp,
 			headers: {
 				kid: this.config.appAuth.keyID
 			}

--- a/lib/util/config.js
+++ b/lib/util/config.js
@@ -22,8 +22,9 @@ var assert = require('assert'),
  * @property {string} keyID The ID of the public key used for app auth
  * @property {string|Buffer} privateKey The private key used for app auth
  * @property {string} passphrase The passphrase associated with the private key
- * @property {string} [algorithm] The signing algorithm to use, "RS256", "RS384", or "RS512" [Default: "RS256"]
- * @property {int} [expirationTime] Number of seconds the JWT should live for [Default: 60]
+ * @property {string} [algorithm=RS256] The signing algorithm to use, "RS256", "RS384", or "RS512"
+ * @property {int} [expirationTime=60] Number of seconds the JWT should live for
+ * @property {bool} [verifyTimestamp=false] Whether the timestamp when the auth token is created should be validated
  */
 
 /**
@@ -81,7 +82,8 @@ var defaults = {
 
 var appAuthDefaults = {
 	algorithm: 'RS256',
-	expirationTime: 60
+	expirationTime: 60,
+	verifyTimestamp: false
 };
 
 /**

--- a/tests/integration-test.js
+++ b/tests/integration-test.js
@@ -263,6 +263,7 @@ describe('Box Node SDK', function() {
 				assert.deepPropertyVal(assertion, 'payload.sub', userID);
 				assert.deepPropertyVal(assertion, 'payload.box_sub_type', 'user');
 				assert.deepPropertyVal(assertion, 'payload.aud', 'https://api.box.com/oauth2/token');
+				assert.notProperty(assertion, 'payload.iat');
 
 				return true;
 			})

--- a/tests/lib/token-manager-test.js
+++ b/tests/lib/token-manager-test.js
@@ -296,7 +296,9 @@ describe('token-manager', function() {
 				appAuth: {
 					keyID: TEST_KEY_ID,
 					privateKey: TEST_KEY,
-					passphrase: TEST_PASSPHRASE
+					passphrase: TEST_PASSPHRASE,
+					expirationTime: 1,
+					verifyTimestamp: true
 				}
 			});
 
@@ -317,6 +319,8 @@ describe('token-manager', function() {
 				audience: 'https://api.box.com/oauth2/token',
 				subject: TEST_ID,
 				issuer: config.clientID,
+				noTimestamp: false,
+				expiresIn: 1,
 				headers: {
 					kid: TEST_KEY_ID
 				}


### PR DESCRIPTION
When the iat parameter for JWT token grants is included by default,
many users are encountering errors due to clock skew.  Instead, the
parameter will be optional.

Fixes #96 
Fixes #97 