### PR TITLE
Updated docs to use "service account" rather than "enterprise client".

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ client.comments.delete('456', function(err) {});
 
 The following resources are supported by the SDK:
 
+- [Authentication](https://github.com/box/box-node-sdk/blob/master/docs/authentication.md)
 - [Collaborations](https://github.com/box/box-node-sdk/blob/master/docs/collaborations.md)
 - [Collections](https://github.com/box/box-node-sdk/blob/master/docs/collections.md)
 - [Comments](https://github.com/box/box-node-sdk/blob/master/docs/comments.md)

--- a/README.md
+++ b/README.md
@@ -166,8 +166,11 @@ var sdk = new BoxSDK({
 	}
 });
 
-// Get the enterprise client, used to create and manage app user accounts
-sdk.getAppAuthClient('enterprise', 'APP_ENTERPRISE_ID');
+// Get the service account client, used to create and manage app user accounts
+var serviceAccountClient = sdk.getAppAuthClient('enterprise', 'APP_ENTERPRISE_ID');
+
+// Get an app user client
+var appUserClient = sdk.getAppAuthClient('user', 'YOUR-APP-USER-ID');
 ```
 
 Accessing Data on Box

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ the SDK are available by topic:
 - [Folders](folders.md)
 - [Groups](groups.md)
 - [Legal Hold Policies](legal-hold-policies.md)
+- [Metadata](metadata.md)
 - [Retention Policies](retention-policies.md)
 - [Search](search.md)
 - [Shared Items](shared-items.md)

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -86,13 +86,13 @@ var client = sdk.getAnonymousClient();
 
 App Users allows your application to provision and control Box accounts that do
 not have an associated login and can only be accessed through the Content API by
-the controlling application.  You may authenticate as the app enterprise to
+the controlling application.  You may authenticate as the service account to
 provision and manage users, or as an individual app user to make calls as that
 user.  See the [API documentation](https://docs.box.com/docs/getting-started-box-platform)
 and [sample app](https://github.com/box/box-node-sdk/blob/master/examples/app-auth)
 for detailed instructions on how to use app auth.
 
-Enterprise admin client example:
+Service account client example:
 ```js
 var BoxSDK = require('box-node-sdk');
 var sdk = new BoxSDK({
@@ -104,7 +104,7 @@ var sdk = new BoxSDK({
 		passphrase: 'YOUR-PRIVATE-KEY-PASSPHRASE'
 	}
 });
-var adminClient = sdk.getAppAuthClient('enterprise', 'YOUR-ENTERPRISE-ID');
+var serviceAccountClient = sdk.getAppAuthClient('enterprise', 'YOUR-ENTERPRISE-ID');
 ```
 
 App User client example:

--- a/lib/sessions/anonymous-session.js
+++ b/lib/sessions/anonymous-session.js
@@ -90,7 +90,7 @@ AnonymousSession.prototype._refreshAnonymousAccessToken = function(callback) {
 
 /**
  * Returns a valid, anonymous access token to the callback.
- * Initiates a refresh before returning if the current token is expired. If the current
+ * Performs a refresh before returning if the current token is expired. If the current
  * token is considered stale but still valid, return the current token but initiate a
  * new refresh in the background.
  *
@@ -99,17 +99,17 @@ AnonymousSession.prototype._refreshAnonymousAccessToken = function(callback) {
  */
 AnonymousSession.prototype.getAccessToken = function(callback) {
 
-	// If the current token is completly expired, get a new token. All incoming
+	// If the current token is expired, get a new token. All incoming
 	// requests will be held until a fresh token is retrieved.
 	if (!this.tokenInfo || !this.tokenManager.isAccessTokenValid(this.tokenInfo, this._config.expiredBufferMS)) {
 		this._refreshAnonymousAccessToken(callback);
 		return;
 	}
 
-	// If the current token is are getting stale, fire off a refresh in the background. We can still return the
+	// If the current token is getting stale, fire off a refresh in the background. We still return the
 	// current, valid access token below.
-	// A token object is considered stale before its considered expired, usually in the range of a few minutes.
-	// This gives the session a chance to optomistically refresh the session's tokens in the background without
+	// A token object is considered stale before it expires, usually in the range of a few minutes.
+	// This gives the session a chance to optimistically refresh the session's tokens in the background without
 	// holding up the user request.
 	if (!this.tokenManager.isAccessTokenValid(this.tokenInfo, this._config.staleBufferMS)) {
 		this._refreshAnonymousAccessToken();
@@ -126,10 +126,7 @@ AnonymousSession.prototype.getAccessToken = function(callback) {
  * @returns {void}
  */
 AnonymousSession.prototype.revokeTokens = function(callback) {
-	// @TODO(fschott) 2014-04-03: Clarify the full anonymous revoke flow. Currently this token
-	// will be revoked, but then a new one will be gotten on the next call by any anonymous
-	// session. Is that correct? Should this session be manually shut down as well to prevent
-	// it from calling with the new tokens? Should anything happen globally? (probably not).
+	// The current anonymous token is revoked (but a new one will be created automatically as needed).
 	var tokenInfo = this.tokenInfo || {},
 		accessToken = tokenInfo.accessToken;
 	this.tokenInfo = null;

--- a/lib/sessions/app-auth-session.js
+++ b/lib/sessions/app-auth-session.js
@@ -95,7 +95,7 @@ AppAuthSession.prototype._refreshAppAuthAccessToken = function(callback) {
 
 /**
  * Returns a valid, app auth access token to the callback.
- * Initiates a refresh before returning if the current token is expired. If the current
+ * Performs a refresh before returning if the current token is expired. If the current
  * token is considered stale but still valid, return the current token but initiate a
  * new refresh in the background.
  *
@@ -104,17 +104,17 @@ AppAuthSession.prototype._refreshAppAuthAccessToken = function(callback) {
  */
 AppAuthSession.prototype.getAccessToken = function(callback) {
 
-	// If the current token is completly expired, get a new token. All incoming
+	// If the current token is expired, get a new token. All incoming
 	// requests will be held until a fresh token is retrieved.
 	if (!this.tokenInfo || !this.tokenManager.isAccessTokenValid(this.tokenInfo, this._config.expiredBufferMS)) {
 		this._refreshAppAuthAccessToken(callback);
 		return;
 	}
 
-	// If the current token is are getting stale, fire off a refresh in the background. We can still return the
+	// If the current token is getting stale, fire off a refresh in the background. We still return the
 	// current, valid access token below.
-	// A token object is considered stale before its considered expired, usually in the range of a few minutes.
-	// This gives the session a chance to optomistically refresh the session's tokens in the background without
+	// A token object is considered stale before it expires, usually in the range of a few minutes.
+	// This gives the session a chance to optimistically refresh the session's tokens in the background without
 	// holding up the user request.
 	if (!this.tokenManager.isAccessTokenValid(this.tokenInfo, this._config.staleBufferMS)) {
 		this._refreshAppAuthAccessToken();
@@ -125,16 +125,13 @@ AppAuthSession.prototype.getAccessToken = function(callback) {
 };
 
 /**
- * Revokes the app auth token used by this sessions, and clears the saved tokenInfo.
+ * Revokes the app auth token used by this session, and clears the saved tokenInfo.
  *
  * @param {Function} callback Called after tokens have been revoked
  * @returns {void}
  */
 AppAuthSession.prototype.revokeTokens = function(callback) {
-	// @TODO(fschott) 2014-04-03: Clarify the full anonymous revoke flow. Currently this token
-	// will be revoked, but then a new one will be gotten on the next call by any anonymous
-	// session. Is that correct? Should this session be manually shut down as well to prevent
-	// it from calling with the new tokens? Should anything happen globally? (probably not).
+	// The current app auth token is revoked (but a new one will be created automatically as needed).
 	var tokenInfo = this.tokenInfo || {},
 		accessToken = tokenInfo.accessToken;
 	this.tokenInfo = null;

--- a/lib/sessions/persistent-session.js
+++ b/lib/sessions/persistent-session.js
@@ -247,7 +247,7 @@ PersistentSession.prototype.getAccessToken = function(callback) {
 	// If our tokens are getting stale, fire off a refresh in the background. We can still return the current
 	// valid access token below.
 	// A token object is considered stale before it is considered expired, usually in the range of a few minutes.
-	// This gives the session a chance to optomistically refresh the session's tokens in the background without
+	// This gives the session a chance to optimistically refresh the session's tokens in the background without
 	// holding up a user request.
 	if (!this.tokenManager.isAccessTokenValid(this._tokenInfo, this._config.staleBufferMS)) {
 		this._refreshTokens();


### PR DESCRIPTION
Updated docs to use "service account" rather than "enterprise client"