### PR TITLE
Retry JWT grant with Box server time when exp claim fails

### DIFF
--- a/lib/token-manager.js
+++ b/lib/token-manager.js
@@ -341,7 +341,7 @@ TokenManager.prototype = {
 		null,
 		function(err, tokenInfo) {
 
-            // When a client's clock is out of sync with Box API servers, they'll get an error about the exp claim
+			// When a client's clock is out of sync with Box API servers, they'll get an error about the exp claim
 			// In these cases, we can attempt to retry the grant request with a new exp claim calculated frem the
 			// Date header sent by the server
 			if (err && err.authExpired && err.response.body.error_description.indexOf('exp') > -1 && err.response.headers.date) {

--- a/lib/token-manager.js
+++ b/lib/token-manager.js
@@ -306,6 +306,7 @@ TokenManager.prototype = {
 		}
 
 		var claims = {
+			exp: Math.floor(Date.now() / 1000) + this.config.appAuth.expirationTime,
 			box_sub_type: type
 		};
 		var options = {
@@ -314,7 +315,6 @@ TokenManager.prototype = {
 			subject: id,
 			issuer: this.config.clientID,
 			jwtid: uuid.v4(),
-			expiresIn: this.config.appAuth.expirationTime,
 			noTimestamp: !this.config.appAuth.verifyTimestamp,
 			headers: {
 				kid: this.config.appAuth.keyID
@@ -325,20 +325,47 @@ TokenManager.prototype = {
 			passphrase: this.config.appAuth.passphrase
 		};
 
+		var assertion;
 		try {
-			var assertion = jwt.sign(claims, keyParams, options);
-		} catch (err) {
-			callback(err);
+			assertion = jwt.sign(claims, keyParams, options);
+		} catch (jwtErr) {
+			callback(jwtErr);
 			return;
 		}
 
-
+		var self = this;
 		this.getTokens({
 			grant_type: grantTypes.JWT,
 			assertion: assertion
 		},
 		null,
-		callback);
+		function(err, tokenInfo) {
+
+			if (err && err.authExpired && err.response.body.error_description.indexOf('exp') > -1 && err.response.headers.date) {
+
+				// Retry using the server time
+				var serverTime = Math.floor(Date.parse(err.response.headers.date) / 1000);
+				claims.exp = serverTime + self.config.appAuth.expirationTime;
+
+				try {
+					assertion = jwt.sign(claims, keyParams, options);
+				} catch (jwtErr) {
+					callback(err);
+					return;
+				}
+
+				self.getTokens({
+					grant_type: grantTypes.JWT,
+					assertion: assertion
+				},
+				null,
+				callback);
+				return;
+			}
+
+            // Pass through
+			callback(err, tokenInfo);
+		});
 	},
 
 	/**

--- a/lib/token-manager.js
+++ b/lib/token-manager.js
@@ -341,9 +341,11 @@ TokenManager.prototype = {
 		null,
 		function(err, tokenInfo) {
 
+            // When a client's clock is out of sync with Box API servers, they'll get an error about the exp claim
+			// In these cases, we can attempt to retry the grant request with a new exp claim calculated frem the
+			// Date header sent by the server
 			if (err && err.authExpired && err.response.body.error_description.indexOf('exp') > -1 && err.response.headers.date) {
 
-				// Retry using the server time
 				var serverTime = Math.floor(Date.parse(err.response.headers.date) / 1000);
 				claims.exp = serverTime + self.config.appAuth.expirationTime;
 
@@ -363,7 +365,7 @@ TokenManager.prototype = {
 				return;
 			}
 
-            // Pass through
+			// Pass through
 			callback(err, tokenInfo);
 		});
 	},


### PR DESCRIPTION
Fixes #115
Fixes #109

When a client's clock is desynchronized from Box API servers, JWT
grant calls might fail due to the exp claim not being valid.  In
order to mitigate this type of error, the SDK will attempt one
retry using the timestamp sent back in the Date header of the API
error response, which should correct most cases of this error.