### PR TITLE
Added helper function to validate signatures on webhook messages

### DIFF
--- a/lib/box-node-sdk.js
+++ b/lib/box-node-sdk.js
@@ -59,7 +59,8 @@ var EventEmitter = require('events').EventEmitter,
 	PersistentAPISession = require('./sessions/persistent-session'),
 	AnonymousAPISession = require('./sessions/anonymous-session'),
 	AppAuthSession = require('./sessions/app-auth-session'),
-	BoxClient = require('./box-client');
+	BoxClient = require('./box-client'),
+	Webhooks = require('./managers/webhooks');
 
 // ------------------------------------------------------------------------------
 // Private
@@ -241,6 +242,13 @@ BoxSDKNode.prototype.getAppUserTokens = function(userID, callback) {
 BoxSDKNode.prototype.revokeTokens = function(token, callback) {
 	this.tokenManager.revokeTokens(token, callback);
 };
+
+/**
+ * Expose the Webhooks module to the SDK as a whole. This allows
+ * the consumer to call BoxSDK.webhooks.validateMessage() by requiring the SDK,
+ * instead of needing to create a client (which is not needed to validate messages).
+ */
+BoxSDKNode.webhooks = Webhooks;
 
 /** @module box-node-sdk/lib/box-node-sdk */
 module.exports = BoxSDKNode;

--- a/lib/box-node-sdk.js
+++ b/lib/box-node-sdk.js
@@ -244,11 +244,11 @@ BoxSDKNode.prototype.revokeTokens = function(token, callback) {
 };
 
 /**
- * Expose the Webhooks module to the SDK as a whole. This allows
- * the consumer to call BoxSDK.webhooks.validateMessage() by requiring the SDK,
+ * Expose Webhooks.validateMessage() to the SDK as a whole. This allows
+ * the consumer to call BoxSDK.validateWebhookMessage() by just requiring the SDK,
  * instead of needing to create a client (which is not needed to validate messages).
  */
-BoxSDKNode.webhooks = Webhooks;
+BoxSDKNode.validateWebhookMessage = Webhooks.validateMessage;
 
 /** @module box-node-sdk/lib/box-node-sdk */
 module.exports = BoxSDKNode;

--- a/lib/managers/webhooks.js
+++ b/lib/managers/webhooks.js
@@ -300,6 +300,8 @@ Webhooks.validateMessage = function(body, headers, primarySignatureKey, secondar
 	return true;
 };
 
+Webhooks.prototype.validateMessage = Webhooks.validateMessage;
+
 /**
  * @module box-node-sdk/lib/managers/webhooks
  * @see {@Link Webhooks}

--- a/lib/managers/webhooks.js
+++ b/lib/managers/webhooks.js
@@ -45,12 +45,10 @@ function computeSignature(body, headers, signatureKey) {
 	}
 
 	if (headers['box-signature-version'] !== '1') {
-		// console.log('Unrecognized signature version: %s', headers['box-signature-version']);
 		return null;
 	}
 
 	if (headers['box-signature-algorithm'] !== 'HmacSHA256') {
-		// console.log('Unrecognized signature algorithm: %s', headers['box-signature-algorithm']);
 		return null;
 	}
 
@@ -59,7 +57,6 @@ function computeSignature(body, headers, signatureKey) {
 	hmac.update(headers['box-delivery-timestamp']);
 
 	const signature = hmac.digest('base64');
-	// console.log('Signature: %s', signature);
 
 	return signature;
 }
@@ -81,18 +78,15 @@ function validateSignature(body, headers, primarySignatureKey, secondarySignatur
 	const primarySignature = computeSignature(body, headers, primarySignatureKey);
 
 	if (primarySignature && primarySignature === headers['box-signature-primary']) {
-		// console.log('Primary signature verified');
 		return true;
 	}
 
 	const secondarySignature = computeSignature(body, headers, secondarySignatureKey);
 
 	if (secondarySignature && secondarySignature === headers['box-signature-secondary']) {
-		// console.log('Secondary signature verified');
 		return true;
 	}
 
-	// console.log('Signature not verified');
 	return false;
 }
 
@@ -109,10 +103,7 @@ function validateDeliveryTimestamp(headers, maxMessageAge) {
 	const currentTime = Date.now();
 	const messageAge = (currentTime - deliveryTime) / 1000;
 
-	// console.log('Message age: %d', messageAge);
-
 	if (messageAge > maxMessageAge) {
-		// console.log('Message too old');
 		return false;
 	}
 

--- a/lib/managers/webhooks.js
+++ b/lib/managers/webhooks.js
@@ -17,6 +17,7 @@
 // -----------------------------------------------------------------------------
 
 var urlPath = require('../util/url-path');
+const crypto = require('crypto');
 
 // -----------------------------------------------------------------------------
 // Private
@@ -24,6 +25,99 @@ var urlPath = require('../util/url-path');
 
 // Base path for all webhooks endpoints
 var BASE_PATH = '/webhooks';
+
+// This prevents replay attacks
+const MAX_MESSAGE_AGE = 10 * 60; // 10 minutes
+
+/**
+ * Compute the message signature
+ * @see {@Link https://docs.box.com/reference#signatures}
+ *
+ * @param {string} body - The request body of the webhook message
+ * @param {Object} headers - The request headers of the webhook message
+ * @param {string} signatureKey - The signature to verify the message with
+ * @returns {?string} - The message signature (or null, if it can't be computed)
+ * @private
+ */
+function computeSignature(body, headers, signatureKey) {
+	if (!signatureKey) {
+		return null;
+	}
+
+	if (headers['box-signature-version'] !== '1') {
+		// console.log('Unrecognized signature version: %s', headers['box-signature-version']);
+		return null;
+	}
+
+	if (headers['box-signature-algorithm'] !== 'HmacSHA256') {
+		// console.log('Unrecognized signature algorithm: %s', headers['box-signature-algorithm']);
+		return null;
+	}
+
+	let hmac = crypto.createHmac('sha256', signatureKey);
+	hmac.update(body);
+	hmac.update(headers['box-delivery-timestamp']);
+
+	const signature = hmac.digest('base64');
+	// console.log('Signature: %s', signature);
+
+	return signature;
+}
+
+/**
+ * Validate the message signature
+ * @see {@Link https://docs.box.com/reference#signatures}
+ *
+ * @param {string} body - The request body of the webhook message
+ * @param {Object} headers - The request headers of the webhook message
+ * @param {string} primarySignatureKey - The primary signature to verify the message with
+ * @param {string} [secondarySignatureKey] - The secondary signature to verify the message with
+ * @returns {boolean} - True or false
+ * @private
+ */
+function validateSignature(body, headers, primarySignatureKey, secondarySignatureKey) {
+	// Either the primary or secondary signature must match the corresponding signature from Box
+	// (The use of two signatures allows the signing keys to be rotated one at a time)
+	const primarySignature = computeSignature(body, headers, primarySignatureKey);
+
+	if (primarySignature && primarySignature === headers['box-signature-primary']) {
+		// console.log('Primary signature verified');
+		return true;
+	}
+
+	const secondarySignature = computeSignature(body, headers, secondarySignatureKey);
+
+	if (secondarySignature && secondarySignature === headers['box-signature-secondary']) {
+		// console.log('Secondary signature verified');
+		return true;
+	}
+
+	// console.log('Signature not verified');
+	return false;
+}
+
+/**
+ * Validate that the delivery timestamp is not too far in the past (to prevent replay attacks)
+ *
+ * @param {Object} headers - The request headers of the webhook message
+ * @param {int} maxMessageAge - The maximum message age (in seconds)
+ * @returns {boolean} - True or false
+ * @private
+ */
+function validateDeliveryTimestamp(headers, maxMessageAge) {
+	const deliveryTime = Date.parse(headers['box-delivery-timestamp']);
+	const currentTime = Date.now();
+	const messageAge = (currentTime - deliveryTime) / 1000;
+
+	// console.log('Message age: %d', messageAge);
+
+	if (messageAge > maxMessageAge) {
+		// console.log('Message too old');
+		return false;
+	}
+
+	return true;
+}
 
 // -----------------------------------------------------------------------------
 // Public
@@ -193,114 +287,22 @@ Webhooks.prototype.delete = function(webhookID, callback) {
 	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
 };
 
-const crypto = require('crypto');
-
-/**
- * Compute the message signature (see https://docs.box.com/reference#signatures)
- *
- * @param {string} body - The request body of the webhook message
- * @param {Object} headers - The request headers of the webhook message
- * @param {string} signatureKey - The signature to verify the message with
- * @returns {string} - The message signature
- * @private
- */
-function computeSignature(body, headers, signatureKey) {
-	if (!signatureKey) {
-		return undefined;
-	}
-
-	if (headers['box-signature-version'] !== '1') {
-		// console.log('Unrecognized signature version: %s', headers['box-signature-version']);
-		return undefined;
-	}
-
-	if (headers['box-signature-algorithm'] !== 'HmacSHA256') {
-		// console.log('Unrecognized signature algorithm: %s', headers['box-signature-algorithm']);
-		return undefined;
-	}
-
-	let hmac = crypto.createHmac('sha256', signatureKey);
-	hmac.update(body);
-	hmac.update(headers['box-delivery-timestamp']);
-
-	const signature = hmac.digest('base64');
-	// console.log('Signature: %s', signature);
-
-	return signature;
-}
-
-/**
- * Validate the message signature (see https://docs.box.com/reference#signatures)
- *
- * @param {string} body - The request body of the webhook message
- * @param {Object} headers - The request headers of the webhook message
- * @param {string} primarySignatureKey - The primary signature to verify the message with
- * @param {?string} secondarySignatureKey - The secondary signature to verify the message with
- * @returns {boolean} - True or false
- * @private
- */
-function validateSignature(body, headers, primarySignatureKey, secondarySignatureKey) {
-	// Either the primary or secondary signature must match the corresponding signature from Box
-	// (The use of two signatures allows the signing keys to be rotated one at a time)
-	const primarySignature = computeSignature(body, headers, primarySignatureKey);
-
-	if (primarySignature && primarySignature === headers['box-signature-primary']) {
-		// console.log('Primary signature verified');
-		return true;
-	}
-
-	const secondarySignature = computeSignature(body, headers, secondarySignatureKey);
-
-	if (secondarySignature && secondarySignature === headers['box-signature-secondary']) {
-		// console.log('Secondary signature verified');
-		return true;
-	}
-
-	// console.log('Signature not verified');
-	return false;
-}
-
-/**
- * Validate that the delivery timestamp is not too far in the past (to prevent replay attacks)
- *
- * @param {Object} headers - The request headers of the webhook message
- * @param {int} maxMessageAge - The maximum message age (in seconds)
- * @returns {boolean} - True or false
- * @private
- */
-function validateDeliveryTimestamp(headers, maxMessageAge) {
-	const deliveryTime = Date.parse(headers['box-delivery-timestamp']);
-	const currentTime = Date.now();
-	const messageAge = (currentTime - deliveryTime) / 1000;
-
-	// console.log('Message age: %d', messageAge);
-
-	if (messageAge > maxMessageAge) {
-		// console.log('Message too old');
-		return false;
-	}
-
-	return true;
-}
-
-// This prevents replay attacks
-const maxMessageAge = 10 * 60; // 10 minutes
-
 /**
  * Validate a webhook message by verifying the signature and the delivery timestamp
  *
  * @param {string} body - The request body of the webhook message
  * @param {Object} headers - The request headers of the webhook message
  * @param {string} primarySignatureKey - The primary signature to verify the message with
- * @param {?string} secondarySignatureKey - The secondary signature to verify the message with
+ * @param {string} [secondarySignatureKey] - The secondary signature to verify the message with
+ * @param {int} [maxMessageAge] - The maximum message age (in seconds).  Defaults to 10 minutes
  * @returns {boolean} - True or false
  */
-Webhooks.validateMessage = function(body, headers, primarySignatureKey, secondarySignatureKey) {
+Webhooks.validateMessage = function(body, headers, primarySignatureKey, secondarySignatureKey, maxMessageAge) {
 	if (!validateSignature(body, headers, primarySignatureKey, secondarySignatureKey)) {
 		return false;
 	}
 
-	if (!validateDeliveryTimestamp(headers, maxMessageAge)) {
+	if (!validateDeliveryTimestamp(headers, maxMessageAge | MAX_MESSAGE_AGE)) {
 		return false;
 	}
 

--- a/lib/managers/webhooks.js
+++ b/lib/managers/webhooks.js
@@ -35,7 +35,7 @@ const MAX_MESSAGE_AGE = 10 * 60; // 10 minutes
  *
  * @param {string} body - The request body of the webhook message
  * @param {Object} headers - The request headers of the webhook message
- * @param {string} signatureKey - The signature to verify the message with
+ * @param {?string} signatureKey - The signature to verify the message with
  * @returns {?string} - The message signature (or null, if it can't be computed)
  * @private
  */
@@ -289,11 +289,15 @@ Webhooks.prototype.delete = function(webhookID, callback) {
  * @returns {boolean} - True or false
  */
 Webhooks.validateMessage = function(body, headers, primarySignatureKey, secondarySignatureKey, maxMessageAge) {
+	if (typeof maxMessageAge !== 'number') {
+		maxMessageAge = MAX_MESSAGE_AGE;
+	}
+
 	if (!validateSignature(body, headers, primarySignatureKey, secondarySignatureKey)) {
 		return false;
 	}
 
-	if (!validateDeliveryTimestamp(headers, maxMessageAge | MAX_MESSAGE_AGE)) {
+	if (!validateDeliveryTimestamp(headers, maxMessageAge)) {
 		return false;
 	}
 

--- a/lib/managers/webhooks.js
+++ b/lib/managers/webhooks.js
@@ -179,7 +179,7 @@ Webhooks.prototype.update = function(webhookID, options, callback) {
 };
 
 /**
- * Delete a specifed webhook by ID
+ * Delete a specified webhook by ID
  *
  * API Endpoint: '/webhooks/:webhookID'
  * Method: DELETE
@@ -191,6 +191,120 @@ Webhooks.prototype.update = function(webhookID, options, callback) {
 Webhooks.prototype.delete = function(webhookID, callback) {
 	var apiPath = urlPath(BASE_PATH, webhookID);
 	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+};
+
+const crypto = require('crypto');
+
+/**
+ * Compute the message signature (see https://docs.box.com/reference#signatures)
+ *
+ * @param {string} body - The request body of the webhook message
+ * @param {Object} headers - The request headers of the webhook message
+ * @param {string} signatureKey - The signature to verify the message with
+ * @returns {string} - The message signature
+ * @private
+ */
+function computeSignature(body, headers, signatureKey) {
+	if (!signatureKey) {
+		return undefined;
+	}
+
+	if (headers['box-signature-version'] !== '1') {
+		// console.log('Unrecognized signature version: %s', headers['box-signature-version']);
+		return undefined;
+	}
+
+	if (headers['box-signature-algorithm'] !== 'HmacSHA256') {
+		// console.log('Unrecognized signature algorithm: %s', headers['box-signature-algorithm']);
+		return undefined;
+	}
+
+	let hmac = crypto.createHmac('sha256', signatureKey);
+	hmac.update(body);
+	hmac.update(headers['box-delivery-timestamp']);
+
+	const signature = hmac.digest('base64');
+	// console.log('Signature: %s', signature);
+
+	return signature;
+}
+
+/**
+ * Validate the message signature (see https://docs.box.com/reference#signatures)
+ *
+ * @param {string} body - The request body of the webhook message
+ * @param {Object} headers - The request headers of the webhook message
+ * @param {string} primarySignatureKey - The primary signature to verify the message with
+ * @param {?string} secondarySignatureKey - The secondary signature to verify the message with
+ * @returns {boolean} - True or false
+ * @private
+ */
+function validateSignature(body, headers, primarySignatureKey, secondarySignatureKey) {
+	// Either the primary or secondary signature must match the corresponding signature from Box
+	// (The use of two signatures allows the signing keys to be rotated one at a time)
+	const primarySignature = computeSignature(body, headers, primarySignatureKey);
+
+	if (primarySignature && primarySignature === headers['box-signature-primary']) {
+		// console.log('Primary signature verified');
+		return true;
+	}
+
+	const secondarySignature = computeSignature(body, headers, secondarySignatureKey);
+
+	if (secondarySignature && secondarySignature === headers['box-signature-secondary']) {
+		// console.log('Secondary signature verified');
+		return true;
+	}
+
+	// console.log('Signature not verified');
+	return false;
+}
+
+/**
+ * Validate that the delivery timestamp is not too far in the past (to prevent replay attacks)
+ *
+ * @param {Object} headers - The request headers of the webhook message
+ * @param {int} maxMessageAge - The maximum message age (in seconds)
+ * @returns {boolean} - True or false
+ * @private
+ */
+function validateDeliveryTimestamp(headers, maxMessageAge) {
+	const deliveryTime = Date.parse(headers['box-delivery-timestamp']);
+	const currentTime = Date.now();
+	const messageAge = (currentTime - deliveryTime) / 1000;
+
+	// console.log('Message age: %d', messageAge);
+
+	if (messageAge > maxMessageAge) {
+		// console.log('Message too old');
+		return false;
+	}
+
+	return true;
+}
+
+// This prevents replay attacks
+const maxMessageAge = 10 * 60; // 10 minutes
+
+/**
+ * Validate a webhook message by verifying the signature and the delivery timestamp
+ *
+ * @param {string} body - The request body of the webhook message
+ * @param {Object} headers - The request headers of the webhook message
+ * @param {string} primarySignatureKey - The primary signature to verify the message with
+ * @param {?string} secondarySignatureKey - The secondary signature to verify the message with
+ * @returns {boolean} - True or false
+ */
+Webhooks.validateMessage = function(body, headers, primarySignatureKey, secondarySignatureKey) {
+	if (!validateSignature(body, headers, primarySignatureKey, secondarySignatureKey)) {
+		return false;
+	}
+
+	if (!validateDeliveryTimestamp(headers, maxMessageAge)) {
+		return false;
+	}
+
+	return true;
 };
 
 /**

--- a/tests/lib/managers/webhooks-test.js
+++ b/tests/lib/managers/webhooks-test.js
@@ -168,8 +168,8 @@ describe('Webhooks', function() {
 			PRIMARY_SIGNATURE_KEY = 'SamplePrimaryKey',
 			SECONDARY_SIGNATURE_KEY = 'SampleSecondaryKey',
 			INCORRECT_SIGNATURE_KEY = 'IncorrectKey',
-			DATE_IN_PAST = Date.parse('2010-01-01T00:00:00-07:00'),
-			DATE_IN_FUTURE = Date.parse('2030-01-01T00:00:00-07:00'),
+			DATE_IN_PAST = Date.parse('2010-01-01T00:00:00-07:00'),			// 10 years in the past
+			DATE_IN_FUTURE = Date.parse('2020-01-01T00:15:00-07:00'),		// 15 min in future
 			HEADERS_WITH_WRONG_SIGNATURE_VERSION = Object.assign({}, HEADERS, {'box-signature-version': '2'}),
 			HEADERS_WITH_WRONG_SIGNATURE_ALGORITHM = Object.assign({}, HEADERS, {'box-signature-algorithm': 'XXX'});
 
@@ -206,6 +206,18 @@ describe('Webhooks', function() {
 		it('should NOT validate the webhook message if it is too old', function() {
 			const clock = sinon.useFakeTimers(DATE_IN_FUTURE);
 			assert.ok(!Webhooks.validateMessage(BODY, HEADERS, PRIMARY_SIGNATURE_KEY, SECONDARY_SIGNATURE_KEY));
+			clock.restore();
+		});
+
+		it('should NOT validate the webhook message if maxMessageAge is not big enough', function() {
+			const clock = sinon.useFakeTimers(DATE_IN_FUTURE);
+			assert.ok(!Webhooks.validateMessage(BODY, HEADERS, PRIMARY_SIGNATURE_KEY, SECONDARY_SIGNATURE_KEY, 5 * 60));
+			clock.restore();
+		});
+
+		it('should validate the webhook message if maxMessageAge is big enough', function() {
+			const clock = sinon.useFakeTimers(DATE_IN_FUTURE);
+			assert.ok(Webhooks.validateMessage(BODY, HEADERS, PRIMARY_SIGNATURE_KEY, SECONDARY_SIGNATURE_KEY, 20 * 60));
 			clock.restore();
 		});
 

--- a/tests/lib/managers/webhooks-test.js
+++ b/tests/lib/managers/webhooks-test.js
@@ -8,12 +8,10 @@
 // ------------------------------------------------------------------------------
 var sinon = require('sinon'),
 	mockery = require('mockery'),
-	leche = require('leche');
+	leche = require('leche'),
+	assert = require('chai').assert;
 
 var BoxClient = require('../../../lib/box-client');
-
-var assert = require('assert');
-
 
 // ------------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
Consumers can validate a webhook message by using:
```
const BoxSDK = require('box-node-sdk');
if(BoxSDK.webhooks.validateMessage(body,headers, primarySignatureKey, secondarySignatureKey)) {...}
```