### PR TITLE
Add Promises support

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -85,7 +85,7 @@ target.lint = function() {
 
 target.test = function() {
 	var code = target.lint();
-	code += nodeCLI.exec('istanbul', 'cover', MOCHA_BINARY, '--', '-c', '-R nyan', TEST_FILES).code;
+	code += nodeCLI.exec('istanbul', 'cover', MOCHA_BINARY, '--', '-c', '-R spec', TEST_FILES).code;
 
 	if (code) {
 		exit(code);

--- a/lib/box-client.js
+++ b/lib/box-client.js
@@ -566,9 +566,6 @@ BoxClient.prototype.buildSharedItemAuthHeader = function(url, password) {
  * body to the original callback. Any request error or unsuccessful response codes are propagated
  * back to the callback as errors. This is the standard behavior of most endpoints.
  *
- * @NOTE(fschott) 2014-05-03: This method will most likely be phased out so that we can provide less
- * generic and more granular responses & errors.
- *
  * @param {Function} callback The original callback given by the consumer
  * @returns {?APIRequest~Callback} A new callback that processes the response before passing it to the callback.
  */
@@ -596,6 +593,11 @@ BoxClient.prototype.defaultResponseHandler = function(callback) {
 	};
 };
 
+/**
+ * Wrap a client method with the default handler for both callback and promise styles
+ * @param {Function} method The client method (e.g. client.get)
+ * @returns {Function}  The wrapped method
+ */
 BoxClient.prototype.wrapWithDefaultHandler = function(method) {
 
 	var self = this;
@@ -621,7 +623,7 @@ BoxClient.prototype.wrapWithDefaultHandler = function(method) {
 		}
 
 		if (callback) {
-			// If the callback will handle any errors, don't wprry about the promise
+			// If the callback will handle any errors, don't worry about the promise
 			ret.suppressUnhandledRejections();
 		}
 

--- a/lib/box-client.js
+++ b/lib/box-client.js
@@ -31,7 +31,8 @@ var util = require('util'),
 	errors = require('./util/errors'),
 	httpStatusCodes = require('http-status'),
 	isIP = require('net').isIP,
-	merge = require('merge-options');
+	merge = require('merge-options'),
+	Promise = require('bluebird');
 
 // API Resource Managers
 var Users = require('./managers/users'),
@@ -197,42 +198,61 @@ BoxClient.prototype._createHeadersForRequest = function(callerHeaders, accessTok
  * a permanent error, or if usable tokens are not available.
  *
  * @param {Object} params - Request lib params to configure the request
- * @param {APIRequest~Callback} callback - passed response data
- * @returns {void}
+ * @param {APIRequest~Callback} [cb] - passed response data
+ * @returns {Promise} Promise resolving to the response
  * @private
  */
-BoxClient.prototype._makeRequest = function(params, callback) {
+BoxClient.prototype._makeRequest = function(params, cb) {
 	var self = this;
 
-	// Check that tokens are fresh, update if tokens are expired or soon-to-be expired
-	this._session.getAccessToken(function(err, accessToken) {
-		// Handle Error
-		if (err) {
-			callback(err);
-			return;
-		}
+	var promise = Promise.fromCallback(function(callback) {
 
-		params.headers = self._createHeadersForRequest(params.headers, accessToken);
+		// Check that tokens are fresh, update if tokens are expired or soon-to-be expired
+		self._session.getAccessToken(function(err, accessToken) {
+			// Handle Error
+			if (err) {
+				callback(err);
+				return;
+			}
 
-		if (params.streaming) {
-			// streaming is specific to the SDK, so delete it from params before continuing
-			delete params.streaming;
-			var responseStream = self._requestManager.makeStreamingRequest(params);
-			// Listen to 'response' event, so we can cleanup the token store in case when the request is unauthorized
-			// due to expired access token
-			responseStream.on('response', function(response) {
-				self._handleStreamingResponse(response);
+			params.headers = self._createHeadersForRequest(params.headers, accessToken);
+
+			if (params.streaming) {
+				// streaming is specific to the SDK, so delete it from params before continuing
+				delete params.streaming;
+				var responseStream = self._requestManager.makeStreamingRequest(params);
+				// Listen to 'response' event, so we can cleanup the token store in case when the request is unauthorized
+				// due to expired access token
+				responseStream.on('response', function(response) {
+					self._handleStreamingResponse(response);
+				});
+				// Callback with the response stream
+				callback(null, responseStream);
+				return;
+			}
+
+			// Make the request to Box, and pass the response to `_handleResponse()` with the original callback
+			self._requestManager.makeRequest(params, function handleResponseCallback(responseErr, response) {
+				self._handleResponse(responseErr, response, callback);
 			});
-			// Callback with the response stream
-			callback(null, responseStream);
-			return;
-		}
-
-		// Make the request to Box, and pass the response to `_handleResponse()` with the original callback
-		self._requestManager.makeRequest(params, function handleResponseCallback(responseErr, response) {
-			self._handleResponse(responseErr, response, callback);
 		});
 	});
+
+	promise = promise.catch(err => {
+
+		if (err.cause) {
+			// Unwrap Bluebird promise
+			throw err.cause;
+		}
+
+		throw err;
+	});
+
+	if (cb) {
+		promise = promise.asCallback(cb);
+	}
+
+	return promise;
 };
 
 /**
@@ -439,7 +459,8 @@ BoxClient.prototype.get = function(path, params, callback) {
 	var newParams = merge({}, params || {});
 	newParams.method = 'GET';
 	newParams.url = getFullURL(this._baseURL, path);
-	this._makeRequest(newParams, callback);
+
+	return this._makeRequest(newParams, callback);
 };
 
 /**
@@ -454,7 +475,7 @@ BoxClient.prototype.post = function(path, params, callback) {
 	var newParams = merge({}, params || {});
 	newParams.method = 'POST';
 	newParams.url = getFullURL(this._baseURL, path);
-	this._makeRequest(newParams, callback);
+	return this._makeRequest(newParams, callback);
 };
 
 /**
@@ -469,7 +490,7 @@ BoxClient.prototype.put = function(path, params, callback) {
 	var newParams = merge({}, params || {});
 	newParams.method = 'PUT';
 	newParams.url = getFullURL(this._baseURL, path);
-	this._makeRequest(newParams, callback);
+	return this._makeRequest(newParams, callback);
 };
 
 /**
@@ -484,7 +505,7 @@ BoxClient.prototype.del = function(path, params, callback) {
 	var newParams = merge({}, params || {});
 	newParams.method = 'DELETE';
 	newParams.url = getFullURL(this._baseURL, path);
-	this._makeRequest(newParams, callback);
+	return this._makeRequest(newParams, callback);
 };
 
 
@@ -501,7 +522,7 @@ BoxClient.prototype.options = function(path, params, callback) {
 	newParams.method = 'OPTIONS';
 	newParams.url = getFullURL(this._baseURL, path);
 
-	this._makeRequest(newParams, callback);
+	return this._makeRequest(newParams, callback);
 };
 
 /**
@@ -519,7 +540,7 @@ BoxClient.prototype.upload = function(path, params, formData, callback) {
 	newParams.formData = formData;
 	newParams.timeout = this._uploadRequestTimeoutMS;
 
-	this._makeRequest(newParams, callback);
+	return this._makeRequest(newParams, callback);
 };
 
 /**
@@ -549,9 +570,14 @@ BoxClient.prototype.buildSharedItemAuthHeader = function(url, password) {
  * generic and more granular responses & errors.
  *
  * @param {Function} callback The original callback given by the consumer
- * @returns {APIRequest~Callback} A new callback that processes the response before passing it to the callback.
+ * @returns {?APIRequest~Callback} A new callback that processes the response before passing it to the callback.
  */
 BoxClient.prototype.defaultResponseHandler = function(callback) {
+
+	if (!callback) {
+		return null;
+	}
+
 	return function(err, response) {
 		// Error with Request
 		if (err) {
@@ -567,6 +593,39 @@ BoxClient.prototype.defaultResponseHandler = function(callback) {
 		}
 		// Unexpected Response
 		callback(errors.buildUnexpectedResponseError(response));
+	};
+};
+
+BoxClient.prototype.wrapWithDefaultHandler = function(method) {
+
+	var self = this;
+	return function wrappedClientMethod(url, params, callback) {
+
+		if (callback) {
+			callback = self.defaultResponseHandler(callback);
+		}
+
+		var ret = method.bind(self)(url, params, callback);
+
+		if (ret instanceof Promise) {
+
+			ret = ret.then(response => {
+
+				if (response.statusCode >= HTTP_STATUS_CODE_SUCCESS_BLOCK_RANGE[0]
+						&& response.statusCode <= HTTP_STATUS_CODE_SUCCESS_BLOCK_RANGE[1]) {
+					return response.body;
+				}
+
+				throw errors.buildResponseError(response);
+			});
+		}
+
+		if (callback) {
+			// If the callback will handle any errors, don't wprry about the promise
+			ret.suppressUnhandledRejections();
+		}
+
+		return ret;
 	};
 };
 

--- a/lib/managers/collaborations.js
+++ b/lib/managers/collaborations.js
@@ -38,16 +38,16 @@ function Collaborations(client) {
  * Method: GET
  *
  * @param {string} collaborationID - Box ID of the collaboration being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
- * @param {Function} callback - Passed the collaboration information if it was acquired successfully
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Function} [callback] - Passed the collaboration information if it was acquired successfully
+ * @returns {Promise<Object>} A promise resolving to the collaboration object
  */
 Collaborations.prototype.get = function(collaborationID, qs, callback) {
 	var params = {
 		qs: qs
 	};
 	var apiPath = urlPath(BASE_PATH, collaborationID);
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -56,8 +56,8 @@ Collaborations.prototype.get = function(collaborationID, qs, callback) {
  * API Endpoint: '/collaborations'
  * Method: GET
  *
- * @param {Function} callback - Called with a collection of pending collaborations if successful
- * @returns {void}
+ * @param {Function} [callback] - Called with a collection of pending collaborations if successful
+ * @returns {Promise<Object>} A promise resolving to the collection of pending collaborations
  */
 Collaborations.prototype.getPending = function(callback) {
 	var params = {
@@ -65,7 +65,7 @@ Collaborations.prototype.getPending = function(callback) {
 			status: 'pending'
 		}
 	};
-	this.client.get(BASE_PATH, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(BASE_PATH, params, callback);
 };
 
 /**
@@ -75,9 +75,9 @@ Collaborations.prototype.getPending = function(callback) {
  * Method: PUT
  *
  * @param {string} collaborationID - Box ID of the collaboration being requested
- * @param {?Object} options - Fields of the collaboration to be updated
- * @param {Function} callback - Passed the updated collaboration information if it was acquired successfully
- * @returns {void}
+ * @param {Object} options - Fields of the collaboration to be updated
+ * @param {Function} [callback] - Passed the updated collaboration information if it was acquired successfully
+ * @returns {Promise<Object>} A promise resolving to the updated collaboration object
  */
 Collaborations.prototype.update = function(collaborationID, options, callback) {
 	var params = {
@@ -85,7 +85,7 @@ Collaborations.prototype.update = function(collaborationID, options, callback) {
 	};
 
 	var apiPath = urlPath(BASE_PATH, collaborationID);
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -96,14 +96,14 @@ Collaborations.prototype.update = function(collaborationID, options, callback) {
  *
  * @param {string} collaborationID - Box ID of the collaboration being requested
  * @param {string} newStatus - The new collaboration status ('accepted'/'rejected')
- * @param {Function} callback - Passed the updated collaboration information if it was acquired successfully
- * @returns {void}
+ * @param {Function} [callback] - Passed the updated collaboration information if it was acquired successfully
+ * @returns {Promise<Object>} A promise resolving to the accepted collaboration object
  */
 Collaborations.prototype.respondToPending = function(collaborationID, newStatus, callback) {
 	var options = {
 		status: newStatus
 	};
-	this.update(collaborationID, options, callback);
+	return this.update(collaborationID, options, callback);
 };
 
 /**
@@ -120,8 +120,8 @@ Collaborations.prototype.respondToPending = function(collaborationID, newStatus,
  * @param {CollaborationRole} role - The role which the invited collaborator should have
  * @param {Object} [options] - Optional parameters for the collaboration
  * @param {ItemType} [options.type=folder] - Type of object to be collaborated
- * @param {Function} callback - Called with the new collaboration if successful
- * @returns {void}
+ * @param {Function} [callback] - Called with the new collaboration if successful
+ * @returns {Promise<Object>} A promise resolving to the created collaboration object
  */
 Collaborations.prototype.create = function(accessibleBy, itemID, role, options, callback) {
 
@@ -146,7 +146,7 @@ Collaborations.prototype.create = function(accessibleBy, itemID, role, options, 
 			role: role
 		}
 	};
-	this.client.post(BASE_PATH, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(BASE_PATH, params, callback);
 };
 
 /**
@@ -160,8 +160,8 @@ Collaborations.prototype.create = function(accessibleBy, itemID, role, options, 
  * @param {CollaborationRole} role - The role which the invited collaborator should have
  * @param {Object} [options] - Optional parameters for the collaboration
  * @param {ItemType} [options.type=folder] - Type of object to be collaborated
- * @param {Function} callback - Called with the new collaboration if successful
- * @returns {void}
+ * @param {Function} [callback] - Called with the new collaboration if successful
+ * @returns {Promise<Object>} A promise resolving to the created collaboration object
  */
 Collaborations.prototype.createWithUserID = function(userID, itemID, role, options, callback) {
 
@@ -174,7 +174,7 @@ Collaborations.prototype.createWithUserID = function(userID, itemID, role, optio
 		type: 'user',
 		id: userID
 	};
-	this.create(accessibleBy, itemID, role, options, callback);
+	return this.create(accessibleBy, itemID, role, options, callback);
 };
 
 /**
@@ -188,8 +188,8 @@ Collaborations.prototype.createWithUserID = function(userID, itemID, role, optio
  * @param {CollaborationRole} role - The role which the invited collaborator should have
  * @param {Object} [options] - Optional parameters for the collaboration
  * @param {ItemType} [options.type=folder] - Type of object to be collaborated
- * @param {Function} callback - Called with the new collaboration if successful
- * @returns {void}
+ * @param {Function} [callback] - Called with the new collaboration if successful
+ * @returns {Promise<Object>} A promise resolving to the created collaboration object
  */
 Collaborations.prototype.createWithUserEmail = function(email, itemID, role, options, callback) {
 
@@ -202,7 +202,7 @@ Collaborations.prototype.createWithUserEmail = function(email, itemID, role, opt
 		type: 'user',
 		login: email
 	};
-	this.create(accessibleBy, itemID, role, options, callback);
+	return this.create(accessibleBy, itemID, role, options, callback);
 };
 
 /**
@@ -216,8 +216,8 @@ Collaborations.prototype.createWithUserEmail = function(email, itemID, role, opt
  * @param {CollaborationRole} role - The role which the invited collaborator should have
  * @param {Object} [options] - Optional parameters for the collaboration
  * @param {ItemType} [options.type=folder] - Type of object to be collaborated
- * @param {Function} callback - Called with the new collaboration if successful
- * @returns {void}
+ * @param {Function} [callback] - Called with the new collaboration if successful
+ * @returns {Promise<Object>} A promise resolving to the created collaboration object
  */
 Collaborations.prototype.createWithGroupID = function(groupID, itemID, role, options, callback) {
 
@@ -230,7 +230,7 @@ Collaborations.prototype.createWithGroupID = function(groupID, itemID, role, opt
 		type: 'group',
 		id: groupID
 	};
-	this.create(accessibleBy, itemID, role, options, callback);
+	return this.create(accessibleBy, itemID, role, options, callback);
 };
 
 /**
@@ -240,13 +240,13 @@ Collaborations.prototype.createWithGroupID = function(groupID, itemID, role, opt
  * Method: DELETE
  *
  * @param {string} collaborationID - Box ID of the collaboration being requested
- * @param {Function} callback - Empty response body passed if successful.
- * @returns {void}
+ * @param {Function} [callback] - Empty response body passed if successful.
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 Collaborations.prototype.delete = function(collaborationID, callback) {
 
 	var apiPath = urlPath(BASE_PATH, collaborationID);
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, null, callback);
 };
 
 

--- a/lib/managers/collections.js
+++ b/lib/managers/collections.js
@@ -39,7 +39,7 @@ function Collections(client) {
  * @returns {void}
  */
 Collections.prototype.getAll = function(callback) {
-	this.client.get(BASE_PATH, {}, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(BASE_PATH, {}, callback);
 };
 
 /**
@@ -58,7 +58,7 @@ Collections.prototype.getItems = function(collectionID, qs, callback) {
 		qs: qs
 	};
 	var apiPath = urlPath(BASE_PATH, collectionID, 'items');
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**

--- a/lib/managers/collections.js
+++ b/lib/managers/collections.js
@@ -35,8 +35,8 @@ function Collections(client) {
  * API Endpoint: '/collections'
  * Method: GET
  *
- * @param {Function} callback - Called with a collection of collections if successful
- * @returns {void}
+ * @param {Function} [callback] - Called with a collection of collections if successful
+ * @returns {Promise<Object>} A promise resolving to the collection of collections
  */
 Collections.prototype.getAll = function(callback) {
 	return this.client.wrapWithDefaultHandler(this.client.get)(BASE_PATH, {}, callback);
@@ -49,9 +49,9 @@ Collections.prototype.getAll = function(callback) {
  * Method: GET
  *
  * @param {string} collectionID - Box ID of the collection with items being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
- * @param {Function} callback - Passed the items information if they were acquired successfully
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Function} [callback] - Passed the items information if they were acquired successfully
+ * @returns {Promise<Object>} A promise resolving to the collection of items in the collection
  */
 Collections.prototype.getItems = function(collectionID, qs, callback) {
 	var params = {

--- a/lib/managers/comments.js
+++ b/lib/managers/comments.js
@@ -38,16 +38,16 @@ function Comments(client) {
  * Method: GET
  *
  * @param {string} commentID - Box ID of the comment being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
- * @param {Function} callback - Passed the comment information if it was acquired successfully
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Function} [callback] - Passed the comment information if it was acquired successfully
+ * @returns {Promise<Object>} A promise resolving to the comment object
  */
 Comments.prototype.get = function(commentID, qs, callback) {
 	var params = {
 		qs: qs
 	};
 	var apiPath = urlPath(BASE_PATH, commentID);
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -58,8 +58,8 @@ Comments.prototype.get = function(commentID, qs, callback) {
  *
  * @param {string} fileID - Box file id of the file to comment on
  * @param {string} commentBody - text of the comment
- * @param {Function} callback - passed the new comment data if it was posted successfully
- * @returns {void}
+ * @param {Function} [callback] - passed the new comment data if it was posted successfully
+ * @returns {Promise<Object>} A promise resolving to the new comment object
  */
 Comments.prototype.create = function(fileID, commentBody, callback) {
 	// @TODO(bemerick) 2013-10-29: Don't hardcode this 'item'. Abstract to all commentable types...
@@ -72,7 +72,7 @@ Comments.prototype.create = function(fileID, commentBody, callback) {
 			message: commentBody
 		}
 	};
-	this.client.post(BASE_PATH, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(BASE_PATH, params, callback);
 };
 
 /**
@@ -83,8 +83,8 @@ Comments.prototype.create = function(fileID, commentBody, callback) {
  *
  * @param {string} fileID - Box file id of the file to comment on
  * @param {string} commentBody - text of the tagged comment
- * @param {Function} callback - passed the new tagged comment data if it was posted successfully
- * @returns {void}
+ * @param {Function} [callback] - passed the new tagged comment data if it was posted successfully
+ * @returns {Promise<Object>} A promise resolving to the new comment object
  */
 Comments.prototype.createTaggedComment = function(fileID, commentBody, callback) {
 	var params = {
@@ -96,7 +96,7 @@ Comments.prototype.createTaggedComment = function(fileID, commentBody, callback)
 			tagged_message: commentBody
 		}
 	};
-	this.client.post(BASE_PATH, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(BASE_PATH, params, callback);
 };
 
 /**
@@ -106,9 +106,9 @@ Comments.prototype.createTaggedComment = function(fileID, commentBody, callback)
  * Method: PUT
  *
  * @param {string} commentID - Box ID of the comment being requested
- * @param {?Object} options - Additional options can be passed with the request via form body. Can be left null in most cases.
- * @param {Function} callback - Passed the updated comment information if it was acquired successfully
- * @returns {void}
+ * @param {Object} options - Fields to update on the comment
+ * @param {Function} [callback] - Passed the updated comment information if it was acquired successfully
+ * @returns {Promise<Object>} A promise resolving to the updated comment object
  */
 Comments.prototype.update = function(commentID, options, callback) {
 	var params = {
@@ -116,7 +116,7 @@ Comments.prototype.update = function(commentID, options, callback) {
 	};
 
 	var apiPath = urlPath(BASE_PATH, commentID);
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -126,13 +126,13 @@ Comments.prototype.update = function(commentID, options, callback) {
  * Method: DELETE
  *
  * @param {string} commentID - Box ID of the comment being requested
- * @param {Function} callback - Empty response body passed if successful.
- * @returns {void}
+ * @param {Function} [callback] - Empty response body passed if successful.
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 Comments.prototype.delete = function(commentID, callback) {
 
 	var apiPath = urlPath(BASE_PATH, commentID);
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, null, callback);
 };
 
 

--- a/lib/managers/device-pins.js
+++ b/lib/managers/device-pins.js
@@ -39,9 +39,9 @@ function DevicePins(client) {
  * Method: GET
  *
  * @param {string} pinID - The ID of the pin to retrieve
- * @param {?Object} options - Optional paramters, can be left null in many cases
- * @param {Function} callback - Passed the device pin if successful, error otherwise
- * @returns {void}
+ * @param {Object} [options] - Optional paramters, can be left null in many cases
+ * @param {Function} [callback] - Passed the device pin if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the device pin object
  */
 DevicePins.prototype.get = function(pinID, options, callback) {
 
@@ -50,7 +50,7 @@ DevicePins.prototype.get = function(pinID, options, callback) {
 			qs: options
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -60,9 +60,9 @@ DevicePins.prototype.get = function(pinID, options, callback) {
  * Method: DELETE
  *
  * @param {string} pinID - The ID of the pin to delete
- * @param {?Object} options - Optional paramters, can be left null in many cases
- * @param {Function} callback - Passed nothing if successful, error otherwise
- * @returns {void}
+ * @param {Object} [options] - Optional paramters, can be left null in many cases
+ * @param {Function} [callback] - Passed nothing if successful, error otherwise
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 DevicePins.prototype.delete = function(pinID, options, callback) {
 
@@ -71,7 +71,7 @@ DevicePins.prototype.delete = function(pinID, options, callback) {
 			qs: options
 		};
 
-	this.client.del(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, params, callback);
 };
 
 /**
@@ -80,31 +80,27 @@ DevicePins.prototype.delete = function(pinID, options, callback) {
  * API Endpoint: '/enterprises/:enterpriseID/device_pinners'
  * Method: GET
  *
- * @param {?Object} options - Optional paramters, can be left null in many cases
- * @param {Function} callback - Passed a list of device pins if successful, error otherwise
- * @returns {void}
+ * @param {Object} [options] - Optional paramters, can be left null in many cases
+ * @param {Function} [callback] - Passed a list of device pins if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the collection of device pins
  */
 DevicePins.prototype.getAll = function(options, callback) {
 
-	this.client.users.get(this.client.CURRENT_USER_ID, {fields: 'enterprise'}, (err, data) => {
+	return this.client.users.get(this.client.CURRENT_USER_ID, {fields: 'enterprise'})
+		.then(data => {
 
-		if (err) {
-			callback(err);
-			return;
-		}
+			if (!data.enterprise || !data.enterprise.id) {
+				throw new Error('User must be in an enterprise to view device pins');
+			}
 
-		if (!data.enterprise || !data.enterprise.id) {
-			callback(new Error('User must be in an enterprise to view device pins'));
-			return;
-		}
+			var apiPath = urlPath(ENTERPRISES_PATH, data.enterprise.id, DEVICE_PINNERS_SUBRESOURCE),
+				params = {
+					qs: options
+				};
 
-		var apiPath = urlPath(ENTERPRISES_PATH, data.enterprise.id, DEVICE_PINNERS_SUBRESOURCE),
-			params = {
-				qs: options
-			};
-
-		this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
-	});
+			return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params);
+		})
+		.asCallback(callback);
 };
 
 module.exports = DevicePins;

--- a/lib/managers/enterprise.js
+++ b/lib/managers/enterprise.js
@@ -81,13 +81,13 @@ Enterprise.prototype.userRoles = Object.freeze({
  * API Endpoint: '/users'
  * Method: GET
  *
- * @param {?Object} options - Optional parameters, can be left null in most cases
+ * @param {Object} [options] - Optional parameters, can be left null in most cases
  * @param {string} [options.filter_term] - Filter the results to only users starting with the filter_term in either the name or the login
  * @param {int} [options.limit=100] - The number of records to return
  * @param {int} [options.offset=0] - The record at which to start
  * @param {EnterpriseUserType} [options.user_type=managed] - The type of user to search for
- * @param {Function} callback - Passed the list of users if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the list of users if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the collection of users
  */
 Enterprise.prototype.getUsers = function(options, callback) {
 
@@ -96,7 +96,7 @@ Enterprise.prototype.getUsers = function(options, callback) {
 			qs: options
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -107,8 +107,8 @@ Enterprise.prototype.getUsers = function(options, callback) {
  *
  * @param {string} enterpriseID - The ID of the enterprise to invite the user to
  * @param {string} email - The email address of the user to invite
- * @param {Function} callback - Passed the invite object if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the invite object if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the invite object
  */
 Enterprise.prototype.inviteUser = function(enterpriseID, email, callback) {
 
@@ -124,7 +124,7 @@ Enterprise.prototype.inviteUser = function(enterpriseID, email, callback) {
 			}
 		};
 
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -135,7 +135,7 @@ Enterprise.prototype.inviteUser = function(enterpriseID, email, callback) {
  *
  * @param {string} login - The email address this user uses to login
  * @param {string} name - The name of this user
- * @param {?Object} options - Optional parameters, can be left null in most cases
+ * @param {Object} [options] - Optional parameters, can be left null in most cases
  * @param {EnterpriseRole} [options.role] - This user’s enterprise role
  * @param {string} [options.language] - The user's language
  * @param {bool} [options.is_sync_enabled] - Whether or not this user can use Box Sync
@@ -149,8 +149,8 @@ Enterprise.prototype.inviteUser = function(enterpriseID, email, callback) {
  * @param {string} [options.timezone] - The user's timezone
  * @param {bool} [options.is_exempt_from_device_limits] - Whether to exempt this user from Enterprise device limits
  * @param {bool} [options.is_exempt_from_login_verification] - Whether or not this user must use two-factor authentication
- * @param {Function} callback - Passed the list of users if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the created user if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the created user
  */
 Enterprise.prototype.addUser = function(login, name, options, callback) {
 
@@ -161,7 +161,7 @@ Enterprise.prototype.addUser = function(login, name, options, callback) {
 
 	Object.assign(params.body, options);
 
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -171,15 +171,15 @@ Enterprise.prototype.addUser = function(login, name, options, callback) {
  * Method: POST
  *
  * @param {string} name - The name of this user
- * @param {?Object} options - Optional parameters, can be left null in most cases
+ * @param {Object} [options] - Optional parameters, can be left null in most cases
  * @param {string} [options.language] - The user's language
  * @param {string} [options.job_title] - The user’s job title
  * @param {string} [options.phone] - The user’s phone number
  * @param {string} [options.address] - The user’s address
  * @param {int} [options.space_amount] - The user’s total available storage space in bytes
  * @param {string} [options.timezone] - The user's timezone
- * @param {Function} callback - Passed the list of users if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the created user if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the created user
  */
 Enterprise.prototype.addAppUser = function(name, options, callback) {
 
@@ -193,7 +193,7 @@ Enterprise.prototype.addAppUser = function(name, options, callback) {
 
 	Object.assign(params.body, options);
 
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -204,8 +204,8 @@ Enterprise.prototype.addAppUser = function(name, options, callback) {
  *
  * @param {string} sourceUserID - The ID of the user whose files will be transferred
  * @param {string} destUserID - The ID of the user to transfer the files to
- * @param {Function} callback - Passed the new folder which contains all the files if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the new folder which contains all the files if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the folder containing the transferred content
  */
 Enterprise.prototype.transferUserContent = function(sourceUserID, destUserID, callback) {
 
@@ -216,7 +216,7 @@ Enterprise.prototype.transferUserContent = function(sourceUserID, destUserID, ca
 			}
 		};
 
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 module.exports = Enterprise;

--- a/lib/managers/events.js
+++ b/lib/managers/events.js
@@ -12,6 +12,7 @@
 var urlPath = require('../util/url-path'),
 	errors = require('../util/errors'),
 	EventStream = require('../event-stream'),
+	Promise = require('bluebird'),
 	httpStatusCodes = require('http-status');
 
 
@@ -48,8 +49,8 @@ Events.prototype.CURRENT_STREAM_POSITION = CURRENT_STREAM_POSITION;
  * API Endpoint: '/events'
  * Method: GET
  *
- * @param {Function} callback Passed the current stream position if successful
- * @returns {void}
+ * @param {Function} [callback] Passed the current stream position if successful
+ * @returns {Promise<string>} A promise resolving to the stream position
  */
 Events.prototype.getCurrentStreamPosition = function(callback) {
 	var params = {
@@ -58,20 +59,16 @@ Events.prototype.getCurrentStreamPosition = function(callback) {
 		}
 	};
 	var apiPath = urlPath(BASE_PATH);
-	this.client.get(apiPath, params, function(err, response) {
+	return this.client.get(apiPath, params)
+		.then(response => {
 
-		if (err) {
-			callback(err);
-			return;
-		}
+			if (response.statusCode !== httpStatusCodes.OK) {
+				throw errors.buildUnexpectedResponseError(response);
+			}
 
-		if (response.statusCode !== httpStatusCodes.OK) {
-			callback(errors.buildUnexpectedResponseError(response));
-			return;
-		}
-
-		callback(null, response.body.next_stream_position);
-	});
+			return response.body.next_stream_position;
+		})
+		.asCallback(callback);
 };
 
 /**
@@ -80,9 +77,9 @@ Events.prototype.getCurrentStreamPosition = function(callback) {
  * API Endpoint: '/events'
  * Method: GET
  *
- * @param {?Object} qs Query string options
- * @param {Function} callback Passed the current stream position if successful
- * @returns {void}
+ * @param {Object} [qs] Query string options
+ * @param {Function} [callback] Passed the current stream position if successful
+ * @returns {Promise<Object>} A promise resolving to the collection of events
  */
 Events.prototype.get = function(qs, callback) {
 
@@ -90,35 +87,39 @@ Events.prototype.get = function(qs, callback) {
 		qs: qs
 	};
 	var apiPath = urlPath(BASE_PATH);
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
+/**
+ * Get information for long-polling until new events are available
+ *
+ * API Endpoint: '/events'
+ * Method: OPTIONS
+ *
+ * @param {Function} [callback] Passed the long poll info if successful
+ * @returns {Promise<Object>} A promise resolving to the long poll info
+ */
 Events.prototype.getLongPollInfo = function(callback) {
 
 	var apiPath = urlPath(BASE_PATH);
-	this.client.options(apiPath, {}, function(err, response) {
+	return this.client.options(apiPath, {})
+		.then(function(response) {
 
-		if (err) {
-			callback(err);
-			return;
-		}
+			if (response.statusCode !== httpStatusCodes.OK) {
+				throw errors.buildUnexpectedResponseError(response);
+			}
 
-		if (response.statusCode !== httpStatusCodes.OK) {
-			callback(errors.buildUnexpectedResponseError(response));
-			return;
-		}
+			var longpollInfo = response.body.entries.find(function(entry) {
+				return entry.type === 'realtime_server';
+			});
 
-		var longpollInfo = response.body.entries.find(function(entry) {
-			return entry.type === 'realtime_server';
-		});
+			if (!longpollInfo) {
+				throw errors.buildResponseError('No valid long poll server specified', response);
+			}
 
-		if (!longpollInfo) {
-			callback(errors.buildResponseError('No valid long poll server specified', response));
-			return;
-		}
-
-		callback(null, longpollInfo);
-	});
+			return longpollInfo;
+		})
+		.asCallback(callback);
 };
 
 /**
@@ -128,32 +129,23 @@ Events.prototype.getLongPollInfo = function(callback) {
  * Method: OPTIONS
  *
  * @param {string} [streamPosition] Starting stream position
- * @param {Function} callback Passed the events stream if successful
- * @returns {void}
+ * @param {Function} [callback] Passed the events stream if successful
+ * @returns {Promise<EventStream>} A promise resolving to the event stream
  */
 Events.prototype.getEventStream = function(streamPosition, callback) {
 
 	var self = this;
 	if (typeof streamPosition === 'string') {
 
-
-		setImmediate(function() {
-			callback(null, new EventStream(self.client, streamPosition));
-		});
-		return;
+		return Promise.resolve(new EventStream(self.client, streamPosition)).asCallback(callback);
 	}
 
 	// Fix up optional arguments
 	callback = streamPosition;
 
-	this.getCurrentStreamPosition(function(err, currentStreamPosition) {
-		if (err) {
-			callback(err);
-			return;
-		}
-
-		callback(null, new EventStream(self.client, currentStreamPosition));
-	});
+	return this.getCurrentStreamPosition()
+		.then(currentStreamPosition => new EventStream(self.client, currentStreamPosition))
+		.asCallback(callback);
 };
 
 module.exports = Events;

--- a/lib/managers/files.js
+++ b/lib/managers/files.js
@@ -87,16 +87,16 @@ function Files(client) {
  * Method: GET
  *
  * @param {string} fileID - Box ID of the file being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
- * @param {Function} callback - Passed the file information if it was acquired successfully
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Function} [callback] - Passed the file information if it was acquired successfully
+ * @returns {Promise<Object>} A promise resolving to the file object
  */
 Files.prototype.get = function(fileID, qs, callback) {
 	var params = {
 		qs: qs
 	};
 	var apiPath = urlPath(BASE_PATH, fileID);
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -109,9 +109,9 @@ Files.prototype.get = function(fileID, qs, callback) {
  *   302 FOUND - Download is available. A Download URL is returned.
  *
  * @param {string} fileID - Box ID of the file being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
- * @param {Function} callback - Passed the download URL if request was successful.
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Function} [callback] - Passed the download URL if request was successful.
+ * @returns {Promise<string>} A promise resolving to the file's download URL
  */
 Files.prototype.getDownloadURL = function(fileID, qs, callback) {
 	var params = {
@@ -121,35 +121,26 @@ Files.prototype.getDownloadURL = function(fileID, qs, callback) {
 	var apiPath = urlPath(BASE_PATH, fileID, '/content');
 
 	// Handle Special API Response
-	this.client.get(apiPath, params, function(err, response) {
+	return this.client.get(apiPath, params)
+		.then(response => {
 
-		// Error - No successful request could be made
-		if (err) {
-			callback(err);
-			return;
-		}
-
-		/* eslint-disable callback-return */
-		switch (response.statusCode) {
+			switch (response.statusCode) {
 
 			// 302 - Found
 			// No data returned, but the location header points to a download link for that file.
-		case httpStatusCodes.FOUND:
-			callback(null, response.headers.location);
-			return;
+			case httpStatusCodes.FOUND:
+				return response.headers.location;
 
 			// 202 - Download isn't ready yet.
-		case httpStatusCodes.ACCEPTED:
-			callback(errors.buildResponseError(response, 'Download not ready at this time'));
-			return;
+			case httpStatusCodes.ACCEPTED:
+				throw errors.buildResponseError(response, 'Download not ready at this time');
 
 			// Unexpected Response
-		default:
-			callback(errors.buildUnexpectedResponseError(response));
-			return;
-		}
-		/* eslint-enable callback-return */
-	});
+			default:
+				throw errors.buildUnexpectedResponseError(response);
+			}
+		})
+		.asCallback(callback);
 };
 
 /**
@@ -162,23 +153,17 @@ Files.prototype.getDownloadURL = function(fileID, qs, callback) {
  *   302 FOUND - Download is available. A Download stream is returned.
  *
  * @param {string} fileID - Box ID of the file being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
- * @param {Function} callback - passed the readable stream if request was successful
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Function} [callback] - passed the readable stream if request was successful
+ * @returns {Promise<Readable>} A promise resolving for the file stream
  */
 Files.prototype.getReadStream = function(fileID, qs, callback) {
-	var self = this;
 
 	// Get the download URL to download from
-	this.getDownloadURL(fileID, qs, function(err, url) {
-		if (err) {
-			callback(err);
-			return;
-		}
-
+	return this.getDownloadURL(fileID, qs)
 		// Return a read stream to download the file
-		self.client.get(url, {streaming: true}, callback);
-	});
+		.then(url => this.client.get(url, {streaming: true}))
+		.asCallback(callback);
 };
 
 /**
@@ -192,9 +177,9 @@ Files.prototype.getReadStream = function(fileID, qs, callback) {
  *   302 FOUND - Unable to generate thumbnail. Returns a `location` URL for a generic placeholder thumbnail.
  *
  * @param {string} fileID - Box ID of the file being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
- * @param {Function} callback - Passed the thumbnail file or the URL to a placeholder thumbnail if successful.
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Function} [callback] - Passed the thumbnail file or the URL to a placeholder thumbnail if successful.
+ * @returns {Promise<Object>} A promise resolving to the thumbnail information
  */
 Files.prototype.getThumbnail = function(fileID, qs, callback) {
 	var params = {
@@ -205,44 +190,35 @@ Files.prototype.getThumbnail = function(fileID, qs, callback) {
 	var apiPath = urlPath(BASE_PATH, fileID, '/thumbnail.png');
 
 	// Handle Special API Response
-	this.client.get(apiPath, params, function(err, response) {
+	return this.client.get(apiPath, params)
+		.then(response => {
 
-		// Error - No successful request could be made
-		if (err) {
-			callback(err);
-			return;
-		}
-
-		/* eslint-disable callback-return */
-		switch (response.statusCode) {
+			switch (response.statusCode) {
 
 			// 202 - Thumbnail will be generated, but is not ready yet
 			// 302 - Thumbnail can not be generated
 			// return the url for a thumbnail placeholder
-		case httpStatusCodes.ACCEPTED:
-		case httpStatusCodes.FOUND:
-			callback(null, {
-				statusCode: response.statusCode,
-				location: response.headers.location
-			});
-			return;
+			case httpStatusCodes.ACCEPTED:
+			case httpStatusCodes.FOUND:
+				return {
+					statusCode: response.statusCode,
+					location: response.headers.location
+				};
 
 			// 200 - Thumbnail image recieved
 			// return the thumbnail file
-		case httpStatusCodes.OK:
-			callback(null, {
-				statusCode: response.statusCode,
-				file: response.body
-			});
-			return;
+			case httpStatusCodes.OK:
+				return {
+					statusCode: response.statusCode,
+					file: response.body
+				};
 
 			// Unexpected Response
-		default:
-			callback(errors.buildUnexpectedResponseError(response));
-			return;
-		}
-		/* eslint-enable callback-return */
-	});
+			default:
+				throw errors.buildUnexpectedResponseError(response);
+			}
+		})
+		.asCallback(callback);
 };
 
 /**
@@ -252,16 +228,16 @@ Files.prototype.getThumbnail = function(fileID, qs, callback) {
  * Method: GET
  *
  * @param {string} fileID - Box file id of the file
- * @param {?Object} qs - Optional additional querystring to add to the request. Can be left null in most cases.
- * @param {Function} callback - passed the file comments if they were successfully acquired
- * @returns {void}
+ * @param {Object} [qs] - Optional additional querystring to add to the request. Can be left null in most cases.
+ * @param {Function} [callback] - passed the file comments if they were successfully acquired
+ * @returns {Promise<Object>} A promise resolving to the collection of comments
  */
 Files.prototype.getComments = function(fileID, qs, callback) {
 	var params = {
 		qs: qs
 	};
 	var apiPath = urlPath(BASE_PATH, fileID, '/comments');
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 
@@ -272,9 +248,9 @@ Files.prototype.getComments = function(fileID, qs, callback) {
  * Method: PUT
  *
  * @param {string} fileID - Box ID of the file being requested
- * @param {?Object} options - File fields to update
- * @param {Function} callback - Passed the updated file information if it was acquired successfully
- * @returns {void}
+ * @param {Object} options - File fields to update
+ * @param {Function} [callback] - Passed the updated file information if it was acquired successfully
+ * @returns {Promise<Object>} A promise resolving to the update file object
  */
 Files.prototype.update = function(fileID, options, callback) {
 	var params = {
@@ -282,7 +258,7 @@ Files.prototype.update = function(fileID, options, callback) {
 	};
 
 	var apiPath = urlPath(BASE_PATH, fileID);
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -293,30 +269,27 @@ Files.prototype.update = function(fileID, options, callback) {
  *
  * @param {string} fileID - The file to add to the collection
  * @param {string} collectionID - The collection to add the file to
- * @param {Function} callback - Passed the updated file if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the updated file if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the updated file object
  */
 Files.prototype.addToCollection = function(fileID, collectionID, callback) {
 
-	this.get(fileID, {fields: 'collections'}, (err, data) => {
+	return this.get(fileID, {fields: 'collections'})
+		.then(data => {
 
-		if (err) {
-			callback(err);
-			return;
-		}
+			var collections = data.collections || [];
 
-		var collections = data.collections || [];
+			// Convert to correct format
+			collections = collections.map(c => ({id: c.id}));
 
-		// Convert to correct format
-		collections = collections.map(c => ({id: c.id}));
+			if (!collections.find(c => c.id === collectionID)) {
 
-		if (!collections.find(c => c.id === collectionID)) {
+				collections.push({id: collectionID});
+			}
 
-			collections.push({id: collectionID});
-		}
-
-		this.update(fileID, {collections}, callback);
-	});
+			return this.update(fileID, {collections});
+		})
+		.asCallback(callback);
 };
 
 /**
@@ -327,24 +300,21 @@ Files.prototype.addToCollection = function(fileID, collectionID, callback) {
  *
  * @param {string} fileID - The file to remove from the collection
  * @param {string} collectionID - The collection to remove the file from
- * @param {Function} callback - Passed the updated file if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the updated file if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the updated file object
  */
 Files.prototype.removeFromCollection = function(fileID, collectionID, callback) {
 
-	this.get(fileID, {fields: 'collections'}, (err, data) => {
+	return this.get(fileID, {fields: 'collections'})
+		.then(data => {
 
-		if (err) {
-			callback(err);
-			return;
-		}
+			var collections = data.collections || [];
+			// Convert to correct object format and remove the specified collection
+			collections = collections.map(c => ({id: c.id})).filter(c => c.id !== collectionID);
 
-		var collections = data.collections || [];
-		// Convert to correct object format and remove the specified collection
-		collections = collections.map(c => ({id: c.id})).filter(c => c.id !== collectionID);
-
-		this.update(fileID, {collections}, callback);
-	});
+			return this.update(fileID, {collections});
+		})
+		.asCallback(callback);
 };
 
 /**
@@ -355,8 +325,8 @@ Files.prototype.removeFromCollection = function(fileID, collectionID, callback) 
  *
  * @param {string} fileID - The Box ID of the file being requested
  * @param {string} newParentID - The Box ID for the new parent folder. '0' to move to All Files.
- * @param {Function} callback - Passed the updated file information if it was acquired successfully
- * @returns {void}
+ * @param {Function} [callback] - Passed the updated file information if it was acquired successfully
+ * @returns {Promise<Object>} A promise resolving to the updated file object
  */
 Files.prototype.move = function(fileID, newParentID, callback) {
 	var params = {
@@ -367,7 +337,7 @@ Files.prototype.move = function(fileID, newParentID, callback) {
 		}
 	};
 	var apiPath = urlPath(BASE_PATH, fileID);
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -378,10 +348,10 @@ Files.prototype.move = function(fileID, newParentID, callback) {
  *
  * @param {string} fileID - The Box ID of the file being requested
  * @param {string} newParentID - The Box ID for the new parent folder. '0' to copy to All Files.
- * @param {?Object} options - Optional parameters for the copy operation, can be left null in most cases
+ * @param {Object} [options] - Optional parameters for the copy operation, can be left null in most cases
  * @param {string} [options.name] - A new name to use if there is an identically-named item in the new parent folder
- * @param {Function} callback - passed the new file info if call was successful
- * @returns {void}
+ * @param {Function} [callback] - passed the new file info if call was successful
+ * @returns {Promise<Object>} A promise resolving to the new file object
  */
 Files.prototype.copy = function(fileID, newParentID, options, callback) {
 
@@ -402,7 +372,7 @@ Files.prototype.copy = function(fileID, newParentID, options, callback) {
 		body: options
 	};
 	var apiPath = urlPath(BASE_PATH, fileID, '/copy');
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -412,13 +382,13 @@ Files.prototype.copy = function(fileID, newParentID, options, callback) {
  * Method: DELETE
  *
  * @param {string} fileID - Box ID of the file being requested
- * @param {Function} callback - Empty response body passed if successful.
- * @returns {void}
+ * @param {Function} [callback] - Empty response body passed if successful.
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 Files.prototype.delete = function(fileID, callback) {
 
 	var apiPath = urlPath(BASE_PATH, fileID);
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, null, callback);
 };
 
 /**
@@ -435,10 +405,10 @@ Files.prototype.delete = function(fileID, callback) {
  * Method: OPTIONS
  *
  * @param {string} parentFolderID - The id of the parent folder to upload to
- * @param {?Object} fileData - Optional data about the file to be uploaded
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
- * @param {Function} callback - Called with upload data if successful, or err if the upload would not succeed
- * @returns {void}
+ * @param {Object} [fileData] - Optional data about the file to be uploaded
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Function} [callback] - Called with upload data if successful, or err if the upload would not succeed
+ * @returns {Promise<Object>} A promise resolving to the upload data
  */
 Files.prototype.preflightUploadFile = function(parentFolderID, fileData, qs, callback) {
 	var params = {
@@ -454,7 +424,7 @@ Files.prototype.preflightUploadFile = function(parentFolderID, fileData, qs, cal
 		Object.assign(params.body, fileData);
 	}
 	var apiPath = urlPath(BASE_PATH, '/content');
-	this.client.options(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.options)(apiPath, params, callback);
 };
 
 /**
@@ -471,10 +441,10 @@ Files.prototype.preflightUploadFile = function(parentFolderID, fileData, qs, cal
  * Method: OPTIONS
  *
  * @param {string} fileID - The file ID to which a new version will be uploaded
- * @param {?Object} fileData - Optional data about the file to be uploaded
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
- * @param {Function} callback - Called with upload data if successful, or err if the upload would not succeed
- * @returns {void}
+ * @param {Object} [fileData] - Optional data about the file to be uploaded
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Function} [callback] - Called with upload data if successful, or err if the upload would not succeed
+ * @returns {Promise<Object>} A promise resolving to the upload data
  */
 Files.prototype.preflightUploadNewFileVersion = function(fileID, fileData, qs, callback) {
 	var params = {
@@ -486,7 +456,7 @@ Files.prototype.preflightUploadNewFileVersion = function(fileID, fileData, qs, c
 	}
 
 	var apiPath = urlPath(BASE_PATH, fileID, '/content');
-	this.client.options(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.options)(apiPath, params, callback);
 };
 
 /**
@@ -500,8 +470,8 @@ Files.prototype.preflightUploadNewFileVersion = function(fileID, fileData, qs, c
  *
  * @param {string} fileID - The file ID which version will be promoted
  * @param {string} versionID - The ID of the file_version that you want to make current
- * @param {Function} callback - Passed the promoted file version information if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the promoted file version information if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the promoted file version
  */
 Files.prototype.promoteVersion = function(fileID, versionID, callback) {
 	var apiPath = urlPath(BASE_PATH, fileID, VERSIONS_SUBRESOURCE, '/current'),
@@ -512,7 +482,7 @@ Files.prototype.promoteVersion = function(fileID, versionID, callback) {
 			}
 		};
 
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -526,9 +496,9 @@ Files.prototype.promoteVersion = function(fileID, versionID, callback) {
  * @param {string} filename - the file name that the uploaded file should have
  * @param {string|Buffer|Stream} content - the content of the file. It can be a string, a Buffer, or a read stream
  * (like that returned by fs.createReadStream()).
- * @param {Function} callback - called with data about the upload if successful, or an error if the
+ * @param {Function} [callback] - called with data about the upload if successful, or an error if the
  * upload failed
- * @returns {void}
+ * @returns {Promise<Object>} A promise resolving to the uploaded file
  */
 Files.prototype.uploadFile = function(parentFolderID, filename, content, callback) {
 	var apiPath = urlPath(BASE_PATH, '/content'),
@@ -537,7 +507,7 @@ Files.prototype.uploadFile = function(parentFolderID, filename, content, callbac
 			content: createFileContentFormData(content)
 		};
 
-	this.client.upload(apiPath, null, multipartFormData, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.upload)(apiPath, null, multipartFormData, callback);
 };
 
 /**
@@ -550,9 +520,9 @@ Files.prototype.uploadFile = function(parentFolderID, filename, content, callbac
  * @param {string} fileID - the id of the file to upload a new version of
  * @param {string|Buffer|Stream} content - the content of the file. It can be a string, a Buffer, or a read stream
  * (like that returned by fs.createReadStream()).
- * @param {Function} callback - called with data about the upload if successful, or an error if the
+ * @param {Function} [callback] - called with data about the upload if successful, or an error if the
  * upload failed
- * @returns {void}
+ * @returns {Promise<Object>} A promise resolving to the uploaded file
  */
 Files.prototype.uploadNewFileVersion = function(fileID, content, callback) {
 	var apiPath = urlPath(BASE_PATH, fileID, '/content'),
@@ -560,7 +530,7 @@ Files.prototype.uploadNewFileVersion = function(fileID, content, callback) {
 			content: createFileContentFormData(content)
 		};
 
-	this.client.upload(apiPath, null, multipartFormData, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.upload)(apiPath, null, multipartFormData, callback);
 };
 
 /**
@@ -570,13 +540,13 @@ Files.prototype.uploadNewFileVersion = function(fileID, content, callback) {
  * Method: GET
  *
  * @param {string} fileID - the ID of the file to get metadata for
- * @param {Function} callback - called with an array of metadata when successful
- * @returns {void}
+ * @param {Function} [callback] - called with an array of metadata when successful
+ * @returns {Promise<Object>} A promise resolving to a collection of metadata on the file
  */
 Files.prototype.getAllMetadata = function(fileID, callback) {
 
 	var apiPath = urlPath(BASE_PATH, fileID, 'metadata');
-	this.client.get(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, null, callback);
 };
 
 /**
@@ -588,13 +558,13 @@ Files.prototype.getAllMetadata = function(fileID, callback) {
  * @param {string} fileID - The ID of the file to retrive the metadata of
  * @param {string} scope - The scope of the metadata template, e.g. "global"
  * @param {string} template - The metadata template to retrieve
- * @param {Function} callback - Passed the metadata template if successful
- * @returns {void}
+ * @param {Function} [callback] - Passed the metadata template if successful
+ * @returns {Promise<Object>} A promise resolving to the metadata template
  */
 Files.prototype.getMetadata = function(fileID, scope, template, callback) {
 
 	var apiPath = urlPath(BASE_PATH, fileID, 'metadata', scope, template);
-	this.client.get(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, null, callback);
 };
 
 /**
@@ -608,8 +578,8 @@ Files.prototype.getMetadata = function(fileID, scope, template, callback) {
  * @param {string} scope - The scope of the metadata template, e.g. "enterprise"
  * @param {string} template - The metadata template schema to add
  * @param {Object} data - Key/value pairs tp add as metadata
- * @param {Function} callback - Called with error if unsuccessful
- * @returns {void}
+ * @param {Function} [callback] - Called with error if unsuccessful
+ * @returns {Promise<Object>} A promise resolving to the new metadata
  */
 Files.prototype.addMetadata = function(fileID, scope, template, data, callback) {
 
@@ -618,7 +588,7 @@ Files.prototype.addMetadata = function(fileID, scope, template, data, callback) 
 			body: data
 		};
 
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -631,8 +601,8 @@ Files.prototype.addMetadata = function(fileID, scope, template, data, callback) 
  * @param {string} scope - The scope of the template to update
  * @param {string} template - The template to update
  * @param {Object} patch - The patch data
- * @param {Function} callback - Called with updated metadata if successful
- * @returns {void}
+ * @param {Function} [callback] - Called with updated metadata if successful
+ * @returns {Promise<Object>} A promise resolving to the updated metadata
  */
 Files.prototype.updateMetadata = function(fileID, scope, template, patch, callback) {
 
@@ -644,7 +614,7 @@ Files.prototype.updateMetadata = function(fileID, scope, template, patch, callba
 			}
 		};
 
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -656,13 +626,13 @@ Files.prototype.updateMetadata = function(fileID, scope, template, patch, callba
  * @param {string} fileID - The ID of the file to remove metadata from
  * @param {string} scope - The scope of the metadata template
  * @param {string} template - The template to remove from the file
- * @param {Function} callback - Called with nothing if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Called with nothing if successful, error otherwise
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 Files.prototype.deleteMetadata = function(fileID, scope, template, callback) {
 
 	var apiPath = urlPath(BASE_PATH, fileID, 'metadata', scope, template);
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, null, callback);
 };
 
 /**
@@ -672,25 +642,25 @@ Files.prototype.deleteMetadata = function(fileID, scope, template, callback) {
  * Method: DELETE
  *
  * @param {string} fileID - The ID of the file to remove metadata from
- * @param {Function} callback - Called with nothing if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Called with nothing if successful, error otherwise
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 Files.prototype.deletePermanently = function(fileID, callback) {
 
 	var apiPath = urlPath(BASE_PATH, fileID, '/trash');
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, null, callback);
 };
 
-/*
+/**
  * Retrieves a file that has been moved to the trash.
  *
  * API Endpoint: '/files/:fileID/trash'
  * Method: GET
  *
  * @param {string} fileID - The ID of the file being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
- * @param {Function} callback - Passed the trashed file information if successful, error otherwise
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Function} [callback] - Passed the trashed file information if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the trashed file
  */
 Files.prototype.getTrashedFile = function(fileID, qs, callback) {
 
@@ -699,7 +669,7 @@ Files.prototype.getTrashedFile = function(fileID, qs, callback) {
 	};
 
 	var apiPath = urlPath(BASE_PATH, fileID, 'trash');
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -709,9 +679,9 @@ Files.prototype.getTrashedFile = function(fileID, qs, callback) {
  * Method: GET
  *
  * @param {string} fileID - The ID of the file to get tasks for
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
- * @param {Function} callback - Passed the file tasks if successful, error otherwise
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Function} [callback] - Passed the file tasks if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to a collections of tasks on the file
  */
 Files.prototype.getTasks = function(fileID, qs, callback) {
 
@@ -720,7 +690,7 @@ Files.prototype.getTasks = function(fileID, qs, callback) {
 	};
 
 	var apiPath = urlPath(BASE_PATH, fileID, '/tasks');
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -731,8 +701,8 @@ Files.prototype.getTasks = function(fileID, qs, callback) {
  * Method: GET
  *
  * @param {string} fileID - The ID of the file to generate embed link for
- * @param {Function} callback - Passed with the embed link if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed with the embed link if successful, error otherwise
+ * @returns {Promise<string>} A promise resolving to the file embed link URL
  */
 Files.prototype.getEmbedLink = function(fileID, callback) {
 
@@ -743,20 +713,16 @@ Files.prototype.getEmbedLink = function(fileID, callback) {
 	};
 
 	var apiPath = urlPath(BASE_PATH, fileID);
-	this.client.get(apiPath, params, function(err, response) {
+	return this.client.get(apiPath, params)
+		.then(response => {
 
-		if (err) {
-			callback(err);
-			return;
-		}
+			if (response.statusCode !== httpStatusCodes.OK) {
+				throw errors.buildUnexpectedResponseError(response);
+			}
 
-		if (response.statusCode !== httpStatusCodes.OK) {
-			callback(errors.buildUnexpectedResponseError(response));
-			return;
-		}
-
-		callback(null, response.body.expiring_embed_link.url);
-	});
+			return response.body.expiring_embed_link.url;
+		})
+		.asCallback(callback);
 };
 
 /**
@@ -766,11 +732,11 @@ Files.prototype.getEmbedLink = function(fileID, callback) {
  * Method: PUT
  *
  * @param {string} fileID - The ID of the file to lock
- * @param {?Object} options - Optional parameters, can be left null in most cases
+ * @param {Object} [options] - Optional parameters, can be left null in most cases
  * @param {?string} [options.expires_at] - The time the lock expires
  * @param {boolean} [options.is_download_prevented] - Whether or not the file can be downloaded while locked
- * @param {Function} callback - Passed with the locked file information if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed with the locked file information if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the locked file object
  */
 Files.prototype.lock = function(fileID, options, callback) {
 
@@ -785,7 +751,7 @@ Files.prototype.lock = function(fileID, options, callback) {
 
 	Object.assign(params.body.lock, options);
 
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -795,8 +761,8 @@ Files.prototype.lock = function(fileID, options, callback) {
  *  Method: PUT
  *
  * @param {string} fileID - The ID of the file to unlock
- * @param {Function} callback - Passed with the unlocked file information if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed with the unlocked file information if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the unlocked file object
  */
 Files.prototype.unlock = function(fileID, callback) {
 
@@ -809,7 +775,7 @@ Files.prototype.unlock = function(fileID, callback) {
 			}
 		};
 
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -823,11 +789,11 @@ Files.prototype.unlock = function(fileID, callback) {
  * Method: POST
  *
  * @param {string} fileID - The ID of the file to restore
- * @param {?Object} options - Optional parameters, can be left null in most cases
+ * @param {Object} [options] - Optional parameters, can be left null in most cases
  * @param {string} [options.name] - The new name for this item
  * @param {string} [options.parent_id] - The new parent folder for this item
- * @param {Function} callback - Called with item information if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Called with item information if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the restored file object
  */
 Files.prototype.restoreFromTrash = function(fileID, options, callback) {
 
@@ -846,7 +812,7 @@ Files.prototype.restoreFromTrash = function(fileID, options, callback) {
 			body: options || {}
 		};
 
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -857,9 +823,9 @@ Files.prototype.restoreFromTrash = function(fileID, options, callback) {
  * Method: GET
  *
  * @param {string} fileID - The ID of the file to view version for
- * @param {?Object} qs - Additional options for the request, can be left null in most cases
- * @param {Function} callback - Passed a list of previous file versions if successful, error otherwise
- * @returns {void}
+ * @param {Object} [qs] - Additional options for the request, can be left null in most cases
+ * @param {Function} [callback] - Passed a list of previous file versions if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the collection of file versions
  */
 Files.prototype.getVersions = function(fileID, qs, callback) {
 
@@ -868,7 +834,7 @@ Files.prototype.getVersions = function(fileID, qs, callback) {
 			qs: qs
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -878,9 +844,9 @@ Files.prototype.getVersions = function(fileID, qs, callback) {
  * Method: GET
  *
  * @param {string} fileID - The Box ID of the file to get watermark for
- * @param {?Object} qs - Additional options can be passed with the request via querystring
- * @param {Function} callback - Passed the watermark information if successful, error otherwise
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Function} [callback] - Passed the watermark information if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the watermark info
  */
 Files.prototype.getWatermark = function(fileID, qs, callback) {
 
@@ -889,20 +855,16 @@ Files.prototype.getWatermark = function(fileID, qs, callback) {
 			qs: qs
 		};
 
-	this.client.get(apiPath, params, function(err, response) {
+	return this.client.get(apiPath, params)
+		.then(response => {
 
-		if (err) {
-			callback(err);
-			return;
-		}
+			if (response.statusCode !== 200) {
+				throw errors.buildUnexpectedResponseError(response);
+			}
 
-		if (response.statusCode !== 200) {
-			callback(errors.buildUnexpectedResponseError(response));
-			return;
-		}
-
-		callback(null, response.body.watermark);
-	});
+			return response.body.watermark;
+		})
+		.asCallback(callback);
 };
 
 /**
@@ -912,9 +874,9 @@ Files.prototype.getWatermark = function(fileID, qs, callback) {
  * Method: PUT
  *
  * @param {string} fileID - The Box ID of the file to update watermark for
- * @param {string} options - Optional parameters, can be left null
- * @param {Function} callback - Passed the watermark information if successful, error otherwise
- * @returns {void}
+ * @param {Object} [options] - Optional parameters, can be left null
+ * @param {Function} [callback] - Passed the watermark information if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the watermark info
  */
 Files.prototype.applyWatermark = function(fileID, options, callback) {
 	var apiPath = urlPath(BASE_PATH, fileID, WATERMARK_SUBRESOURCE),
@@ -928,7 +890,7 @@ Files.prototype.applyWatermark = function(fileID, options, callback) {
 
 	Object.assign(params.body.watermark, options);
 
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -938,14 +900,14 @@ Files.prototype.applyWatermark = function(fileID, options, callback) {
  * Method: DELETE
  *
  * @param {string} fileID - The Box ID of the file to remove watermark from
- * @param {Function} callback - Empty response body passed if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Empty response body passed if successful, error otherwise
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 Files.prototype.removeWatermark = function(fileID, callback) {
 
 	var apiPath = urlPath(BASE_PATH, fileID, WATERMARK_SUBRESOURCE);
 
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, null, callback);
 };
 
 /**
@@ -957,14 +919,14 @@ Files.prototype.removeWatermark = function(fileID, callback) {
  *
  * @param {string} fileID - The file ID which old version will be moved to the trash or delete permanently
  * @param {string} versionID - The ID of the version to move to the trash or delete permanently
- * @param {Function} callback - Empty response body, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Empty response body, error otherwise
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 Files.prototype.deleteVersion = function(fileID, versionID, callback) {
 
 	var apiPath = urlPath(BASE_PATH, fileID, VERSIONS_SUBRESOURCE, versionID);
 
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, null, callback);
 };
 
 /**
@@ -974,19 +936,19 @@ Files.prototype.deleteVersion = function(fileID, versionID, callback) {
  * Method: GET
  *
  * @param {string} fileID - Box ID of the file being requested
- * @param {?Object} options - Additional options. Can be left null in most cases.
+ * @param {Object} [options] - Additional options. Can be left null in most cases.
  * @param {int} [options.limit] - The maximum number of collaborations to return
  * @param {int} [options.offset] - Paging parameter for the collaborations collection
  * @param {string} [options.fields] - Comma-separated list of fields to return on the collaboration objects
- * @param {Function} callback - Passed the collaborations if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the collaborations if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the collection of collaborations on the file
  */
 Files.prototype.getCollaborations = function(fileID, options, callback) {
 	var params = {
 		qs: options
 	};
 	var apiPath = urlPath(BASE_PATH, fileID, '/collaborations');
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**

--- a/lib/managers/folders.js
+++ b/lib/managers/folders.js
@@ -40,16 +40,16 @@ function Folders(client) {
  * Method: GET
  *
  * @param {string} folderID - Box ID of the folder being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
- * @param {Function} callback - Passed the folder information if it was acquired successfully
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Function} [callback] - Passed the folder information if it was acquired successfully
+ * @returns {Promise<Object>} A promise resolving to the folder object
  */
 Folders.prototype.get = function(folderID, qs, callback) {
 	var params = {
 		qs: qs
 	};
 	var apiPath = urlPath(BASE_PATH, folderID);
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -59,16 +59,16 @@ Folders.prototype.get = function(folderID, qs, callback) {
  * Method: GET
  *
  * @param {string} folderID - Box ID of the folder being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
- * @param {Function} callback - Passed the folder information if it was acquired successfully
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Function} [callback] - Passed the folder information if it was acquired successfully
+ * @returns {Promise<Object>} A prmoise resolving to the collection of the items in the folder
  */
 Folders.prototype.getItems = function(folderID, qs, callback) {
 	var params = {
 		qs: qs
 	};
 	var apiPath = urlPath(BASE_PATH, folderID, '/items');
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -78,16 +78,16 @@ Folders.prototype.getItems = function(folderID, qs, callback) {
  * Method: GET
  *
  * @param {string} folderID - Box ID of the folder being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
- * @param {Function} callback - Passed the folder information if it was acquired successfully
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Function} [callback] - Passed the folder information if it was acquired successfully
+ * @returns {Promise<Object>} A promise resolving to the collection of collaborations
  */
 Folders.prototype.getCollaborations = function(folderID, qs, callback) {
 	var params = {
 		qs: qs
 	};
 	var apiPath = urlPath(BASE_PATH, folderID, '/collaborations');
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -98,8 +98,8 @@ Folders.prototype.getCollaborations = function(folderID, qs, callback) {
  *
  * @param {string} parentFolderID - Box folder id of the folder to add into
  * @param {string} name - The name for the new folder
- * @param {Function} callback - passed the new folder info if call was successful
- * @returns {void}
+ * @param {Function} [callback] - passed the new folder info if call was successful
+ * @returns {Promise<Object>} A promise resolving to the created folder object
  */
 Folders.prototype.create = function(parentFolderID, name, callback) {
 	var params = {
@@ -110,7 +110,7 @@ Folders.prototype.create = function(parentFolderID, name, callback) {
 			}
 		}
 	};
-	this.client.post(BASE_PATH, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(BASE_PATH, params, callback);
 };
 
 /**
@@ -121,10 +121,10 @@ Folders.prototype.create = function(parentFolderID, name, callback) {
  *
  * @param {string} folderID - The Box ID of the folder being requested
  * @param {string} newParentID - The Box ID for the new parent folder. '0' to copy to All Files.
- * @param {?Object} options - Optional parameters for the copy operation, can be left null in most cases
+ * @param {Object} [options] - Optional parameters for the copy operation, can be left null in most cases
  * @param {string} [options.name] - A new name to use if there is an identically-named item in the new parent folder
- * @param {Function} callback - passed the new folder info if call was successful
- * @returns {void}
+ * @param {Function} [callback] - passed the new folder info if call was successful
+ * @returns {Promise<Object>} A promise resolving to the new folder object
  */
 Folders.prototype.copy = function(folderID, newParentID, options, callback) {
 
@@ -145,7 +145,7 @@ Folders.prototype.copy = function(folderID, newParentID, options, callback) {
 		body: options
 	};
 	var apiPath = urlPath(BASE_PATH, folderID, '/copy');
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -155,9 +155,9 @@ Folders.prototype.copy = function(folderID, newParentID, options, callback) {
  * Method: PUT
  *
  * @param {string} folderID - The Box ID of the folder being requested
- * @param {?Object} options - Folder fields to update
- * @param {Function} callback - Passed the updated folder information if it was acquired successfully
- * @returns {void}
+ * @param {Object} options - Folder fields to update
+ * @param {Function} [callback] - Passed the updated folder information if it was acquired successfully
+ * @returns {Promise<Object>} A promise resolving to the updated folder object
  */
 Folders.prototype.update = function(folderID, options, callback) {
 	var params = {
@@ -165,7 +165,7 @@ Folders.prototype.update = function(folderID, options, callback) {
 	};
 
 	var apiPath = urlPath(BASE_PATH, folderID);
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -176,30 +176,27 @@ Folders.prototype.update = function(folderID, options, callback) {
  *
  * @param {string} folderID - The folder to add to the collection
  * @param {string} collectionID - The collection to add the folder to
- * @param {Function} callback - Passed the updated folder if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the updated folder if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the updated folder object
  */
 Folders.prototype.addToCollection = function(folderID, collectionID, callback) {
 
-	this.get(folderID, {fields: 'collections'}, (err, data) => {
+	return this.get(folderID, {fields: 'collections'})
+		.then(data => {
 
-		if (err) {
-			callback(err);
-			return;
-		}
+			var collections = data.collections || [];
 
-		var collections = data.collections || [];
+			// Convert to correct format
+			collections = collections.map(c => ({id: c.id}));
 
-		// Convert to correct format
-		collections = collections.map(c => ({id: c.id}));
+			if (!collections.find(c => c.id === collectionID)) {
 
-		if (!collections.find(c => c.id === collectionID)) {
+				collections.push({id: collectionID});
+			}
 
-			collections.push({id: collectionID});
-		}
-
-		this.update(folderID, {collections}, callback);
-	});
+			return this.update(folderID, {collections});
+		})
+		.asCallback(callback);
 };
 
 /**
@@ -210,24 +207,21 @@ Folders.prototype.addToCollection = function(folderID, collectionID, callback) {
  *
  * @param {string} folderID - The folder to remove from the collection
  * @param {string} collectionID - The collection to remove the folder from
- * @param {Function} callback - Passed the updated folder if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the updated folder if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the updated folder object
  */
 Folders.prototype.removeFromCollection = function(folderID, collectionID, callback) {
 
-	this.get(folderID, {fields: 'collections'}, (err, data) => {
+	return this.get(folderID, {fields: 'collections'})
+		.then(data => {
 
-		if (err) {
-			callback(err);
-			return;
-		}
+			var collections = data.collections || [];
+			// Convert to correct object format and remove the specified collection
+			collections = collections.map(c => ({id: c.id})).filter(c => c.id !== collectionID);
 
-		var collections = data.collections || [];
-		// Convert to correct object format and remove the specified collection
-		collections = collections.map(c => ({id: c.id})).filter(c => c.id !== collectionID);
-
-		this.update(folderID, {collections}, callback);
-	});
+			return this.update(folderID, {collections});
+		})
+		.asCallback(callback);
 };
 
 /**
@@ -238,8 +232,8 @@ Folders.prototype.removeFromCollection = function(folderID, collectionID, callba
  *
  * @param {string} folderID - The Box ID of the folder being requested
  * @param {string} newParentID - The Box ID for the new parent folder. '0' to move to All Files.
- * @param {Function} callback - Passed the updated folder information if it was acquired successfully
- * @returns {void}
+ * @param {Function} [callback] - Passed the updated folder information if it was acquired successfully
+ * @returns {Promise<Object>} A promise resolving to the updated folder object
  */
 Folders.prototype.move = function(folderID, newParentID, callback) {
 	var params = {
@@ -250,7 +244,7 @@ Folders.prototype.move = function(folderID, newParentID, callback) {
 		}
 	};
 	var apiPath = urlPath(BASE_PATH, folderID);
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -260,9 +254,9 @@ Folders.prototype.move = function(folderID, newParentID, callback) {
  * Method: DELETE
  *
  * @param {string} folderID - Box ID of the folder being requested
- * @param {?Object} qs - Optional query string params, can be left null in most cases
- * @param {Function} callback - Empty response body passed if successful.
- * @returns {void}
+ * @param {Object} [qs] - Optional query string params, can be left null in most cases
+ * @param {Function} [callback] - Empty response body passed if successful.
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 Folders.prototype.delete = function(folderID, qs, callback) {
 
@@ -271,7 +265,7 @@ Folders.prototype.delete = function(folderID, qs, callback) {
 	};
 
 	var apiPath = urlPath(BASE_PATH, folderID);
-	this.client.del(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, params, callback);
 };
 
 /**
@@ -281,13 +275,13 @@ Folders.prototype.delete = function(folderID, qs, callback) {
  * Method: GET
  *
  * @param {string} folderID - the ID of the folder to get metadata for
- * @param {Function} callback - called with an array of metadata when successful
- * @returns {void}
+ * @param {Function} [callback] - called with an array of metadata when successful
+ * @returns {Promise<Object>} A promise resolving to the collection of metadata on the folder
  */
 Folders.prototype.getAllMetadata = function(folderID, callback) {
 
 	var apiPath = urlPath(BASE_PATH, folderID, 'metadata');
-	this.client.get(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, null, callback);
 };
 
 /**
@@ -299,13 +293,13 @@ Folders.prototype.getAllMetadata = function(folderID, callback) {
  * @param {string} folderID - The ID of the folder to retrive the metadata of
  * @param {string} scope - The scope of the metadata template, e.g. "global"
  * @param {string} template - The metadata template to retrieve
- * @param {Function} callback - Passed the metadata template if successful
- * @returns {void}
+ * @param {Function} [callback] - Passed the metadata template if successful
+ * @returns {Promise<Object>} A promise resolving to the metadata template
  */
 Folders.prototype.getMetadata = function(folderID, scope, template, callback) {
 
 	var apiPath = urlPath(BASE_PATH, folderID, 'metadata', scope, template);
-	this.client.get(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, null, callback);
 };
 
 /**
@@ -319,8 +313,8 @@ Folders.prototype.getMetadata = function(folderID, scope, template, callback) {
  * @param {string} scope - The scope of the metadata template, e.g. "enterprise"
  * @param {string} template - The metadata template schema to add
  * @param {Object} data - Key/value pairs tp add as metadata
- * @param {Function} callback - Called with error if unsuccessful
- * @returns {void}
+ * @param {Function} [callback] - Called with error if unsuccessful
+ * @returns {Promise<Object>} A promise resolving to the created metadata
  */
 Folders.prototype.addMetadata = function(folderID, scope, template, data, callback) {
 
@@ -329,7 +323,7 @@ Folders.prototype.addMetadata = function(folderID, scope, template, data, callba
 			body: data
 		};
 
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -342,8 +336,8 @@ Folders.prototype.addMetadata = function(folderID, scope, template, data, callba
  * @param {string} scope - The scope of the template to update
  * @param {string} template - The template to update
  * @param {Object} patch - The patch data
- * @param {Function} callback - Called with updated metadata if successful
- * @returns {void}
+ * @param {Function} [callback] - Called with updated metadata if successful
+ * @returns {Promise<Object>} A promise resolving to the updated metadata
  */
 Folders.prototype.updateMetadata = function(folderID, scope, template, patch, callback) {
 
@@ -355,7 +349,7 @@ Folders.prototype.updateMetadata = function(folderID, scope, template, patch, ca
 			}
 		};
 
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -367,13 +361,13 @@ Folders.prototype.updateMetadata = function(folderID, scope, template, patch, ca
  * @param {string} folderID - The ID of the folder to remove metadata from
  * @param {string} scope - The scope of the metadata template
  * @param {string} template - The template to remove from the folder
- * @param {Function} callback - Called with nothing if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Called with nothing if successful, error otherwise
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 Folders.prototype.deleteMetadata = function(folderID, scope, template, callback) {
 
 	var apiPath = urlPath(BASE_PATH, folderID, 'metadata', scope, template);
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, null, callback);
 };
 
 /**
@@ -383,9 +377,9 @@ Folders.prototype.deleteMetadata = function(folderID, scope, template, callback)
  * Method: GET
  *
  * @param  {string} folderID  - The ID of the folder being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
- * @param  {Funnction} callback  - Passed the folder information if it was acquired successfully
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param  {Funnction} [callback]  - Passed the folder information if it was acquired successfully
+ * @returns {Promise<Object>} A promise resolving to the trashed folder object
  */
 Folders.prototype.getTrashedFolder = function(folderID, qs, callback) {
 	var params = {
@@ -393,7 +387,7 @@ Folders.prototype.getTrashedFolder = function(folderID, qs, callback) {
 	};
 
 	var apiPath = urlPath(BASE_PATH, folderID, 'trash');
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -406,11 +400,11 @@ Folders.prototype.getTrashedFolder = function(folderID, qs, callback) {
  * Method: POST
  *
  * @param {string} folderID - The ID of the folder to restore
- * @param {?Object} options - Optional parameters, can be left null
+ * @param {Object} [options] - Optional parameters, can be left null
  * @param {?string} [options.name] - The new name for this item
  * @param {string} [options.parent_id] - The new parent folder for this item
- * @param {Function} callback - Called with folder information if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Called with folder information if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the restored folder object
  */
 Folders.prototype.restoreFromTrash = function(folderID, options, callback) {
 
@@ -429,7 +423,7 @@ Folders.prototype.restoreFromTrash = function(folderID, options, callback) {
 			body: options || {}
 		};
 
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -439,13 +433,13 @@ Folders.prototype.restoreFromTrash = function(folderID, options, callback) {
  * Method: DELETE
  *
  * @param  {string} folderID Box ID of the folder being requested
- * @param  {Function} callback Called with nothing if successful, error otherwise
- * @returns {void}
+ * @param  {Function} [callback] Called with nothing if successful, error otherwise
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 Folders.prototype.deletePermanently = function(folderID, callback) {
 
 	var apiPath = urlPath(BASE_PATH, folderID, '/trash');
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, null, callback);
 };
 
 /**
@@ -455,9 +449,9 @@ Folders.prototype.deletePermanently = function(folderID, callback) {
  * Method: GET
  *
  * @param {string} folderID - The Box ID of the folder to get watermark for
- * @param {?Object} qs - Additional options can be passed with the request via querystring
- * @param {Function} callback - Passed the watermark information if successful, error otherwise
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Function} [callback] - Passed the watermark information if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the watermark info
  */
 Folders.prototype.getWatermark = function(folderID, qs, callback) {
 
@@ -466,20 +460,16 @@ Folders.prototype.getWatermark = function(folderID, qs, callback) {
 			qs: qs
 		};
 
-	this.client.get(apiPath, params, function(err, response) {
+	return this.client.get(apiPath, params)
+		.then(response => {
 
-		if (err) {
-			callback(err);
-			return;
-		}
+			if (response.statusCode !== 200) {
+				throw errors.buildUnexpectedResponseError(response);
+			}
 
-		if (response.statusCode !== 200) {
-			callback(errors.buildUnexpectedResponseError(response));
-			return;
-		}
-
-		callback(null, response.body.watermark);
-	});
+			return response.body.watermark;
+		})
+		.asCallback(callback);
 };
 
 /**
@@ -489,9 +479,9 @@ Folders.prototype.getWatermark = function(folderID, qs, callback) {
  * Method: PUT
  *
  * @param {string} folderID - The Box ID of the folder to update watermark for
- * @param {string} options - Optional parameters, can be left null
- * @param {Function} callback - Passed the watermark information if successful, error otherwise
- * @returns {void}
+ * @param {Object} [options] - Optional parameters, can be left null
+ * @param {Function} [callback] - Passed the watermark information if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the watermark info
  */
 Folders.prototype.applyWatermark = function(folderID, options, callback) {
 	var apiPath = urlPath(BASE_PATH, folderID, WATERMARK_SUBRESOURCE),
@@ -505,7 +495,7 @@ Folders.prototype.applyWatermark = function(folderID, options, callback) {
 
 	Object.assign(params.body.watermark, options);
 
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -515,14 +505,14 @@ Folders.prototype.applyWatermark = function(folderID, options, callback) {
  * Method: DELETE
  *
  * @param {string} folderID - The Box ID of the folder to remove watermark from
- * @param {Function} callback - Empty response body passed if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Empty response body passed if successful, error otherwise
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 Folders.prototype.removeWatermark = function(folderID, callback) {
 
 	var apiPath = urlPath(BASE_PATH, folderID, WATERMARK_SUBRESOURCE);
 
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, null, callback);
 };
 /**
  * @module box-node-sdk/lib/managers/folders

--- a/lib/managers/groups.js
+++ b/lib/managers/groups.js
@@ -74,14 +74,14 @@ Groups.prototype.userRoles = Object.freeze({
  * Method: POST
  *
  * @param {string} name - The name for the new group
- * @param {?Object} options - Additional parameters
+ * @param {Object} [options] - Additional parameters
  * @param {string} [options.provenance] - Used to track the external source where the group is coming from
  * @param {string} [options.external_sync_identifier] - Used as a group identifier for groups coming from an external source
  * @param {string} [options.description] - Description of the group
  * @param {GroupAccessLevel} [options.invitability_level] - Specifies who can invite this group to collaborate on folders
  * @param {GroupAccessLevel} [options.member_viewability_level] - Specifies who can view the members of this group
- * @param {Function} callback - Passed the new group object if it was created successfully, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the new group object if it was created successfully, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the new group object
  */
 Groups.prototype.create = function(name, options, callback) {
 
@@ -92,7 +92,7 @@ Groups.prototype.create = function(name, options, callback) {
 
 	params.body.name = name;
 
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -102,9 +102,9 @@ Groups.prototype.create = function(name, options, callback) {
  * Method: GET
  *
  * @param {string} groupID - The ID of the group to retrieve
- * @param {?Object} qs - Additional options passed by query string, can be left null in most cases
- * @param {Function} callback - Passed the group object if successful, error otherwise
- * @returns {void}
+ * @param {Object} [qs] - Additional options passed by query string, can be left null in most cases
+ * @param {Function} [callback] - Passed the group object if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the group object
  */
 Groups.prototype.get = function(groupID, qs, callback) {
 
@@ -113,7 +113,7 @@ Groups.prototype.get = function(groupID, qs, callback) {
 			qs: qs
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -123,9 +123,9 @@ Groups.prototype.get = function(groupID, qs, callback) {
  * Method: PUT
  *
  * @param {string} groupID - The ID of the group to update
- * @param {Object} options - Group fields to update
- * @param {Function} callback - Passed the updated group object if successful, error otherwise
- * @returns {void}
+ * @param {Object} [options] - Group fields to update
+ * @param {Function} [callback] - Passed the updated group object if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the updated group object
  */
 Groups.prototype.update = function(groupID, options, callback) {
 
@@ -134,7 +134,7 @@ Groups.prototype.update = function(groupID, options, callback) {
 			body: options
 		};
 
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -144,14 +144,14 @@ Groups.prototype.update = function(groupID, options, callback) {
  * Method: DELETE
  *
  * @param {string} groupID - The ID of the group to delete
- * @param {Function} callback - Passed nothing if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed nothing if successful, error otherwise
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 Groups.prototype.delete = function(groupID, callback) {
 
 	var apiPath = urlPath(BASE_PATH, groupID);
 
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, null, callback);
 };
 
 /**
@@ -162,10 +162,10 @@ Groups.prototype.delete = function(groupID, callback) {
  *
  * @param {string} groupID - The ID of the group to add the user to
  * @param {string} userID - The ID of the user to add the the group
- * @param {?Object} options - Optional parameters for adding the user, can be left null in most cases
+ * @param {Object} [options] - Optional parameters for adding the user, can be left null in most cases
  * @param {GroupUserRole} [options.role] - The role of the user in the group
- * @param {Function} callback - Passed the membership record if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the membership record if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the new membership object
  */
 Groups.prototype.addUser = function(groupID, userID, options, callback) {
 
@@ -183,7 +183,7 @@ Groups.prototype.addUser = function(groupID, userID, options, callback) {
 
 	Object.assign(params.body, options);
 
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 
 };
 
@@ -195,9 +195,9 @@ Groups.prototype.addUser = function(groupID, userID, options, callback) {
  * Method: GET
  *
  * @param {string} membershipID - The ID of the membership to fetch
- * @param {?Object} qs - Optional parameters, can be left null in most cases
- * @param {Function} callback - Passed the membership record if successful, error otherwise
- * @returns {void}
+ * @param {Object} [qs] - Optional parameters, can be left null in most cases
+ * @param {Function} [callback] - Passed the membership record if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the membership object
  */
 Groups.prototype.getMembership = function(membershipID, qs, callback) {
 
@@ -206,7 +206,7 @@ Groups.prototype.getMembership = function(membershipID, qs, callback) {
 			qs: qs
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -217,8 +217,8 @@ Groups.prototype.getMembership = function(membershipID, qs, callback) {
  *
  * @param {string} membershipID - The ID of the membership to update
  * @param {Object} options - Membership record fields to update
- * @param {Function} callback - Passed the updated membership object if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the updated membership object if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the updated membership object
  */
 Groups.prototype.updateMembership = function(membershipID, options, callback) {
 
@@ -227,7 +227,7 @@ Groups.prototype.updateMembership = function(membershipID, options, callback) {
 			body: options
 		};
 
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -237,14 +237,14 @@ Groups.prototype.updateMembership = function(membershipID, options, callback) {
  * Method: DELETE
  *
  * @param {string} membershipID - The ID of the membership to be removed
- * @param {Function} callback - Passed nothing if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed nothing if successful, error otherwise
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 Groups.prototype.removeMembership = function(membershipID, callback) {
 
 	var apiPath = urlPath(MEMBERSHIPS_PATH, membershipID);
 
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, null, callback);
 };
 
 /**
@@ -255,11 +255,11 @@ Groups.prototype.removeMembership = function(membershipID, callback) {
  * Method: GET
  *
  * @param {string} groupID - The ID of the group to get memberships for
- * @param {?Object} options - Optional parameters, can be left null in most cases
+ * @param {Object} [options] - Optional parameters, can be left null in most cases
  * @param {int} [options.limit] - The number of memberships to retrieve
  * @param {int} [options.offset] - Paging marker, retrieve records starting at this position in the list
- * @param {Function} callback - Passed a list of memberships if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed a list of memberships if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the collection of memberships
  */
 Groups.prototype.getMemberships = function(groupID, options, callback) {
 
@@ -268,7 +268,7 @@ Groups.prototype.getMemberships = function(groupID, options, callback) {
 			qs: options
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -278,11 +278,11 @@ Groups.prototype.getMemberships = function(groupID, options, callback) {
  * API Endpoint: '/groups'
  * Method: GET
  *
- * @param {?Object} options - Optional parameters, can be left null in most cases
+ * @param {Object} [options] - Optional parameters, can be left null in most cases
  * @param {int} [options.limit] - The number of memberships to retrieve
  * @param {int} [options.offset] - Paging marker, retrieve records starting at this position in the list
- * @param {Function} callback - Passed a list of groups if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed a list of groups if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the collection of groups
  */
 Groups.prototype.getAll = function(options, callback) {
 
@@ -291,7 +291,7 @@ Groups.prototype.getAll = function(options, callback) {
 			qs: options
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -302,11 +302,11 @@ Groups.prototype.getAll = function(options, callback) {
  * Method: GET
  *
  * @param {string} groupID - The ID of the group to get collaborations for
- * @param {?Object} options - Optional parameters, can be left null in most cases
+ * @param {Object} [options] - Optional parameters, can be left null in most cases
  * @param {int} [options.limit] - The number of memberships to retrieve
  * @param {int} [options.offset] - Paging marker, retrieve records starting at this position in the list
- * @param {Function} callback - Passed a list of collaborations if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed a list of collaborations if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the collection of collaborations for the group
  */
 Groups.prototype.getCollaborations = function(groupID, options, callback) {
 
@@ -315,7 +315,7 @@ Groups.prototype.getCollaborations = function(groupID, options, callback) {
 			qs: options
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 module.exports = Groups;

--- a/lib/managers/legal-hold-policies.js
+++ b/lib/managers/legal-hold-policies.js
@@ -60,12 +60,12 @@ LegalHoldPolicies.prototype.assignmentTypes = Object.freeze({
  * Method: POST
  *
  * @param {string} name - The name of the legal hold policy to be created
- * @param {?Object} options - Additional parameters
+ * @param {Object} [options] - Additional parameters
  * @param {string} [options.description] - Description of the legal hold policy
  * @param {string} [options.filter_started_at] - Date filter, any Custodian assignments will apply only to file versions created or uploaded inside of the date range
  * @param {string} [options.filter_ended_at] - Date filter, any Custodian assignments will apply only to file versions created or uploaded inside of the date range
- * @param {Function} callback - Passed the new policy information if it was acquired successfully, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the new policy information if it was acquired successfully, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the created policy
  */
 LegalHoldPolicies.prototype.create = function(name, options, callback) {
 	var apiPath = urlPath(BASE_PATH),
@@ -75,7 +75,7 @@ LegalHoldPolicies.prototype.create = function(name, options, callback) {
 
 	params.body.policy_name = name;
 
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -85,9 +85,9 @@ LegalHoldPolicies.prototype.create = function(name, options, callback) {
  * Method: GET
  *
  * @param {string} policyID - The Box ID of the legal hold policy being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring
- * @param {Function} callback - Passed the policy information if it was acquired successfully, error otherwise
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Function} [callback] - Passed the policy information if it was acquired successfully, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the policy object
  */
 LegalHoldPolicies.prototype.get = function(policyID, qs, callback) {
 	var apiPath = urlPath(BASE_PATH, policyID),
@@ -95,7 +95,7 @@ LegalHoldPolicies.prototype.get = function(policyID, qs, callback) {
 			qs: qs
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -109,8 +109,8 @@ LegalHoldPolicies.prototype.get = function(policyID, qs, callback) {
  * @param {string} [options.policy_name] - Name of Legal Hold Policy
  * @param {string} [options.description] - Description of Legal Hold Policy
  * @param {string} [options.release_notes] - Notes around why the policy was released
- * @param {Function} callback - Passed the updated policy information if it was acquired successfully, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the updated policy information if it was acquired successfully, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the updated policy
  */
 LegalHoldPolicies.prototype.update = function(policyID, options, callback) {
 
@@ -119,7 +119,7 @@ LegalHoldPolicies.prototype.update = function(policyID, options, callback) {
 			body: options
 		};
 
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -128,12 +128,12 @@ LegalHoldPolicies.prototype.update = function(policyID, options, callback) {
  * API Endpoint: '/legal_hold_policies'
  * Method: GET
  *
- * @param {?Object} qs - Additional options can be passed with the request via querystring
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring
  * @param {string} [qs.policy_name] - A full or partial name to filter the legal hold policies by
  * @param {int} [qs.limit] - Limit result size to this number
  * @param {string} [qs.marker] - Paging marker, leave blank to start at the first page
- * @param {Function} callback - Passed the policy objects if they were acquired successfully, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the policy objects if they were acquired successfully, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the collection of policies
  */
 LegalHoldPolicies.prototype.getAll = function(qs, callback) {
 	var apiPath = urlPath(BASE_PATH),
@@ -141,7 +141,7 @@ LegalHoldPolicies.prototype.getAll = function(qs, callback) {
 			qs: qs
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -153,14 +153,14 @@ LegalHoldPolicies.prototype.getAll = function(qs, callback) {
  * Method: DELETE
  *
  * @param {string} policyID - The legal hold policy to delete
- * @param {Function} callback - Passed nothing if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed nothing if successful, error otherwise
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 LegalHoldPolicies.prototype.delete = function(policyID, callback) {
 
 	var apiPath = urlPath(BASE_PATH, policyID);
 
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, null, callback);
 };
 
 /**
@@ -170,11 +170,11 @@ LegalHoldPolicies.prototype.delete = function(policyID, callback) {
  * Method: GET
  *
  * @param {string} policyID - The Box ID of the legal hold policy to get assignments for
- * @param {?Object} qs - Additional options can be passed with the request via querystring
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring
  * @param {LegalHoldPolicyAssignmentType} [qs.assign_to_type] - Filter assignments of this type only
   * @param {string} [qs.assign_to_id] - Filter assignments to this ID only. Note that this will only show assignments applied directly to this entity.
- * @param {Function} callback - Passed the assignment objects if they were acquired successfully, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the assignment objects if they were acquired successfully, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the collection of policy assignments
  */
 LegalHoldPolicies.prototype.getAssignments = function(policyID, qs, callback) {
 
@@ -183,7 +183,7 @@ LegalHoldPolicies.prototype.getAssignments = function(policyID, qs, callback) {
 			qs: qs
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -195,8 +195,8 @@ LegalHoldPolicies.prototype.getAssignments = function(policyID, qs, callback) {
  * @param {string} policyID - The ID of the policy to assign
  * @param {LegalHoldPolicyAssignmentType} assignType - The type of object the policy will be assigned to
  * @param {string} assignID - The Box ID of the object to assign the legal hold policy to
- * @param {Function} callback - Passed the new assignment object if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the new assignment object if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the created assignment object
  */
 LegalHoldPolicies.prototype.assign = function(policyID, assignType, assignID, callback) {
 
@@ -211,7 +211,7 @@ LegalHoldPolicies.prototype.assign = function(policyID, assignType, assignID, ca
 			}
 		};
 
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -221,9 +221,9 @@ LegalHoldPolicies.prototype.assign = function(policyID, assignType, assignID, ca
  * Method: GET
  *
  * @param {string} assignmentID - The Box ID of the policy assignment object to fetch
- * @param {?Object} qs - Additional options can be passed with the request via querystring
- * @param {Function} callback - Passed the assignment object if it was acquired successfully, error otherwise
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Function} [callback] - Passed the assignment object if it was acquired successfully, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the assignment object
  */
 LegalHoldPolicies.prototype.getAssignment = function(assignmentID, qs, callback) {
 
@@ -232,7 +232,7 @@ LegalHoldPolicies.prototype.getAssignment = function(assignmentID, qs, callback)
 			qs: qs
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -244,14 +244,14 @@ LegalHoldPolicies.prototype.getAssignment = function(assignmentID, qs, callback)
  * Method: DELETE
  *
  * @param {string} assignmentID - The legal hold policy assignment to delete
- * @param {Function} callback - Passed nothing if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed nothing if successful, error otherwise
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 LegalHoldPolicies.prototype.deleteAssignment = function(assignmentID, callback) {
 
 	var apiPath = urlPath(ASSIGNMENTS_PATH, assignmentID);
 
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, null, callback);
 };
 
 /**
@@ -261,9 +261,9 @@ LegalHoldPolicies.prototype.deleteAssignment = function(assignmentID, callback) 
  * Method: GET
  *
  * @param {string} legalHoldID - The ID for the file legal hold record to retrieve
- * @param {?Object} qs - Additional options can be passed with the request via querystring
- * @param {Function} callback - Pass the file version legal hold record if successful, error otherwise
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Function} [callback] - Pass the file version legal hold record if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the legal hold record
  */
 LegalHoldPolicies.prototype.getFileVersionLegalHold = function(legalHoldID, qs, callback) {
 
@@ -272,7 +272,7 @@ LegalHoldPolicies.prototype.getFileVersionLegalHold = function(legalHoldID, qs, 
 			qs: qs
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -282,9 +282,9 @@ LegalHoldPolicies.prototype.getFileVersionLegalHold = function(legalHoldID, qs, 
  * Method: GET
  *
  * @param {string} policyID - ID of Legal Hold Policy to get File Version Legal Holds for
- * @param {?Object} qs - Additional options can be passed with the request via querystring
- * @param {Function} callback - Pass the file version legal holds records if successful, error otherwise
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Function} [callback] - Pass the file version legal holds records if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the collection of all file version legal holds
  */
 LegalHoldPolicies.prototype.getAllFileVersionLegalHolds = function(policyID, qs, callback) {
 
@@ -295,7 +295,7 @@ LegalHoldPolicies.prototype.getAllFileVersionLegalHolds = function(policyID, qs,
 
 	params.qs.policy_id = policyID;
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 module.exports = LegalHoldPolicies;

--- a/lib/managers/metadata.js
+++ b/lib/managers/metadata.js
@@ -86,13 +86,13 @@ Metadata.prototype = {
 	 *
 	 * @param {string} scope - The scope of the template, e.g. "enterprise"
 	 * @param {string} template - The template to retrieve
-	 * @param {Function} callback - Called with the template schema if successful
-	 * @returns {void}
+	 * @param {Function} [callback] - Called with the template schema if successful
+	 * @returns {Promise<Object>} A promise resolving to the template schema
 	 */
 	getTemplateSchema: function(scope, template, callback) {
 
 		var apiPath = urlPath(BASE_PATH, scope, template, SCHEMA_SUBRESOURCE);
-		this.client.get(apiPath, null, this.client.defaultResponseHandler(callback));
+		return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, null, callback);
 	},
 
 	/**
@@ -102,13 +102,13 @@ Metadata.prototype = {
 	 * Method: GET
 	 *
 	 * @param {string} scope - The scope to retrieve templates for
-	 * @param {Function} callback - Called with an array of templates when successful
-	 * @returns {void}
+	 * @param {Function} [callback] - Called with an array of templates when successful
+	 * @returns {Promise<Object>} A promise resolving to the collection of templates
 	 */
 	getTemplates: function(scope, callback) {
 
 		var apiPath = urlPath(BASE_PATH, scope);
-		this.client.get(apiPath, null, this.client.defaultResponseHandler(callback));
+		return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, null, callback);
 	},
 
 	/**
@@ -119,12 +119,12 @@ Metadata.prototype = {
 	 *
 	 * @param {string} templateName - The name of the metadata template
 	 * @param {MetadataTemplateField[]} fields - A list of fields for the template
-	 * @param {?Object} options - Optional parameters, can be left null in many cases
+	 * @param {Object} [options] - Optional parameters, can be left null in many cases
 	 * @param {string} [options.templateKey] - The programmatic key for the template
 	 * @param {bool} [options.hidden] - Whether the template should be hidden in the UI
 	 * @param {string} [options.scope=enterprise] - The scope for the template, only 'enterprise' is supported for now
-	 * @param {Function} callback - Passed the template if successful, error otherwise
-	 * @returns {void}
+	 * @param {Function} [callback] - Passed the template if successful, error otherwise
+	 * @returns {Promise<Object>} A promise resolving to the created template
 	 */
 	createTemplate: function(templateName, fields, options, callback) {
 
@@ -139,7 +139,7 @@ Metadata.prototype = {
 
 		Object.assign(params.body, options);
 
-		this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+		return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 	},
 
 	/**
@@ -153,8 +153,8 @@ Metadata.prototype = {
 	 * @param {string} scope - The scope of the template to modify
 	 * @param {string} template - The template to modify
 	 * @param {Object[]} operations - The operations to perform
-	 * @param {Function} callback - Passed the updated template if successful, error otherwise
-	 * @returns {void}
+	 * @param {Function} [callback] - Passed the updated template if successful, error otherwise
+	 * @returns {Promise<Object>} A promise resolving to the updated template
 	 * @see {@link https://docs.box.com/reference#update-metadata-schema}
 	 */
 	updateTemplate: function(scope, template, operations, callback) {
@@ -164,7 +164,7 @@ Metadata.prototype = {
 				body: operations
 			};
 
-		this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+		return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 	}
 };
 

--- a/lib/managers/retention-policies.js
+++ b/lib/managers/retention-policies.js
@@ -94,10 +94,10 @@ RetentionPolicies.prototype.assignmentTypes = Object.freeze({
  * @param {string} name - The name of the retention policy to be created
  * @param {RetentionPolicyType} type - The type of policy to create
  * @param {RetentionPolicyDispositionAction} action - The disposition action for the new policy
- * @param {?Object} options - Additional parameters
+ * @param {Object} [options] - Additional parameters
  * @param {int} [options.retention_length] - For finite policies, the number of days to retain the content
- * @param {Function} callback - Passed the new policy information if it was acquired successfully, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the new policy information if it was acquired successfully, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the new policy object
  */
 RetentionPolicies.prototype.create = function(name, type, action, options, callback) {
 	var apiPath = urlPath(BASE_PATH),
@@ -111,7 +111,7 @@ RetentionPolicies.prototype.create = function(name, type, action, options, callb
 
 	Object.assign(params.body, options);
 
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -121,9 +121,9 @@ RetentionPolicies.prototype.create = function(name, type, action, options, callb
  * Method: GET
  *
  * @param {string} policyID - The Box ID of the retention policy being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring
- * @param {Function} callback - Passed the policy information if it was acquired successfully, error otherwise
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Function} [callback] - Passed the policy information if it was acquired successfully, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the policy object
  */
 RetentionPolicies.prototype.get = function(policyID, qs, callback) {
 	var apiPath = urlPath(BASE_PATH, policyID),
@@ -131,7 +131,7 @@ RetentionPolicies.prototype.get = function(policyID, qs, callback) {
 			qs: qs
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -145,8 +145,8 @@ RetentionPolicies.prototype.get = function(policyID, qs, callback) {
  * @param {string} [options.policy_name] - The name of the retention policy
  * @param {RetentionPolicyDispositionAction} [options.disposition_action] - The disposition action for the updated policy
  * @param {string} [options.status] - Used to retire a retention policy if status is set to retired
- * @param {Function} callback - Passed the updated policy information if it was acquired successfully, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the updated policy information if it was acquired successfully, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the updated policy object
  */
 RetentionPolicies.prototype.update = function(policyID, options, callback) {
 
@@ -155,7 +155,7 @@ RetentionPolicies.prototype.update = function(policyID, options, callback) {
 			body: options
 		};
 
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -164,12 +164,12 @@ RetentionPolicies.prototype.update = function(policyID, options, callback) {
  * API Endpoint: '/retention_policies
  * Method: GET
  *
- * @param {?Object} qs - Additional options can be passed with the request via querystring
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring
  * @param {string} [qs.policy_name] - A full or partial name to filter the retention policies by
  * @param {RetentionPolicyType} [qs.policy_type] - A policy type to filter the retention policies by
  * @param {string} [qs.created_by_user_id] - A user id to filter the retention policies by
- * @param {Function} callback - Passed the policy objects if they were acquired successfully, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the policy objects if they were acquired successfully, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the collection of policies
  */
 RetentionPolicies.prototype.getAll = function(qs, callback) {
 	var apiPath = urlPath(BASE_PATH),
@@ -177,7 +177,7 @@ RetentionPolicies.prototype.getAll = function(qs, callback) {
 			qs: qs
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -187,10 +187,10 @@ RetentionPolicies.prototype.getAll = function(qs, callback) {
  * Method: GET
  *
  * @param {string} policyID - The Box ID of the retention policy to get assignments for
- * @param {?Object} qs - Additional options can be passed with the request via querystring
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring
  * @param {RetentionPolicyAssignmentType} [qs.type] - The type of the retention policy assignment to retrieve
- * @param {Function} callback - Passed the assignment objects if they were acquired successfully, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the assignment objects if they were acquired successfully, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the collection of policy assignments
  */
 RetentionPolicies.prototype.getAssignments = function(policyID, qs, callback) {
 
@@ -199,7 +199,7 @@ RetentionPolicies.prototype.getAssignments = function(policyID, qs, callback) {
 			qs: qs
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -211,8 +211,8 @@ RetentionPolicies.prototype.getAssignments = function(policyID, qs, callback) {
  * @param {string} policyID - The ID of the policy to assign
  * @param {RetentionPolicyAssignmentType} assignType - The type of object the policy will be assigned to
  * @param {string} assignID - The Box ID of the object to assign the retention policy to
- * @param {Function} callback - Passed the new assignment object if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the new assignment object if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the created assignment object
  */
 RetentionPolicies.prototype.assign = function(policyID, assignType, assignID, callback) {
 
@@ -227,7 +227,7 @@ RetentionPolicies.prototype.assign = function(policyID, assignType, assignID, ca
 			}
 		};
 
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -237,9 +237,9 @@ RetentionPolicies.prototype.assign = function(policyID, assignType, assignID, ca
  * Method: GET
  *
  * @param {string} assignmentID - The Box ID of the policy assignment object to fetch
- * @param {?Object} qs - Additional options can be passed with the request via querystring
- * @param {Function} callback - Passed the assignment object if it was acquired successfully, error otherwise
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Function} [callback] - Passed the assignment object if it was acquired successfully, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the assignment object
  */
 RetentionPolicies.prototype.getAssignment = function(assignmentID, qs, callback) {
 
@@ -248,7 +248,7 @@ RetentionPolicies.prototype.getAssignment = function(assignmentID, qs, callback)
 			qs: qs
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -260,9 +260,9 @@ RetentionPolicies.prototype.getAssignment = function(assignmentID, qs, callback)
  * Method: GET
  *
  * @param {string} retentionID - The ID for the file retention record to retrieve
- * @param {?Object} qs - Additional options can be passed with the request via querystring
- * @param {Function} callback - Pass the file version retention record if successful, error otherwise
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Function} [callback] - Pass the file version retention record if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the retention record
  */
 RetentionPolicies.prototype.getFileVersionRetention = function(retentionID, qs, callback) {
 
@@ -271,7 +271,7 @@ RetentionPolicies.prototype.getFileVersionRetention = function(retentionID, qs, 
 			qs: qs
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -282,7 +282,7 @@ RetentionPolicies.prototype.getFileVersionRetention = function(retentionID, qs, 
  * API Endpoint: '/file_version_retentions'
  * Method: GET
  *
- * @param {?Object} qs - Additional options can be passed with the request via querystring
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring
  * @param {string} [qs.file_id] - A file id to filter the file version retentions by
  * @param {string} [qs.file_version_id] - A file version id to filter the file version retentions by
  * @param {string} [qs.policy_id] - A policy id to filter the file version retentions by
@@ -291,8 +291,8 @@ RetentionPolicies.prototype.getFileVersionRetention = function(retentionID, qs, 
  * @param {string} [qs.disposition_after] - Filter by retention policies which will complete after a certain time
  * @param {int} [qs.limit] - The maximum number of items to return in a page
  * @param {string} [qs.marker] - Paging marker, left blank to begin paging from the beginning
- * @param {Function} callback - Pass the file version retention record if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Pass the file version retention record if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the collection of retention records
  */
 RetentionPolicies.prototype.getAllFileVersionRetentions = function(qs, callback) {
 
@@ -301,7 +301,7 @@ RetentionPolicies.prototype.getAllFileVersionRetentions = function(qs, callback)
 			qs: qs
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 module.exports = RetentionPolicies;

--- a/lib/managers/search.js
+++ b/lib/managers/search.js
@@ -8,7 +8,8 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-var urlPath = require('../util/url-path');
+var urlPath = require('../util/url-path'),
+	Promise = require('bluebird');
 
 // -----------------------------------------------------------------------------
 // Typedefs
@@ -63,7 +64,7 @@ Search.prototype = {
 	 * Searches Box for the given query.
 	 *
 	 * @param {string} searchString - The query string to use for search
-	 * @param {?Object} options - Additional search filters. Can be left null in most cases.
+	 * @param {Object} [options] - Additional search filters. Can be left null in most cases.
 	 * @param {SearchScope} [options.scope] - The scope on which you want search. Can be user_content for a search limited to the current user or enterprise_content to search an entire enterprise
 	 * @param {string} [options.file_extensions] - Single or comma-delimited list of file extensions to filter against
 	 * @param {string} [options.created_at_range] - Date range for filtering on item creation time, e.g. '2014-05-15T13:35:01-07:00,2014-05-17T13:35:01-07:00'
@@ -77,8 +78,8 @@ Search.prototype = {
 	 * @param {SearchMetadataFilter[]} [options.mdfilters] - Searches for objects with a specific metadata object association.  Searches with the this parameter do not require a query string
 	 * @param {int} [options.limit=30] - The number of search results to return, max 200
 	 * @param {int} [options.offset=0] - The search result at which to start the response, must be a multiple of limit
-	 * @param {APIRequest~Callback} callback - passed the new comment data if it was posted successfully
-	 * @returns {void}
+	 * @param {APIRequest~Callback} [callback] - passed the new comment data if it was posted successfully
+	 * @returns {Promise<Object>} A promise resolving to the collection of search results
 	 */
 	query: function(searchString, options, callback) {
 
@@ -91,15 +92,14 @@ Search.prototype = {
 			if (Array.isArray(qs.mdfilters)) {
 				qs.mdfilters = JSON.stringify(qs.mdfilters);
 			} else {
-				setImmediate(() => callback(new Error('Invalid mdfilters parameter: must be a valid array')));
-				return;
+				return Promise.reject(new Error('Invalid mdfilters parameter: must be a valid array')).asCallback(callback);
 			}
 		}
 
 		var params = {
 			qs: qs
 		};
-		this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+		return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 	}
 
 };

--- a/lib/managers/shared-items.js
+++ b/lib/managers/shared-items.js
@@ -39,10 +39,10 @@ function SharedItems(client) {
  * Method: GET
  *
  * @param {string} url - Shared Link URL
- * @param {?string} password - Shared Link Password (null if no password)
- * @param {?Object} qs - Optional additional querystring to add to the request. Can be left null in most cases.
- * @param {Function} callback - passed the shared item if it was successfully acquired
- * @returns {void}
+ * @param {string} [password] - Shared Link Password (null if no password)
+ * @param {Object} [qs] - Optional additional querystring to add to the request. Can be left null in most cases.
+ * @param {Function} [callback] - passed the shared item if it was successfully acquired
+ * @returns {Promise<Object>} A promise resolving to the shared item object
  */
 SharedItems.prototype.get = function(url, password, qs, callback) {
 	var params = {
@@ -53,39 +53,27 @@ SharedItems.prototype.get = function(url, password, qs, callback) {
 	};
 
 	// Handle the Special API Response
-	this.client.get(BASE_PATH, params, function getSharedItemResponse(err, response) {
+	return this.client.get(BASE_PATH, params)
+		.then(response => {
 
-		// Error - No successful request could be made
-		if (err) {
-			callback(err);
-			return;
-		}
-
-		/* eslint-disable callback-return */
-		switch (response.statusCode) {
+			switch (response.statusCode) {
 
 			// 200 - Shared Item Recieved
-		case httpStatusCodes.OK:
-			callback(null, response.body);
-			return;
+			case httpStatusCodes.OK:
+				return response.body;
 
 			// 403 - Incorrect or missing password
 			// Propagate an error explaining that the password is either missing or incorrect
-		case httpStatusCodes.FORBIDDEN:
-			var errMessage = (password) ? 'password_incorrect' : 'password_missing';
-			var sharedLinkPasswordError = errors.buildResponseError(response, errMessage);
-			callback(sharedLinkPasswordError);
-			return;
+			case httpStatusCodes.FORBIDDEN:
+				var errMessage = (password) ? 'password_incorrect' : 'password_missing';
+				throw errors.buildResponseError(response, errMessage);
 
-			// Unexpected Response
-		default:
-			var unexpectedResponseError = errors.buildUnexpectedResponseError(response);
-			callback(unexpectedResponseError);
-			return;
-		}
-		/* eslint-enable callback-return */
-
-	});
+				// Unexpected Response
+			default:
+				throw errors.buildUnexpectedResponseError(response);
+			}
+		})
+		.asCallback(callback);
 };
 
 /**

--- a/lib/managers/tasks.js
+++ b/lib/managers/tasks.js
@@ -57,11 +57,11 @@ Tasks.prototype.resolutionStates = Object.freeze({
  * Method: POST
  *
  * @param {string} fileID - The ID of the item this task is for
- * @param {?Object} options - Additional parameters
+ * @param {Object} [options] - Additional parameters
  * @param {string} [options.message] - An optional message to include with the task
  * @param {string} [options.due_at] - The day at which this task is due
- * @param {Function} callback - Passed the new task information if it was acquired successfully, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the new task information if it was acquired successfully, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the created task object
  */
 Tasks.prototype.create = function(fileID, options, callback) {
 
@@ -78,7 +78,7 @@ Tasks.prototype.create = function(fileID, options, callback) {
 
 	Object.assign(params.body, options);
 
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -88,9 +88,9 @@ Tasks.prototype.create = function(fileID, options, callback) {
  * Method: GET
  *
  * @param {string} taskID - The Box ID of the task being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring
- * @param {Function} callback - Passed the task information if it was acquired successfully, error otherwise
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Function} [callback] - Passed the task information if it was acquired successfully, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the task object
  */
 Tasks.prototype.get = function(taskID, qs, callback) {
 
@@ -99,7 +99,7 @@ Tasks.prototype.get = function(taskID, qs, callback) {
 			qs: qs
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -109,11 +109,11 @@ Tasks.prototype.get = function(taskID, qs, callback) {
  * Method: PUT
  *
  * @param {string} taskID - The Box ID of the task being updated
- * @param {?Object} options - Additional parameters
+ * @param {Object} options - Additional parameters
  * @param {string} [options.message] - An optional message to include with the task
  * @param {string} [options.due_at] - The day at which this task is due
- * @param {Function} callback - Passed the updated task information if it was acquired successfully, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the updated task information if it was acquired successfully, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the updated task object
  */
 Tasks.prototype.update = function(taskID, options, callback) {
 
@@ -122,7 +122,7 @@ Tasks.prototype.update = function(taskID, options, callback) {
 			body: options
 		};
 
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -132,14 +132,14 @@ Tasks.prototype.update = function(taskID, options, callback) {
  * Method: DELETE
  *
  * @param {string} taskID - The Box ID of the task being deleted
- * @param {Function} callback - Empty body passed if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Empty body passed if successful, error otherwise
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 Tasks.prototype.delete = function(taskID, callback) {
 
 	var apiPath = urlPath(BASE_PATH, taskID);
 
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, null, callback);
 };
 
 /**
@@ -149,9 +149,9 @@ Tasks.prototype.delete = function(taskID, callback) {
  * Method: GET
  *
  * @param {string} taskID - The Box ID of the task to get assignments for
- * @param {?Object} options - Additional parameters, can be left null in most cases
- * @param {Function} callback - Passed the list of assignments if successful, error otherwise
- * @returns {void}
+ * @param {Object} [options] - Additional parameters, can be left null in most cases
+ * @param {Function} [callback] - Passed the list of assignments if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the collection of assignment objects
  */
 Tasks.prototype.getAssignments = function(taskID, options, callback) {
 
@@ -160,7 +160,7 @@ Tasks.prototype.getAssignments = function(taskID, options, callback) {
 			qs: options
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -170,9 +170,9 @@ Tasks.prototype.getAssignments = function(taskID, options, callback) {
  * Method: GET
  *
  * @param {string} assignmentID - The Box ID of the task assignment to retrieve
- * @param {?Object} options - Additional parameters, can be left null in most cases
- * @param {Function} callback - Passed the task assignment if successful, error otherwise
- * @returns {void}
+ * @param {Object} [options] - Additional parameters, can be left null in most cases
+ * @param {Function} [callback] - Passed the task assignment if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the assignment object
  */
 Tasks.prototype.getAssignment = function(assignmentID, options, callback) {
 
@@ -181,7 +181,7 @@ Tasks.prototype.getAssignment = function(assignmentID, options, callback) {
 			qs: options
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -192,8 +192,8 @@ Tasks.prototype.getAssignment = function(assignmentID, options, callback) {
  *
  * @param {string} taskID - The Box ID of the task to assign
  * @param {string} userID - The ID of the user to assign the task to
- * @param {Function} callback - Passed the task assignment if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the task assignment if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the new assignment object
  */
 Tasks.prototype.assignByUserID = function(taskID, userID, callback) {
 
@@ -210,7 +210,7 @@ Tasks.prototype.assignByUserID = function(taskID, userID, callback) {
 			}
 		};
 
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -221,8 +221,8 @@ Tasks.prototype.assignByUserID = function(taskID, userID, callback) {
  *
  * @param {string} taskID - The Box ID of the task to assign
  * @param {string} email - The email address of the user to assign the task to
- * @param {Function} callback - Passed the task assignment if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the task assignment if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the new assignment object
  */
 Tasks.prototype.assignByEmail = function(taskID, email, callback) {
 
@@ -239,7 +239,7 @@ Tasks.prototype.assignByEmail = function(taskID, email, callback) {
 			}
 		};
 
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -249,11 +249,11 @@ Tasks.prototype.assignByEmail = function(taskID, email, callback) {
  * Method: PUT
  *
  * @param {string} assignmentID - The Box ID of the task assignment to update
- * @param {?Object} options - The fields of the assignment to update
+ * @param {Object} options - The fields of the assignment to update
  * @param {string} [options.message] - A message from the assignee about this task
  * @param {TaskResolutionState} [options.resolution_state] - Resolution of the task
- * @param {Function} callback - Passed the updated task assignment if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the updated task assignment if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the updated assignment object
  */
 Tasks.prototype.updateAssignment = function(assignmentID, options, callback) {
 
@@ -262,7 +262,7 @@ Tasks.prototype.updateAssignment = function(assignmentID, options, callback) {
 			body: options
 		};
 
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -272,14 +272,14 @@ Tasks.prototype.updateAssignment = function(assignmentID, options, callback) {
  * Method: DELETE
  *
  * @param {string} assignmentID - The Box ID of the task assignment to delete
- * @param {Function} callback - Passed nothing if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed nothing if successful, error otherwise
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 Tasks.prototype.deleteAssignment = function(assignmentID, callback) {
 
 	var apiPath = urlPath(ASSIGNMENTS_PATH, assignmentID);
 
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, null, callback);
 };
 
 module.exports = Tasks;

--- a/lib/managers/trash.js
+++ b/lib/managers/trash.js
@@ -41,10 +41,10 @@ function Trash(client) {
  * API Endpoint: '/folders/trash/items'
  * Method: GET
  *
- * @param {?Object} options - Optional parameters, can be left null in most cases
+ * @param {Object} [options] - Optional parameters, can be left null in most cases
  * @param {string} [options.fields] - Comma-delimited list of item fields to return
- * @param {Function} callback - Passed the list of trashed items if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the list of trashed items if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the collection of trashed items
  */
 Trash.prototype.get = function(options, callback) {
 
@@ -53,7 +53,7 @@ Trash.prototype.get = function(options, callback) {
 			qs: options
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 module.exports = Trash;

--- a/lib/managers/users.js
+++ b/lib/managers/users.js
@@ -44,9 +44,9 @@ Users.prototype.CURRENT_USER_ID = CURRENT_USER_ID;
  * Method: GET
  *
  * @param {string} id - The ID of the user to retrieve
- * @param {?Object} qs - Optional additional querystring to add to the request. Can be left null in most cases.
- * @param {Function} callback - passed the user info if it was acquired successfully
- * @returns {void}
+ * @param {Object} [qs] - Optional additional querystring to add to the request. Can be left null in most cases.
+ * @param {Function} [callback] - passed the user info if it was acquired successfully
+ * @returns {Promise<Object>} A promise resolving to the user object
  */
 Users.prototype.get = function(id, qs, callback) {
 	var apiPath = urlPath(BASE_PATH, id),
@@ -54,7 +54,7 @@ Users.prototype.get = function(id, qs, callback) {
 			qs: qs
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -64,9 +64,9 @@ Users.prototype.get = function(id, qs, callback) {
  * Method: PUT
  *
  * @param {string} id - The ID of the user to update
- * @param {?Object} options - User fields to update
- * @param {Function} callback - Passed the updated user information if it was acquired successfully
- * @returns {void}
+ * @param {Object} [options] - User fields to update
+ * @param {Function} [callback] - Passed the updated user information if it was acquired successfully
+ * @returns {Promise<Object>} A promise resolving to the updated user object
  */
 Users.prototype.update = function(id, options, callback) {
 	var apiPath = urlPath(BASE_PATH, id),
@@ -74,7 +74,7 @@ Users.prototype.update = function(id, options, callback) {
 			body: options
 		};
 
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -84,11 +84,11 @@ Users.prototype.update = function(id, options, callback) {
  * Method: DELETE
  *
  * @param {string} userID - The ID of the user to delete
- * @param {?Object} qs - Optional additional querystring to add to the request. Can be left null in most cases.
+ * @param {Object} [qs] - Optional additional querystring to add to the request. Can be left null in most cases.
  * @param {bool} [qs.notify] - Determines if the destination user should receive email notification of the transfer.
  * @param {bool} [qs.force] - Whether or not the user should be deleted even if this user still own files.
- * @param {Function} callback - Empty response body passed if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Empty response body passed if successful, error otherwise
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 Users.prototype.delete = function(userID, qs ,callback) {
 	var apiPath = urlPath(BASE_PATH, userID),
@@ -96,7 +96,7 @@ Users.prototype.delete = function(userID, qs ,callback) {
 			qs: qs
 		};
 
-	this.client.del(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, params, callback);
 };
 
 /**
@@ -107,12 +107,12 @@ Users.prototype.delete = function(userID, qs ,callback) {
  * Method: GET
  *
  * @param {string} id - The ID of the user to retrieve email alises for
- * @param {Function} callback - Passed the email aliases if successful
- * @returns {void}
+ * @param {Function} [callback] - Passed the email aliases if successful
+ * @returns {Promise<Object>} A promise resolving to the collection of email aliases
  */
 Users.prototype.getEmailAliases = function(id, callback) {
 	var apiPath = urlPath(BASE_PATH, id, EMAIL_ALIASES_SUBRESOURCE);
-	this.client.get(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, null, callback);
 };
 
 /**
@@ -123,8 +123,8 @@ Users.prototype.getEmailAliases = function(id, callback) {
  *
  * @param {string} id - The ID of the user to add an email alias to
  * @param {string} email - The email address to add
- * @param {Function} callback - Passed the new alias if successful
- * @returns {void}
+ * @param {Function} [callback] - Passed the new alias if successful
+ * @returns {Promise<Object>} A promise resolving to the new email alias
  */
 Users.prototype.addEmailAlias = function(id, email, callback) {
 	var apiPath = urlPath(BASE_PATH, id, EMAIL_ALIASES_SUBRESOURCE),
@@ -135,7 +135,7 @@ Users.prototype.addEmailAlias = function(id, email, callback) {
 			}
 		};
 
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -146,12 +146,12 @@ Users.prototype.addEmailAlias = function(id, email, callback) {
  *
  * @param {string} userID - The ID of the user to remove the email alias from
  * @param {string} aliasID - The ID of the linked email alias to remove
- * @param {Function} callback - Passed nothing on success
- * @returns {void}
+ * @param {Function} [callback] - Passed nothing on success
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 Users.prototype.removeEmailAlias = function(userID, aliasID, callback) {
 	var apiPath = urlPath(BASE_PATH, userID, EMAIL_ALIASES_SUBRESOURCE, aliasID);
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, null, callback);
 };
 
 /**
@@ -162,11 +162,11 @@ Users.prototype.removeEmailAlias = function(userID, aliasID, callback) {
  * Method: GET
  *
  * @param {string} userID - The ID of the user to get group memberships for
- * @param {?Object} options - Optional parameters, can be left null in most cases
+ * @param {Object} [options] - Optional parameters, can be left null in most cases
  * @param {int} [options.limit] - The number of memberships to retrieve
  * @param {int} [options.offset] - Paging marker, retrieve records starting at this position in the list
- * @param {Function} callback - Passed a list of memberships if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed a list of memberships if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the collection of group memberships
  */
 Users.prototype.getGroupMemberships = function(userID, options, callback) {
 
@@ -175,7 +175,7 @@ Users.prototype.getGroupMemberships = function(userID, options, callback) {
 			qs: options
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 // @NOTE(fschott) 2014-05-06: Still need to implement get, edit, create, etc.

--- a/lib/managers/web-links.js
+++ b/lib/managers/web-links.js
@@ -37,11 +37,11 @@ function WebLinks(client) {
  *
  * @param {string} url - URL you want the web link to point to. Must include http:// or https://
  * @param {string} parentID - The ID of the parent folder where you're creating the web link
- * @param {?Object} options - Additional parameters
+ * @param {Object} [options] - Additional parameters
  * @param {string} [options.name] - Name for the web link. Will default to the URL if empty.
  * @param {string} [options.description] - Description of the web link. Will provide more context to users about the web link.
- * @param {Function} callback - Passed the new web link information if it was acquired successfully, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the new web link information if it was acquired successfully, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the created weblink object
  */
 WebLinks.prototype.create = function(url, parentID, options, callback) {
 	var apiPath = urlPath(BASE_PATH),
@@ -56,7 +56,7 @@ WebLinks.prototype.create = function(url, parentID, options, callback) {
 
 	Object.assign(params.body, options);
 
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -66,9 +66,9 @@ WebLinks.prototype.create = function(url, parentID, options, callback) {
  * Method: GET
  *
  * @param {string} weblinkID - The Box ID of web link being requested
- * @param {?Object} qs - Additional options can be passed with the request via querystring
- * @param {Function} callback - Passed the web-link information if it was acquired successfully, error otherwise
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Function} [callback] - Passed the web-link information if it was acquired successfully, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the weblink object
  */
 WebLinks.prototype.get = function(weblinkID, qs, callback) {
 	var apiPath = urlPath(BASE_PATH, weblinkID),
@@ -76,7 +76,7 @@ WebLinks.prototype.get = function(weblinkID, qs, callback) {
 			qs: qs
 		};
 
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -86,11 +86,11 @@ WebLinks.prototype.get = function(weblinkID, qs, callback) {
  * Method: PUT
  *
  * @param {string} weblinkID - The Box ID of the web link being updated
- * @param {?Object} options - Additional parameters
+ * @param {Object} options - Additional parameters
  * @param {string} [options.name] - Name for the web link. Will default to the URL if empty.
  * @param {string} [options.description] - Description of the web link. Will provide more context to users about the web link.
- * @param {Function} callback - Passed the updated web-link information if it was acquired successfully, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the updated web-link information if it was acquired successfully, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the updated web link object
  */
 WebLinks.prototype.update = function(weblinkID, options, callback) {
 	var apiPath = urlPath(BASE_PATH, weblinkID),
@@ -98,7 +98,7 @@ WebLinks.prototype.update = function(weblinkID, options, callback) {
 			body: options
 		};
 
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -108,13 +108,13 @@ WebLinks.prototype.update = function(weblinkID, options, callback) {
  * Method: DELETE
  *
  * @param {string} weblinkID - The Box ID of the web link being moved to the trash
- * @param {Function} callback - Empty body passed if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Empty body passed if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to nothing
  */
 WebLinks.prototype.delete = function(weblinkID, callback) {
 	var apiPath = urlPath(BASE_PATH, weblinkID);
 
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, null, callback);
 };
 
 module.exports = WebLinks;

--- a/lib/managers/webhooks.js
+++ b/lib/managers/webhooks.js
@@ -181,8 +181,8 @@ Webhooks.prototype.triggerTypes = {
  * @param {ItemType} targetType - Type of item the webhook will be created on
  * @param {string} notificationURL - The URL of your application where Box will notify you of events triggers
  * @param {WebhookTriggerType[]} triggerTypes - Array of event types that trigger notification for the target
- * @param {Function} callback - Passed the new webhook information if it was acquired successfully
- * @returns {void}
+ * @param {Function} [callback] - Passed the new webhook information if it was acquired successfully
+ * @returns {Promise<Object>} A promise resolving to the new webhook object
  */
 Webhooks.prototype.create = function(targetID, targetType, notificationURL, triggerTypes, callback) {
 	var params = {
@@ -197,7 +197,7 @@ Webhooks.prototype.create = function(targetID, targetType, notificationURL, trig
 	};
 
 	var apiPath = urlPath(BASE_PATH);
-	this.client.post(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.post)(apiPath, params, callback);
 };
 
 /**
@@ -207,9 +207,9 @@ Webhooks.prototype.create = function(targetID, targetType, notificationURL, trig
  * Method: GET
  *
  * @param {string} webhookID - ID of the webhook to retrieve
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
- * @param {Function} callback - Passed the webhook information if it was acquired successfully
- * @returns {void}
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Function} [callback] - Passed the webhook information if it was acquired successfully
+ * @returns {Promise<Object>} A promise resolving to the webhook object
  */
 Webhooks.prototype.get = function(webhookID, qs, callback) {
 	var params = {
@@ -217,7 +217,7 @@ Webhooks.prototype.get = function(webhookID, qs, callback) {
 	};
 
 	var apiPath = urlPath(BASE_PATH, webhookID);
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -226,11 +226,11 @@ Webhooks.prototype.get = function(webhookID, qs, callback) {
  * API Endpoint: '/webhooks'
  * Method: GET
  *
- * @param {?Object} qs - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
  * @param {int} [qs.limit=100] - The number of webhooks to return
  * @param {string} [qs.marker] - Pagination marker
- * @param {Function} callback - Passed the list of webhooks if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the list of webhooks if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the collection of webhooks
  */
 Webhooks.prototype.getAll = function(qs, callback) {
 	var params = {
@@ -238,7 +238,7 @@ Webhooks.prototype.getAll = function(qs, callback) {
 	};
 
 	var apiPath = urlPath(BASE_PATH);
-	this.client.get(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };
 
 /**
@@ -251,8 +251,8 @@ Webhooks.prototype.getAll = function(qs, callback) {
  * @param {Object} options - Webhook fields to update
  * @param {string} [options.address] - The new URL used by Box to send a notification when webhook is triggered
  * @param {WebhookTriggerType[]} [options.triggers] - The new events that triggers a notification
- * @param {Function} callback - Passed the updated webhook information if successful, error otherwise
- * @returns {void}
+ * @param {Function} [callback] - Passed the updated webhook information if successful, error otherwise
+ * @returns {Promise<Object>} A promise resolving to the updated webhook object
  */
 Webhooks.prototype.update = function(webhookID, options, callback) {
 	var apiPath = urlPath(BASE_PATH, webhookID),
@@ -260,7 +260,7 @@ Webhooks.prototype.update = function(webhookID, options, callback) {
 			body: options
 		};
 
-	this.client.put(apiPath, params, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
 };
 
 /**
@@ -270,12 +270,12 @@ Webhooks.prototype.update = function(webhookID, options, callback) {
  * Method: DELETE
  *
  * @param {string} webhookID - ID of webhook to be deleted
- * @param {Function} callback - Empty response body passed if successful.
- * @returns {void}
+ * @param {Function} [callback] - Empty response body passed if successful.
+ * @returns {Promise<void>} A promise resolving to nothing
  */
 Webhooks.prototype.delete = function(webhookID, callback) {
 	var apiPath = urlPath(BASE_PATH, webhookID);
-	this.client.del(apiPath, null, this.client.defaultResponseHandler(callback));
+	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, null, callback);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "major": "node Makefile.js major"
   },
   "dependencies": {
+    "bluebird": "^3.5.0",
     "http-status": "^0.2.2",
     "jsonwebtoken": "^5.7.0",
     "merge-options": "0.0.64",

--- a/tests/integration-test.js
+++ b/tests/integration-test.js
@@ -96,6 +96,51 @@ describe('Box Node SDK', function() {
 
 	});
 
+	it('should return promise when basic client manager function is called', function() {
+
+		var folderID = '98740596456',
+			folderName = 'Test Folder';
+
+		apiMock.get('/2.0/folders/' + folderID)
+			.matchHeader('Authorization', function(authHeader) {
+				assert.equal(authHeader, 'Bearer ' + TEST_ACCESS_TOKEN);
+				return true;
+			})
+			.matchHeader('User-Agent', function(uaHeader) {
+				assert.include(uaHeader, 'Box Node.js SDK v');
+				return true;
+			})
+			.matchHeader('Accept-Encoding', function(header) {
+				assert.equal(header, 'gzip');
+				return true;
+			})
+			.reply(200, {
+				id: folderID,
+				name: folderName
+			});
+
+		var sdk = new BoxSDK({
+			clientID: TEST_CLIENT_ID,
+			clientSecret: TEST_CLIENT_SECRET,
+			request: {
+				headers: {
+					'Accept-Encoding': 'gzip'
+				}
+			}
+		});
+
+		var client = sdk.getBasicClient(TEST_ACCESS_TOKEN);
+
+		return client.folders.get(folderID)
+			.catch(err => {
+				assert.ifError(err);
+			})
+			.then(data => {
+				assert.propertyVal(data, 'id', folderID);
+				assert.propertyVal(data, 'name', folderName);
+			});
+	});
+
 	it('should fire response event when response comes back from the API', function(done) {
 
 		var apiResponse = {

--- a/tests/lib/box-client-test.js
+++ b/tests/lib/box-client-test.js
@@ -137,8 +137,13 @@ describe('box-client', function() {
 
 			sandbox.mock(requestManagerFake).expects('makeRequest').yieldsAsync(null, fakeOKResponse);
 
-			sandbox.mock(basicClient).expects('_handleResponse').withExactArgs(null, fakeOKResponse, done).yieldsAsync();
-			basicClient._makeRequest({}, done);
+			sandbox.mock(basicClient).expects('_handleResponse').withArgs(null, fakeOKResponse).yieldsAsync(null, fakeOKResponse);
+			basicClient._makeRequest({}, function(err, res) {
+
+				assert.ifError(err);
+				assert.equal(res, fakeOKResponse);
+				done();
+			});
 		});
 
 		it('should propagate error when unable to upkeep tokens', function(done) {

--- a/tests/lib/managers/collaborations-test.js
+++ b/tests/lib/managers/collaborations-test.js
@@ -8,6 +8,7 @@
 // ------------------------------------------------------------------------------
 var sinon = require('sinon'),
 	mockery = require('mockery'),
+	assert = require('chai').assert,
 	leche = require('leche');
 
 var BoxClient = require('../../../lib/box-client');
@@ -62,14 +63,38 @@ describe('Collaborations', function() {
 
 	describe('get()', function() {
 		it('should make GET request to get collaboration info when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
-			sandbox.mock(boxClientFake).expects('get').withArgs('/collaborations/1234', testParamsWithQs);
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.mock(boxClientFake).expects('get').withArgs('/collaborations/1234', testParamsWithQs).returns(Promise.resolve());
 			collaborations.get(COLLABORATION_ID, testQS);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/collaborations/1234', testParamsWithQs).yieldsAsync();
-			collaborations.get(COLLABORATION_ID, testQS, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			collaborations.get(COLLABORATION_ID, testQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			collaborations.get(COLLABORATION_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return collaborations.get(COLLABORATION_ID, testQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -83,27 +108,75 @@ describe('Collaborations', function() {
 		});
 
 		it('should make GET request to get all pending collaborations when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/collaborations', expectedParams);
 			collaborations.getPending();
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/collaborations', expectedParams).yieldsAsync();
-			collaborations.getPending(done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get');
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			collaborations.getPending();
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			collaborations.getPending(function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return collaborations.getPending()
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('update()', function() {
 		it('should make PUT request to update collaboration info when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/collaborations/1234', testParamsWithBody);
 			collaborations.update(COLLABORATION_ID, testBody);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs('/collaborations/1234', testParamsWithBody).yieldsAsync();
-			collaborations.update(COLLABORATION_ID, testBody, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'put');
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			collaborations.update(COLLABORATION_ID, testBody);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			collaborations.update(COLLABORATION_ID, testBody, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return collaborations.update(COLLABORATION_ID, testBody)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -121,14 +194,38 @@ describe('Collaborations', function() {
 		});
 
 		it('should make PUT request to update collaboration status when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/collaborations/1234', expectedParams);
 			collaborations.respondToPending(COLLABORATION_ID, newStatus);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs('/collaborations/1234', expectedParams).yieldsAsync();
-			collaborations.respondToPending(COLLABORATION_ID, newStatus, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'put');
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			collaborations.respondToPending(COLLABORATION_ID, newStatus);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			collaborations.respondToPending(COLLABORATION_ID, newStatus, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return collaborations.respondToPending(COLLABORATION_ID, newStatus)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -162,7 +259,7 @@ describe('Collaborations', function() {
 
 		it('should make POST request to create a new collaboration when called', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/collaborations', expectedParams);
 			collaborations.create(newCollabAccessibleBy, itemID, newCollabRole);
 		});
@@ -171,23 +268,51 @@ describe('Collaborations', function() {
 
 			expectedParams.body.item.type = 'file';
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/collaborations', expectedParams);
 			collaborations.create(newCollabAccessibleBy, itemID, newCollabRole, {type: 'file'});
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/collaborations').yieldsAsync();
-			collaborations.create(newCollabAccessibleBy, itemID, newCollabRole, {}, done);
+			sandbox.stub(boxClientFake, 'post');
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			collaborations.create(newCollabAccessibleBy, itemID, newCollabRole);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when options is omitted', function(done) {
+		it('should pass results to callback when callback is present', function(done) {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/collaborations').yieldsAsync();
-			collaborations.create(newCollabAccessibleBy, itemID, newCollabRole, done);
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			collaborations.create(newCollabAccessibleBy, itemID, newCollabRole, {type: 'file'}, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should pass results to callback when callback is present and options is omitted', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			collaborations.create(newCollabAccessibleBy, itemID, newCollabRole, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return collaborations.create(newCollabAccessibleBy, itemID, newCollabRole)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -222,7 +347,7 @@ describe('Collaborations', function() {
 		});
 
 		it('should make POST request to create a new collaboration with the proper accessible_by property when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/collaborations', expectedParams);
 			collaborations.createWithUserID(userID, itemID, newCollabRole);
 		});
@@ -231,22 +356,51 @@ describe('Collaborations', function() {
 
 			expectedParams.body.item.type = 'file';
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/collaborations', expectedParams);
 			collaborations.createWithUserID(userID, itemID, newCollabRole, {type: 'file'});
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/collaborations').yieldsAsync();
-			collaborations.createWithUserID(userID, itemID, newCollabRole, {}, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post');
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			collaborations.createWithUserID(userID, itemID, newCollabRole);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when options is omitted', function(done) {
+		it('should pass results to callback when callback is present', function(done) {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/collaborations').yieldsAsync();
-			collaborations.createWithUserID(userID, itemID, newCollabRole, done);
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			collaborations.createWithUserID(userID, itemID, newCollabRole, {type: 'file'}, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should pass results to callback when callback is present and options is omitted', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			collaborations.createWithUserID(userID, itemID, newCollabRole, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return collaborations.createWithUserID(userID, itemID, newCollabRole)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -281,7 +435,7 @@ describe('Collaborations', function() {
 		});
 
 		it('should make POST request to create a new collaboration with the proper accessible_by property when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/collaborations', expectedParams);
 			collaborations.createWithUserEmail(userEmail, itemID, newCollabRole);
 		});
@@ -290,22 +444,51 @@ describe('Collaborations', function() {
 
 			expectedParams.body.item.type = 'file';
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/collaborations', expectedParams);
 			collaborations.createWithUserEmail(userEmail, itemID, newCollabRole, {type: 'file'});
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/collaborations').yieldsAsync();
-			collaborations.createWithUserEmail(userEmail, itemID, newCollabRole, {}, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post');
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			collaborations.createWithUserEmail(userEmail, itemID, newCollabRole);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when options is omitted', function(done) {
+		it('should pass results to callback when callback is present', function(done) {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/collaborations').yieldsAsync();
-			collaborations.createWithUserEmail(userEmail, itemID, newCollabRole, done);
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			collaborations.createWithUserEmail(userEmail, itemID, newCollabRole, {type: 'file'}, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should pass results to callback when callback is present and options is omitted', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			collaborations.createWithUserEmail(userEmail, itemID, newCollabRole, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return collaborations.createWithUserEmail(userEmail, itemID, newCollabRole)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -340,7 +523,7 @@ describe('Collaborations', function() {
 		});
 
 		it('should make POST request to create a new collaboration with the proper accessible_by property when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/collaborations', expectedParams);
 			collaborations.createWithGroupID(groupID, itemID, newCollabRole);
 		});
@@ -349,35 +532,88 @@ describe('Collaborations', function() {
 
 			expectedParams.body.item.type = 'file';
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/collaborations', expectedParams);
 			collaborations.createWithGroupID(groupID, itemID, newCollabRole, {type: 'file'});
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/collaborations').yieldsAsync();
-			collaborations.createWithGroupID(groupID, itemID, newCollabRole, {}, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post');
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			collaborations.createWithGroupID(groupID, itemID, newCollabRole);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when options is omitted', function(done) {
+		it('should pass results to callback when callback is present', function(done) {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/collaborations').yieldsAsync();
-			collaborations.createWithGroupID(groupID, itemID, newCollabRole, done);
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			collaborations.createWithGroupID(groupID, itemID, newCollabRole, {type: 'file'}, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should pass results to callback when callback is present and options is omitted', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			collaborations.createWithGroupID(groupID, itemID, newCollabRole, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return collaborations.createWithGroupID(groupID, itemID, newCollabRole)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('delete()', function() {
 		it('should make DELETE request to update collaboration info when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs('/collaborations/1234', null);
 			collaborations.delete(COLLABORATION_ID);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/collaborations/1234', null).yieldsAsync();
-			collaborations.delete(COLLABORATION_ID, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'del');
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			collaborations.delete(COLLABORATION_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			collaborations.delete(COLLABORATION_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return collaborations.delete(COLLABORATION_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 

--- a/tests/lib/managers/collections-test.js
+++ b/tests/lib/managers/collections-test.js
@@ -9,6 +9,7 @@
 // ------------------------------------------------------------------------------
 var sinon = require('sinon'),
 	mockery = require('mockery'),
+	assert = require('chai').assert,
 	leche = require('leche');
 
 var BoxClient = require('../../../lib/box-client');
@@ -57,17 +58,39 @@ describe('Collections', function() {
 	describe('getAll()', function() {
 
 		it('should make GET request to get all collections info when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/collections');
 			collections.getAll();
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/collections').yieldsAsync();
-			collections.getAll(done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get');
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			collections.getAll();
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			collections.getAll(function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return collections.getAll()
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 	describe('getItems()', function() {
@@ -80,17 +103,39 @@ describe('Collections', function() {
 		});
 
 		it('should make GET request to get all items from a collection when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/collections/1234/items');
-			collections.getItems(collectionID);
+			collections.getItems(collectionID, testQS);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/collections/1234/items', {qs: testQS}).yieldsAsync();
-			collections.getItems(collectionID, testQS, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get');
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			collections.getItems(collectionID, testQS);
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			collections.getItems(collectionID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return collections.getItems(collectionID, testQS)
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 });

--- a/tests/lib/managers/comments-test.js
+++ b/tests/lib/managers/comments-test.js
@@ -8,6 +8,7 @@
 // ------------------------------------------------------------------------------
 var sinon = require('sinon'),
 	mockery = require('mockery'),
+	assert = require('chai').assert,
 	leche = require('leche');
 
 var BoxClient = require('../../../lib/box-client');
@@ -64,14 +65,38 @@ describe('Comments', function() {
 
 	describe('get()', function() {
 		it('should make GET request to get comment info when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/comments/1234', testParamsWithQs);
 			comments.get(COMMENT_ID, testQS);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/comments/1234', testParamsWithQs).yieldsAsync();
-			comments.get(COMMENT_ID, testQS, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			comments.get(COMMENT_ID, testQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			comments.get(COMMENT_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return comments.get(COMMENT_ID, testQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -96,14 +121,38 @@ describe('Comments', function() {
 		});
 
 		it('should make POST request to create a new comment when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/comments', expectedParams);
 			comments.create(fileID, commentText);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/comments').yieldsAsync();
-			comments.create(fileID, commentText, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			comments.create(fileID, commentText);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			comments.create(fileID, commentText, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return comments.create(fileID, commentText)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -128,40 +177,112 @@ describe('Comments', function() {
 		});
 
 		it('should make POST request to create a new tagged comment when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/comments', expectedParams);
 			comments.createTaggedComment(fileID, taggedCommentText);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/comments').yieldsAsync();
-			comments.createTaggedComment(fileID, taggedCommentText, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			comments.create(fileID, taggedCommentText);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			comments.create(fileID, taggedCommentText, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return comments.create(fileID, taggedCommentText)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('update()', function() {
 		it('should make PUT request to update comment info when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/comments/1234', testParamsWithBody);
 			comments.update(COMMENT_ID, testBody);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs('/comments/1234', testParamsWithBody).yieldsAsync();
-			comments.update(COMMENT_ID, testBody, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			comments.update(COMMENT_ID, testBody);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			comments.update(COMMENT_ID, testBody, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return comments.update(COMMENT_ID, testBody)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('delete()', function() {
 		it('should make DELETE request to delete the comment when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs('/comments/1234', null);
 			comments.delete(COMMENT_ID);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/comments/1234', null).yieldsAsync();
-			comments.delete(COMMENT_ID, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			comments.delete(COMMENT_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			comments.delete(COMMENT_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return comments.delete(COMMENT_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 

--- a/tests/lib/managers/enterprise-test.js
+++ b/tests/lib/managers/enterprise-test.js
@@ -9,6 +9,7 @@
 var sinon = require('sinon'),
 	mockery = require('mockery'),
 	leche = require('leche'),
+	assert = require('chai').assert,
 	BoxClient = require('../../../lib/box-client');
 
 // ------------------------------------------------------------------------------
@@ -25,7 +26,7 @@ var sandbox = sinon.sandbox.create(),
 // Tests
 // ------------------------------------------------------------------------------
 
-describe('WebLinks', function() {
+describe('Enterprise', function() {
 
 	beforeEach(function() {
 		// Enable Mockery
@@ -56,40 +57,86 @@ describe('WebLinks', function() {
 				filter_term: 'Brad'
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/users', {qs});
 			enterprise.getUsers(qs);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/users').yieldsAsync();
-			enterprise.getUsers(null, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			enterprise.getUsers();
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			enterprise.getUsers(null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return enterprise.getUsers()
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('inviteUser()', function() {
 
-		it('should make GET request to get enterprise users when called', function() {
+		var TEST_LOGIN = 'jsmith@box.com';
 
-			var login = 'jsmith@box.com';
+		it('should make POST request to add enterprise user when called', function() {
 
 			var expectedParams = {
 				body: {
 					enterprise: {id: ENTERPRISE_ID},
-					actionable_by: {login}
+					actionable_by: {login: TEST_LOGIN}
 				}
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/invites', expectedParams);
-			enterprise.inviteUser(ENTERPRISE_ID, login);
+			enterprise.inviteUser(ENTERPRISE_ID, TEST_LOGIN);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/invites').yieldsAsync();
-			enterprise.inviteUser(ENTERPRISE_ID, 'hi@example.com', done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			enterprise.inviteUser(ENTERPRISE_ID, TEST_LOGIN);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			enterprise.inviteUser(ENTERPRISE_ID, TEST_LOGIN, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return enterprise.inviteUser(ENTERPRISE_ID, TEST_LOGIN)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -110,7 +157,7 @@ describe('WebLinks', function() {
 		});
 
 		it('should make POST request with mandatory parameters to create an user without optional parameters', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/users', expectedParams);
 			enterprise.addUser(LOGIN, NAME);
 		});
@@ -118,17 +165,39 @@ describe('WebLinks', function() {
 		it('should make POST request with all parameters to create an user when called with optional parameter', function() {
 			expectedParams.body.role = ROLE;
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/users', expectedParams);
 			enterprise.addUser(LOGIN, NAME, {role: ROLE});
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/users').yieldsAsync();
-			enterprise.addUser(LOGIN, NAME, null, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			enterprise.addUser(LOGIN, NAME, {role: ROLE});
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			enterprise.addUser(LOGIN, NAME, {role: ROLE}, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return enterprise.addUser(LOGIN, NAME, {role: ROLE})
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 	describe('addAppUser()', function() {
@@ -147,7 +216,7 @@ describe('WebLinks', function() {
 		});
 
 		it('should make POST request with mandatory parameters to create an app user without optional parameters', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/users', expectedParams);
 			enterprise.addAppUser(NAME);
 		});
@@ -155,17 +224,39 @@ describe('WebLinks', function() {
 		it('should make POST request with all parameters to create an user when called with optional parameter', function() {
 			expectedParams.body.job_title = JOB_TITLE;
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/users', expectedParams);
 			enterprise.addAppUser(NAME, {job_title: JOB_TITLE});
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/users').yieldsAsync();
-			enterprise.addAppUser(NAME, null, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			enterprise.addAppUser(NAME, {job_title: JOB_TITLE});
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			enterprise.addAppUser(NAME, {job_title: JOB_TITLE}, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return enterprise.addAppUser(NAME, {job_title: JOB_TITLE})
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 	describe('transferUserContent()', function() {
@@ -181,15 +272,38 @@ describe('WebLinks', function() {
 				}
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/users/' + SRC_USER_ID + '/folders/0', expectedParams);
 			enterprise.transferUserContent(SRC_USER_ID, DEST_USER_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs('/users/' + SRC_USER_ID + '/folders/0').yieldsAsync();
-			enterprise.transferUserContent(SRC_USER_ID, DEST_USER_ID, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			enterprise.transferUserContent(SRC_USER_ID, DEST_USER_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			enterprise.transferUserContent(SRC_USER_ID, DEST_USER_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return enterprise.transferUserContent(SRC_USER_ID, DEST_USER_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 

--- a/tests/lib/managers/events-test.js
+++ b/tests/lib/managers/events-test.js
@@ -9,6 +9,7 @@
 var sinon = require('sinon'),
 	mockery = require('mockery'),
 	assert = require('chai').assert,
+	Promise = require('bluebird'),
 	leche = require('leche');
 
 var BoxClient = require('../../../lib/box-client'),
@@ -65,15 +66,15 @@ describe('Events', function() {
 				qs: sinon.match({
 					stream_position: 'now'
 				})
-			}));
+			})).returns(Promise.resolve({statusCode: 200, body: {}}));
 
 			events.getCurrentStreamPosition();
 		});
 
-		it('should return error when API call fails', function(done) {
+		it('should call callback with error when API call fails', function(done) {
 
 			var error = new Error('Failure');
-			sandbox.stub(boxClientFake, 'get').yieldsAsync(error);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.reject(error));
 
 			events.getCurrentStreamPosition(function(err) {
 
@@ -82,13 +83,22 @@ describe('Events', function() {
 			});
 		});
 
-		it('should return a response error when API returns non-200 result', function(done) {
+		it('should return promise that rejects when API call fails', function() {
+
+			var error = new Error('Failure');
+			sandbox.stub(boxClientFake, 'get').returns(Promise.reject(error));
+
+			events.getCurrentStreamPosition()
+				.catch(err => assert.equal(err, error));
+		});
+
+		it('should call callback with a response error when API returns non-200 result', function(done) {
 
 			var response = {
 				statusCode: 404
 			};
 
-			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
 
 			events.getCurrentStreamPosition(function(err) {
 
@@ -98,7 +108,22 @@ describe('Events', function() {
 			});
 		});
 
-		it('should return current stream position when API call succeeds', function(done) {
+		it('should return a promise that rejects when API returns non-200 result', function() {
+
+			var response = {
+				statusCode: 404
+			};
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+
+			events.getCurrentStreamPosition()
+				.catch(err => {
+					assert.instanceOf(err, Error);
+					assert.propertyVal(err, 'statusCode', response.statusCode);
+				});
+		});
+
+		it('should call callback with current stream position when API call succeeds', function(done) {
 
 			var response = {
 				statusCode: 200,
@@ -107,7 +132,7 @@ describe('Events', function() {
 				}
 			};
 
-			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
 
 			events.getCurrentStreamPosition(function(err, streamPosition) {
 
@@ -117,6 +142,22 @@ describe('Events', function() {
 			});
 		});
 
+		it('should return a promise resolving to current stream position when API call succeeds', function() {
+
+			var response = {
+				statusCode: 200,
+				body: {
+					next_stream_position: TEST_STREAM_POSITION
+				}
+			};
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+
+			events.getCurrentStreamPosition()
+				.then(streamPosition => {
+					assert.equal(streamPosition, TEST_STREAM_POSITION);
+				});
+		});
 	});
 
 	describe('get()', function() {
@@ -127,35 +168,63 @@ describe('Events', function() {
 				stream_position: TEST_STREAM_POSITION
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/events', sinon.match({qs: qs}));
 
 			events.get(qs);
 		});
 
-		it('should use default response handler when called', function(done) {
+		it('should use default response handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').returnsArg(0);
-			sandbox.stub(boxClientFake, 'get').yieldsAsync();
+			sandbox.stub(boxClientFake, 'get');
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
 
-			events.get({}, done);
+			events.get({});
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			events.get({}, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return events.get()
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 	describe('getLongPollInfo()', function() {
 
 		it('should make API call to get long poll info when called', function() {
 
-			sandbox.mock(boxClientFake).expects('options').withArgs('/events');
+			var response = {
+				statusCode: 200,
+				body: {
+					entries: [{type: 'realtime_server'}]
+				}
+			};
+			sandbox.mock(boxClientFake).expects('options').withArgs('/events')
+				.returns(Promise.resolve(response));
 
 			events.getLongPollInfo();
 		});
 
-		it('should return an error when the API call fails', function(done) {
+		it('should call callback with an error when the API call fails', function(done) {
 
 			var apiError = new Error('No connection');
-			sandbox.stub(boxClientFake, 'options').yieldsAsync(apiError);
+			sandbox.stub(boxClientFake, 'options').returns(Promise.reject(apiError));
 
 			events.getLongPollInfo(function(err) {
 
@@ -164,22 +233,46 @@ describe('Events', function() {
 			});
 		});
 
-		it('should respond with an error when API call returns non-200 status', function(done) {
+		it('should return a promise that rejects when the API call fails', function() {
+
+			var apiError = new Error('No connection');
+			sandbox.stub(boxClientFake, 'options').returns(Promise.reject(apiError));
+
+			events.getLongPollInfo()
+				.catch(err => {
+					assert.equal(err, apiError);
+				});
+		});
+
+		it('should call callback with an error when API call returns non-200 status', function(done) {
 
 			var response = {
 				statusCode: 403
 			};
-			sandbox.stub(boxClientFake, 'options').yieldsAsync(null, response);
+			sandbox.stub(boxClientFake, 'options').returns(Promise.resolve(response));
 
 			events.getLongPollInfo(function(err) {
-
 				assert.instanceOf(err, Error);
 				assert.propertyVal(err, 'statusCode', response.statusCode);
 				done();
 			});
 		});
 
-		it('should respond with an error when API does not return realtime server info', function(done) {
+		it('should return promise that rejects when API call returns non-200 status', function() {
+
+			var response = {
+				statusCode: 403
+			};
+			sandbox.stub(boxClientFake, 'options').returns(Promise.resolve(response));
+
+			events.getLongPollInfo()
+				.catch(err => {
+					assert.instanceOf(err, Error);
+					assert.propertyVal(err, 'statusCode', response.statusCode);
+				});
+		});
+
+		it('should call callback with an error when API does not return realtime server info', function(done) {
 
 			var response = {
 				statusCode: 200,
@@ -187,7 +280,7 @@ describe('Events', function() {
 					entries: []
 				}
 			};
-			sandbox.stub(boxClientFake, 'options').yieldsAsync(null, response);
+			sandbox.stub(boxClientFake, 'options').returns(Promise.resolve(response));
 
 			events.getLongPollInfo(function(err) {
 
@@ -196,7 +289,23 @@ describe('Events', function() {
 			});
 		});
 
-		it('should return realtime server info when API call succeeds', function(done) {
+		it('should return promise that rejects when API does not return realtime server info', function() {
+
+			var response = {
+				statusCode: 200,
+				body: {
+					entries: []
+				}
+			};
+			sandbox.stub(boxClientFake, 'options').returns(Promise.resolve(response));
+
+			events.getLongPollInfo()
+				.catch(err => {
+					assert.instanceOf(err, Error);
+				});
+		});
+
+		it('should call callback with realtime server info when API call succeeds', function(done) {
 
 			var realtimeInfo = {
 				type: 'realtime_server',
@@ -208,7 +317,7 @@ describe('Events', function() {
 					entries: [realtimeInfo]
 				}
 			};
-			sandbox.stub(boxClientFake, 'options').yieldsAsync(null, response);
+			sandbox.stub(boxClientFake, 'options').returns(Promise.resolve(response));
 
 			events.getLongPollInfo(function(err, data) {
 
@@ -218,57 +327,97 @@ describe('Events', function() {
 			});
 		});
 
-		describe('getEventStream()', function() {
+		it('should return promise that resolves to long poll info when API call succeeds', function() {
 
-			it('should return event stream from starting stream position when passed stream position', function(done) {
+			var realtimeInfo = {
+				type: 'realtime_server',
+				url: 'https://realtime.box.com/foo'
+			};
+			var response = {
+				statusCode: 200,
+				body: {
+					entries: [realtimeInfo]
+				}
+			};
+			sandbox.stub(boxClientFake, 'options').returns(Promise.resolve(response));
 
-				var streamPosition = '38746523';
-				sandbox.mock(events).expects('getCurrentStreamPosition').never();
-				events.getEventStream(streamPosition, function(err, stream) {
-
-					assert.ifError(err);
-					assert.ok(EventStreamConstructorStub.calledOnce, 'Should call EventStream constructor');
-					assert.ok(EventStreamConstructorStub.calledWith(boxClientFake, streamPosition), 'Should pass correct args to EventStream constructor');
-					assert.equal(stream, eventStreamFake);
-					done();
+			events.getLongPollInfo()
+				.then(data => {
+					assert.equal(data, realtimeInfo);
 				});
+		});
+	});
+
+	describe('getEventStream()', function() {
+
+		it('should return event stream from starting stream position when passed stream position', function(done) {
+
+			var streamPosition = '38746523';
+			sandbox.mock(events).expects('getCurrentStreamPosition').never();
+			events.getEventStream(streamPosition, function(err, stream) {
+
+				assert.ifError(err);
+				assert.ok(EventStreamConstructorStub.calledOnce, 'Should call EventStream constructor');
+				assert.ok(EventStreamConstructorStub.calledWith(boxClientFake, streamPosition), 'Should pass correct args to EventStream constructor');
+				assert.equal(stream, eventStreamFake);
+				done();
 			});
+		});
 
-			it('should make API call to get stream position when called without stream position', function() {
+		it('should make API call to get stream position when called without stream position', function() {
 
-				sandbox.mock(events).expects('getCurrentStreamPosition');
+			sandbox.mock(events).expects('getCurrentStreamPosition').returns(Promise.resolve(TEST_STREAM_POSITION));
 
-				events.getEventStream();
+			events.getEventStream();
+		});
+
+		it('should call callback with an error when the API call fails', function(done) {
+
+			var apiError = new Error('There is no stream');
+			sandbox.stub(events, 'getCurrentStreamPosition').returns(Promise.reject(apiError));
+
+			events.getEventStream(function(err) {
+
+				assert.equal(err, apiError);
+				done();
 			});
+		});
 
-			it('should return an error when the API call fails', function(done) {
+		it('should return a promise that rejects when the API call fails', function() {
 
-				var apiError = new Error('There is no stream');
-				sandbox.stub(events, 'getCurrentStreamPosition').yieldsAsync(apiError);
+			var apiError = new Error('There is no stream');
+			sandbox.stub(events, 'getCurrentStreamPosition').returns(Promise.reject(apiError));
 
-				events.getEventStream(function(err) {
-
+			events.getEventStream()
+				.catch(err => {
 					assert.equal(err, apiError);
-					done();
 				});
+		});
+
+		it('should call callback with a new event stream from the stream position when the API call succeeds', function(done) {
+
+			sandbox.stub(events, 'getCurrentStreamPosition').returns(Promise.resolve(TEST_STREAM_POSITION));
+
+			events.getEventStream(function(err, stream) {
+
+				assert.ifError(err);
+				assert.ok(EventStreamConstructorStub.calledWithNew(), 'Should call EventStream constructor');
+				assert.ok(EventStreamConstructorStub.calledWith(boxClientFake, TEST_STREAM_POSITION), 'Should pass correct args to EventStream constructor');
+				assert.equal(stream, eventStreamFake);
+				done();
 			});
+		});
 
-			it('should return a new event stream from the stream position when the API call succeeds', function(done) {
+		it('should return a promise that resolves to a new event stream when the API call succeeds', function() {
 
-				sandbox.stub(events, 'getCurrentStreamPosition').yieldsAsync(null, TEST_STREAM_POSITION);
+			sandbox.stub(events, 'getCurrentStreamPosition').returns(Promise.resolve(TEST_STREAM_POSITION));
 
-				events.getEventStream(function(err, stream) {
-
-					assert.ifError(err);
+			events.getEventStream()
+				.then(stream => {
 					assert.ok(EventStreamConstructorStub.calledWithNew(), 'Should call EventStream constructor');
 					assert.ok(EventStreamConstructorStub.calledWith(boxClientFake, TEST_STREAM_POSITION), 'Should pass correct args to EventStream constructor');
 					assert.equal(stream, eventStreamFake);
-					done();
 				});
-			});
-
 		});
-
 	});
-
 });

--- a/tests/lib/managers/files-test.js
+++ b/tests/lib/managers/files-test.js
@@ -9,6 +9,7 @@
 var assert = require('chai').assert,
 	sinon = require('sinon'),
 	mockery = require('mockery'),
+	Promise = require('bluebird'),
 	leche = require('leche');
 
 var BoxClient = require('../../../lib/box-client');
@@ -61,32 +62,62 @@ describe('Files', function() {
 
 	describe('get()', function() {
 		it('should make GET request to get file info when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/files/1234', testParamsWithQs);
 			files.get(FILE_ID, testQS);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/files/1234', testParamsWithQs).yieldsAsync();
-			files.get(FILE_ID, testQS, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			files.get(FILE_ID, testQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			files.get(FILE_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return files.get(FILE_ID, testQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('getDownloadURL()', function() {
 
 		it('should make GET request to get file download when called', function() {
-			sandbox.mock(boxClientFake).expects('get').withArgs('/files/1234/content', testParamsWithQs);
-			files.getDownloadURL(FILE_ID, testQS);
-		});
-
-		it('should return the download URL when a 302 FOUND response is returned', function(done) {
 			var response = {
 				statusCode: 302,
 				headers: {
 					location: 'box.com/somedownloadurl'
 				}
 			};
-			sandbox.stub(boxClientFake, 'get').withArgs('/files/1234/content', testParamsWithQs).yieldsAsync(null, response);
+			sandbox.mock(boxClientFake).expects('get').withArgs('/files/1234/content', testParamsWithQs).returns(Promise.resolve(response));
+			files.getDownloadURL(FILE_ID, testQS);
+		});
+
+		it('should call callback with the download URL when a 302 FOUND response is returned', function(done) {
+			var response = {
+				statusCode: 302,
+				headers: {
+					location: 'box.com/somedownloadurl'
+				}
+			};
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
 			files.getDownloadURL(FILE_ID, testQS, function(err, location) {
 				assert.ifError(err);
 				assert.strictEqual(location, response.headers.location, 'location header is returned');
@@ -94,10 +125,24 @@ describe('Files', function() {
 			});
 		});
 
-		it('should return an error when a 202 ACCEPTED response is returned', function(done) {
+		it('should return a promise resolving to the download URL when a 302 FOUND response is returned', function() {
+			var response = {
+				statusCode: 302,
+				headers: {
+					location: 'box.com/somedownloadurl'
+				}
+			};
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return files.getDownloadURL(FILE_ID, testQS)
+				.then(location => {
+					assert.strictEqual(location, response.headers.location, 'location header is returned');
+				});
+		});
+
+		it('should call callback with an error when a 202 ACCEPTED response is returned', function(done) {
 			var response = {statusCode: 202};
 
-			sandbox.mock(boxClientFake).expects('get').withArgs('/files/1234/content', testParamsWithQs).yieldsAsync(null, response);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
 			files.getDownloadURL(FILE_ID, testQS, function(err) {
 				assert.instanceOf(err, Error);
 				assert.strictEqual(err.statusCode, response.statusCode);
@@ -105,10 +150,21 @@ describe('Files', function() {
 			});
 		});
 
-		it('should return an error when the API call does not succeed', function(done) {
+		it('should return a promise that rejects when a 202 ACCEPTED response is returned', function() {
+			var response = {statusCode: 202};
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return files.getDownloadURL(FILE_ID, testQS)
+				.catch(err => {
+					assert.instanceOf(err, Error);
+					assert.strictEqual(err.statusCode, response.statusCode);
+				});
+		});
+
+		it('should call callback with an error when the API call does not succeed', function(done) {
 
 			var apiError = new Error('ECONNRESET');
-			sandbox.mock(boxClientFake).expects('get').withArgs('/files/1234/content', testParamsWithQs).yieldsAsync(apiError);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.reject(apiError));
 
 			files.getDownloadURL(FILE_ID, testQS, function(err) {
 				assert.equal(err, apiError);
@@ -116,46 +172,74 @@ describe('Files', function() {
 			});
 		});
 
-		it('should return unexpected response error when the API returns unknown status code', function(done) {
+		it('should return a promise that rejects when the API call does not succeed', function() {
+
+			var apiError = new Error('ECONNRESET');
+			sandbox.stub(boxClientFake, 'get').returns(Promise.reject(apiError));
+
+			return files.getDownloadURL(FILE_ID, testQS)
+				.catch(err => {
+					assert.equal(err, apiError);
+				});
+		});
+
+		it('should call callback with unexpected response error when the API returns unknown status code', function() {
 			var response = {statusCode: 403};
 
-			sandbox.mock(boxClientFake).expects('get').withArgs('/files/1234/content', testParamsWithQs).yieldsAsync(null, response);
-			files.getDownloadURL(FILE_ID, testQS, function(err) {
-				assert.instanceOf(err, Error);
-				assert.strictEqual(err.statusCode, response.statusCode);
-				done();
-			});
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			files.getDownloadURL(FILE_ID, testQS)
+				.catch(err => {
+					assert.instanceOf(err, Error);
+					assert.strictEqual(err.statusCode, response.statusCode);
+				});
 		});
 	});
 
 	describe('getReadStream()', function() {
 
-		it('should make a GET request to the box client', function() {
-			sandbox.mock(boxClientFake).expects('get').withArgs('/files/1234/content', testParamsWithQs);
+		it('should get file download URL when called', function() {
+			sandbox.mock(files).expects('getDownloadURL').withArgs(FILE_ID, testQS).returns(Promise.resolve('https://download.url'));
+			sandbox.stub(boxClientFake, 'get');
 			files.getReadStream(FILE_ID, testQS);
 		});
 
-		it('should make a request with the URL returned from getDownloadURL when a 302 FOUND response is returned', function(done) {
-			var dlURL = 'https://dl.boxcloud.com/rawfile',
-				streamFake = {on: sandbox.stub()};
+		it('should make streaming request to file download request when called', function() {
 
-			sandbox.stub(files, 'getDownloadURL').yieldsAsync(null, dlURL);
-			sandbox.mock(boxClientFake).expects('get').withArgs(dlURL, sinon.match({streaming: true})).yieldsAsync(null, streamFake);
-			files.getReadStream(FILE_ID, testQS, function(err, stream) {
+			var downloadURL = 'https://dl.boxcloud.com/adjhgliwenrgiuwndfgjinsdf';
+
+			sandbox.stub(files, 'getDownloadURL').returns(Promise.resolve(downloadURL));
+			sandbox.mock(boxClientFake).expects('get').withArgs(downloadURL, {streaming: true});
+			files.getReadStream(FILE_ID, testQS);
+		});
+
+		it('should call callback with the read stream when callback is passed', function(done) {
+
+			var downloadURL = 'https://dl.boxcloud.com/adjhgliwenrgiuwndfgjinsdf';
+
+			var stream = {};
+
+			sandbox.stub(files, 'getDownloadURL').returns(Promise.resolve(downloadURL));
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(stream));
+			files.getReadStream(FILE_ID, testQS, function(err, data) {
+
 				assert.ifError(err);
-				assert.equal(stream, streamFake);
+				assert.equal(data, stream);
 				done();
 			});
 		});
 
-		it('should return an error when a 202 ACCEPTED response is returned', function(done) {
-			var response = {statusCode: 202};
+		it('should return promise resolving to the read stream when callback is passed', function() {
 
-			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
-			files.getReadStream(FILE_ID, testQS, function(err) {
-				assert.ok(err);
-				done();
-			});
+			var downloadURL = 'https://dl.boxcloud.com/adjhgliwenrgiuwndfgjinsdf';
+
+			var stream = {};
+
+			sandbox.stub(files, 'getDownloadURL').returns(Promise.resolve(downloadURL));
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(stream));
+			return files.getReadStream(FILE_ID, testQS)
+				.then(data => {
+					assert.equal(data, stream);
+				});
 		});
 	});
 
@@ -164,26 +248,41 @@ describe('Files', function() {
 		var expectedThumbnailParams = {qs: testQS, json: false};
 
 		it('should make GET request to get file download when called', function() {
-			sandbox.mock(boxClientFake).expects('get').withArgs('/files/1234/thumbnail.png', expectedThumbnailParams);
+
+			var response = {
+				statusCode: 200
+			};
+			sandbox.mock(boxClientFake).expects('get').withArgs('/files/1234/thumbnail.png', expectedThumbnailParams)
+				.returns(Promise.resolve(response));
 			files.getThumbnail(FILE_ID, testQS);
 		});
 
-		it('should return the thumbnail file when a 200 OK response is returned', function(done) {
+		it('should call callback with the thumbnail file when a 200 OK response is returned', function(done) {
 			var fileData = 'thisistheimagefile! 0101010110111011',
 				response = {statusCode: 200, body: fileData};
 
-			sandbox.stub(boxClientFake, 'get')
-				.withArgs('/files/1234/thumbnail.png', expectedThumbnailParams)
-				.yieldsAsync(null, response);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
 
 			files.getThumbnail(FILE_ID, testQS, function(err, data) {
-				assert.ok(!err);
-				assert.deepEqual(data, { statusCode: 200, file: fileData});
+				assert.ifError(err);
+				assert.deepEqual(data, {statusCode: 200, file: fileData});
 				done();
 			});
 		});
 
-		it('should return a placeholder location when a 202 ACCEPTED response is returned', function(done) {
+		it('should return a promise resolving to the thumbnail file when a 200 OK response is returned', function() {
+			var fileData = 'thisistheimagefile! 0101010110111011',
+				response = {statusCode: 200, body: fileData};
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+
+			return files.getThumbnail(FILE_ID, testQS)
+				.then(data => {
+					assert.deepEqual(data, {statusCode: 200, file: fileData});
+				});
+		});
+
+		it('should call callback with the placeholder location when a 202 ACCEPTED response is returned', function(done) {
 			var placeholderURL = 'https://someplaceholderthumbnail.png',
 				response = {
 					statusCode: 202,
@@ -191,15 +290,30 @@ describe('Files', function() {
 						location: placeholderURL
 					}
 				};
-			sandbox.stub(boxClientFake, 'get').withArgs('/files/1234/thumbnail.png', expectedThumbnailParams).yieldsAsync(null, response);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
 			files.getThumbnail(FILE_ID, testQS, function(err, data) {
-				assert.ok(!err);
+				assert.ifError(err);
 				assert.deepEqual(data, { statusCode: 202, location: placeholderURL});
 				done();
 			});
 		});
 
-		it('should return a placeholder location when a 302 FOUND response is returned', function(done) {
+		it('should return a promise resolving to the placeholder location when a 202 ACCEPTED response is returned', function() {
+			var placeholderURL = 'https://someplaceholderthumbnail.png',
+				response = {
+					statusCode: 202,
+					headers: {
+						location: placeholderURL
+					}
+				};
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return files.getThumbnail(FILE_ID, testQS)
+				.then(data => {
+					assert.deepEqual(data, { statusCode: 202, location: placeholderURL});
+				});
+		});
+
+		it('should call callback with the placeholder location when a 302 FOUND response is returned', function(done) {
 			var placeholderURL = 'https://someplaceholderthumbnail.png',
 				response = {
 					statusCode: 302,
@@ -207,29 +321,54 @@ describe('Files', function() {
 						location: placeholderURL
 					}
 				};
-			sandbox.stub(boxClientFake, 'get').withArgs('/files/1234/thumbnail.png', expectedThumbnailParams).yieldsAsync(null, response);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
 			files.getThumbnail(FILE_ID, testQS, function(err, data) {
-				assert.ok(!err);
+				assert.ifError(err);
 				assert.deepEqual(data, { statusCode: 302, location: placeholderURL});
 				done();
 			});
 		});
 
-		it('should return an error when the API call fails', function(done) {
+		it('should return a promise resolving to the placeholder location when a 302 FOUND response is returned', function() {
+			var placeholderURL = 'https://someplaceholderthumbnail.png',
+				response = {
+					statusCode: 302,
+					headers: {
+						location: placeholderURL
+					}
+				};
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return files.getThumbnail(FILE_ID, testQS)
+				.then(data => {
+					assert.deepEqual(data, { statusCode: 302, location: placeholderURL});
+				});
+		});
+
+		it('should call callback with an error when the API call fails', function(done) {
 
 			var apiError = new Error(':[');
-			sandbox.stub(boxClientFake, 'get').yieldsAsync(apiError);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.reject(apiError));
 			files.getThumbnail(FILE_ID, testQS, function(err) {
 				assert.equal(err, apiError);
 				done();
 			});
 		});
 
-		it('should return unexpected response error when the API returns unknown status code', function(done) {
+		it('should return a promise that rejects when the API call fails', function() {
+
+			var apiError = new Error(':[');
+			sandbox.stub(boxClientFake, 'get').returns(Promise.reject(apiError));
+			files.getThumbnail(FILE_ID, testQS)
+				.catch(err => {
+					assert.equal(err, apiError);
+				});
+		});
+
+		it('should call callback with unexpected response error when the API returns unknown status code', function(done) {
 
 			var response = {statusCode: 403};
 
-			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
 
 			files.getThumbnail(FILE_ID, testQS, function(err) {
 				assert.instanceOf(err, Error);
@@ -237,31 +376,92 @@ describe('Files', function() {
 				done();
 			});
 		});
+
+		it('should return a promise that rejects with unexpected response error when the API returns unknown status code', function() {
+
+			var response = {statusCode: 403};
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+
+			return files.getThumbnail(FILE_ID, testQS)
+				.catch(err => {
+					assert.instanceOf(err, Error);
+					assert.propertyVal(err, 'statusCode', response.statusCode);
+				});
+		});
 	});
 
 	describe('getComments()', function() {
 		it('should make GET request to get file info when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/files/1234/comments', testParamsWithQs);
 			files.getComments(FILE_ID, testQS);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/files/1234/comments', testParamsWithQs).yieldsAsync();
-			files.getComments(FILE_ID, testQS, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			files.getComments(FILE_ID, testQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			files.getComments(FILE_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return files.getComments(FILE_ID, testQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('update()', function() {
 		it('should make PUT request to update file info when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/files/1234', testParamsWithBody);
 			files.update(FILE_ID, testBody);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs('/files/1234', testParamsWithBody).yieldsAsync();
-			files.update(FILE_ID, testBody, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			files.update(FILE_ID, testBody);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			files.update(FILE_ID, testBody, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return files.update(FILE_ID, testBody)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -277,9 +477,8 @@ describe('Files', function() {
 			};
 
 			var filesMock = sandbox.mock(files);
-			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).yieldsAsync(null, file);
-			filesMock.expects('update').withArgs(FILE_ID, {collections: [{id: COLLECTION_ID}]}).yieldsAsync(null, file);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
+			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).returns(Promise.resolve(file));
+			filesMock.expects('update').withArgs(FILE_ID, {collections: [{id: COLLECTION_ID}]}).returns(Promise.resolve(file));
 
 			files.addToCollection(FILE_ID, COLLECTION_ID, done);
 		});
@@ -292,9 +491,8 @@ describe('Files', function() {
 			};
 
 			var filesMock = sandbox.mock(files);
-			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).yieldsAsync(null, file);
-			filesMock.expects('update').withArgs(FILE_ID, {collections: [{id: '111'},{id: COLLECTION_ID}]}).yieldsAsync(null, file);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
+			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).returns(Promise.resolve(file));
+			filesMock.expects('update').withArgs(FILE_ID, {collections: [{id: '111'},{id: COLLECTION_ID}]}).returns(Promise.resolve(file));
 
 			files.addToCollection(FILE_ID, COLLECTION_ID, done);
 		});
@@ -307,11 +505,45 @@ describe('Files', function() {
 			};
 
 			var filesMock = sandbox.mock(files);
-			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).yieldsAsync(null, file);
-			filesMock.expects('update').withArgs(FILE_ID, {collections: [{id: COLLECTION_ID},{id: '111'}]}).yieldsAsync(null, file);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
+			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).returns(Promise.resolve(file));
+			filesMock.expects('update').withArgs(FILE_ID, {collections: [{id: COLLECTION_ID},{id: '111'}]}).returns(Promise.resolve(file));
 
 			files.addToCollection(FILE_ID, COLLECTION_ID, done);
+		});
+
+		it('should call callback with updated file when API calls succeed', function(done) {
+
+			var file = {
+				id: FILE_ID,
+				collections: [{id: COLLECTION_ID},{id: '111'}]
+			};
+
+			sandbox.stub(files, 'get').returns(Promise.resolve(file));
+			sandbox.stub(files, 'update').returns(Promise.resolve(file));
+
+			files.addToCollection(FILE_ID, COLLECTION_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, file);
+				done();
+			});
+		});
+
+		it('should return promise resolving to the updated file when API calls succeed', function() {
+
+			var file = {
+				id: FILE_ID,
+				collections: [{id: COLLECTION_ID},{id: '111'}]
+			};
+
+			sandbox.stub(files, 'get').returns(Promise.resolve(file));
+			sandbox.stub(files, 'update').returns(Promise.resolve(file));
+
+			return files.addToCollection(FILE_ID, COLLECTION_ID)
+				.then(data => {
+
+					assert.equal(data, file);
+				});
 		});
 
 		it('should call callback with error when getting current collections fails', function(done) {
@@ -319,15 +551,28 @@ describe('Files', function() {
 			var error = new Error('Failed get');
 
 			var filesMock = sandbox.mock(files);
-			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).yieldsAsync(error);
+			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).returns(Promise.reject(error));
 			filesMock.expects('update').never();
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
 
 			files.addToCollection(FILE_ID, COLLECTION_ID, function(err) {
 
 				assert.equal(err, error);
 				done();
 			});
+		});
+
+		it('should return promise that rejects when getting current collections fails', function() {
+
+			var error = new Error('Failed get');
+
+			var filesMock = sandbox.mock(files);
+			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).returns(Promise.reject(error));
+			filesMock.expects('update').never();
+
+			return files.addToCollection(FILE_ID, COLLECTION_ID)
+				.catch(err => {
+					assert.equal(err, error);
+				});
 		});
 
 		it('should call callback with error when adding the collection fails', function(done) {
@@ -340,15 +585,33 @@ describe('Files', function() {
 			var error = new Error('Failed update');
 
 			var filesMock = sandbox.mock(files);
-			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).yieldsAsync(null, file);
-			filesMock.expects('update').withArgs(FILE_ID, {collections: [{id: COLLECTION_ID},{id: '111'}]}).yieldsAsync(error);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
+			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).returns(Promise.resolve(file));
+			filesMock.expects('update').withArgs(FILE_ID, {collections: [{id: COLLECTION_ID},{id: '111'}]}).returns(Promise.reject(error));
 
 			files.addToCollection(FILE_ID, COLLECTION_ID, function(err) {
 
 				assert.equal(err, error);
 				done();
 			});
+		});
+
+		it('should return promise that rejects when adding the collection fails', function() {
+
+			var file = {
+				id: FILE_ID,
+				collections: [{id: COLLECTION_ID},{id: '111'}]
+			};
+
+			var error = new Error('Failed update');
+
+			var filesMock = sandbox.mock(files);
+			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).returns(Promise.resolve(file));
+			filesMock.expects('update').withArgs(FILE_ID, {collections: [{id: COLLECTION_ID},{id: '111'}]}).returns(Promise.reject(error));
+
+			return files.addToCollection(FILE_ID, COLLECTION_ID)
+				.catch(err => {
+					assert.equal(err, error);
+				});
 		});
 	});
 
@@ -364,9 +627,8 @@ describe('Files', function() {
 			};
 
 			var filesMock = sandbox.mock(files);
-			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).yieldsAsync(null, file);
-			filesMock.expects('update').withArgs(FILE_ID, {collections: []}).yieldsAsync(null, file);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
+			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).returns(Promise.resolve(file));
+			filesMock.expects('update').withArgs(FILE_ID, {collections: []}).returns(Promise.resolve(file));
 
 			files.removeFromCollection(FILE_ID, COLLECTION_ID, done);
 		});
@@ -379,9 +641,8 @@ describe('Files', function() {
 			};
 
 			var filesMock = sandbox.mock(files);
-			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).yieldsAsync(null, file);
-			filesMock.expects('update').withArgs(FILE_ID, {collections: []}).yieldsAsync(null, file);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
+			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).returns(Promise.resolve(file));
+			filesMock.expects('update').withArgs(FILE_ID, {collections: []}).returns(Promise.resolve(file));
 
 			files.removeFromCollection(FILE_ID, COLLECTION_ID, done);
 		});
@@ -394,9 +655,8 @@ describe('Files', function() {
 			};
 
 			var filesMock = sandbox.mock(files);
-			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).yieldsAsync(null, file);
-			filesMock.expects('update').withArgs(FILE_ID, {collections: [{id: '111'}]}).yieldsAsync(null, file);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
+			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).returns(Promise.resolve(file));
+			filesMock.expects('update').withArgs(FILE_ID, {collections: [{id: '111'}]}).returns(Promise.resolve(file));
 
 			files.removeFromCollection(FILE_ID, COLLECTION_ID, done);
 		});
@@ -409,11 +669,44 @@ describe('Files', function() {
 			};
 
 			var filesMock = sandbox.mock(files);
-			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).yieldsAsync(null, file);
-			filesMock.expects('update').withArgs(FILE_ID, {collections: [{id: '111'},{id: '222'}]}).yieldsAsync(null, file);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
+			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).returns(Promise.resolve(file));
+			filesMock.expects('update').withArgs(FILE_ID, {collections: [{id: '111'},{id: '222'}]}).returns(Promise.resolve(file));
 
 			files.removeFromCollection(FILE_ID, COLLECTION_ID, done);
+		});
+
+		it('should call callback with the updated file when API calls succeed', function(done) {
+
+			var file = {
+				id: FILE_ID,
+				collections: [{id: '111'},{id: '222'}]
+			};
+
+			sandbox.stub(files, 'get').returns(Promise.resolve(file));
+			sandbox.stub(files, 'update').returns(Promise.resolve(file));
+
+			files.removeFromCollection(FILE_ID, COLLECTION_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, file);
+				done();
+			});
+		});
+
+		it('should return promise resolving to the updated file when API calls succeed', function() {
+
+			var file = {
+				id: FILE_ID,
+				collections: [{id: '111'},{id: '222'}]
+			};
+
+			sandbox.stub(files, 'get').returns(Promise.resolve(file));
+			sandbox.stub(files, 'update').returns(Promise.resolve(file));
+
+			return files.removeFromCollection(FILE_ID, COLLECTION_ID)
+				.then(data => {
+					assert.equal(data, file);
+				});
 		});
 
 		it('should call callback with error when getting current collections fails', function(done) {
@@ -421,9 +714,8 @@ describe('Files', function() {
 			var error = new Error('Failed get');
 
 			var filesMock = sandbox.mock(files);
-			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).yieldsAsync(error);
+			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).returns(Promise.reject(error));
 			filesMock.expects('update').never();
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
 
 			files.removeFromCollection(FILE_ID, COLLECTION_ID, function(err) {
 
@@ -432,7 +724,7 @@ describe('Files', function() {
 			});
 		});
 
-		it('should call callback with error when adding the collection fails', function(done) {
+		it('should return promise that rejects when adding the collection fails', function() {
 
 			var file = {
 				id: FILE_ID,
@@ -442,15 +734,13 @@ describe('Files', function() {
 			var error = new Error('Failed update');
 
 			var filesMock = sandbox.mock(files);
-			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).yieldsAsync(null, file);
-			filesMock.expects('update').withArgs(FILE_ID, {collections: [{id: '111'}]}).yieldsAsync(error);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
+			filesMock.expects('get').withArgs(FILE_ID, {fields: 'collections'}).returns(Promise.resolve(file));
+			filesMock.expects('update').withArgs(FILE_ID, {collections: [{id: '111'}]}).returns(Promise.resolve(error));
 
-			files.removeFromCollection(FILE_ID, COLLECTION_ID, function(err) {
-
-				assert.equal(err, error);
-				done();
-			});
+			return files.removeFromCollection(FILE_ID, COLLECTION_ID)
+				.catch(err => {
+					assert.equal(err, error);
+				});
 		});
 	});
 
@@ -466,7 +756,7 @@ describe('Files', function() {
 			};
 
 		it('should make POST request to copy the folder when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/files/1234/copy', expectedParams);
 			files.copy(FILE_ID, NEW_PARENT_ID);
 		});
@@ -477,22 +767,38 @@ describe('Files', function() {
 
 			expectedParams.body.name = name;
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/files/1234/copy', expectedParams);
 			files.copy(FILE_ID, NEW_PARENT_ID, {name});
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withExactArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/files/1234/copy').yieldsAsync();
-			files.copy(FILE_ID, NEW_PARENT_ID, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			files.copy(FILE_ID, NEW_PARENT_ID);
 		});
 
-		it('should call the defaultResponseHandler wrapped callback when response is returned', function(done) {
-			var callbackMock = sandbox.mock().never();
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withExactArgs(callbackMock).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/files/1234/copy').yieldsAsync();
-			files.copy(FILE_ID, NEW_PARENT_ID, callbackMock);
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			files.copy(FILE_ID, NEW_PARENT_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return files.copy(FILE_ID, NEW_PARENT_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -508,31 +814,76 @@ describe('Files', function() {
 			};
 
 		it('should make PUT request to update the file parent ID when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/files/1234', expectedParams);
 			files.move(FILE_ID, NEW_PARENT_ID);
 		});
 
-		it('should call the defaultResponseHandler wrapped callback when response is returned', function(done) {
-			var callbackMock = sandbox.mock().never();
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withExactArgs(callbackMock).returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs('/files/1234').yieldsAsync();
-			files.move(FILE_ID, testBody, callbackMock);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			files.move(FILE_ID, NEW_PARENT_ID);
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			files.move(FILE_ID, NEW_PARENT_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return files.move(FILE_ID, NEW_PARENT_ID)
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 
 	describe('delete()', function() {
 		it('should make DELETE request to update file info when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs('/files/1234', null);
 			files.delete(FILE_ID);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/files/1234', null).yieldsAsync();
-			files.delete(FILE_ID, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			files.delete(FILE_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			files.delete(FILE_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return files.delete(FILE_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -561,14 +912,38 @@ describe('Files', function() {
 		});
 
 		it('should make an OPTIONS request to prepare and validate a file uploads when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('options').withArgs('/files/content', expectedParams);
 			files.preflightUploadFile(parentFolderID, fileData, uploadsQS);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').returns(done);
-			sandbox.stub(boxClientFake, 'options').withArgs('/files/content').yieldsAsync();
-			files.preflightUploadFile(parentFolderID, fileData, uploadsQS, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'options').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.options).returnsArg(0);
+			files.preflightUploadFile(parentFolderID, fileData, uploadsQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'options').yieldsAsync(null, response);
+			files.preflightUploadFile(parentFolderID, fileData, uploadsQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'options').returns(Promise.resolve(response));
+			return files.preflightUploadFile(parentFolderID, fileData, uploadsQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -590,15 +965,38 @@ describe('Files', function() {
 		});
 
 		it('should make an OPTIONS request to prepare and validate a file new version uploads when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('options').withArgs('/files/2345/content', expectedParams);
 			files.preflightUploadNewFileVersion(fileID, fileData, uploadsQS);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').returns(done);
-			sandbox.stub(boxClientFake, 'options').withArgs('/files/2345/content').yieldsAsync();
-			files.preflightUploadNewFileVersion(fileID, fileData, uploadsQS, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'options').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.options).returnsArg(0);
+			files.preflightUploadNewFileVersion(fileID, fileData, uploadsQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'options').yieldsAsync(null, response);
+			files.preflightUploadNewFileVersion(fileID, fileData, uploadsQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'options').returns(Promise.resolve(response));
+			return files.preflightUploadNewFileVersion(fileID, fileData, uploadsQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -616,15 +1014,38 @@ describe('Files', function() {
 		});
 
 		it('should make POST request to promote older file version to top of the stack', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/files/' + FILE_ID + '/versions/current', expectedParams);
 			files.promoteVersion(FILE_ID, FILE_VERSION_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/files/' + FILE_ID + '/versions/current').yieldsAsync();
-			files.promoteVersion(FILE_ID, FILE_VERSION_ID, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			files.promoteVersion(FILE_ID, FILE_VERSION_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			files.promoteVersion(FILE_ID, FILE_VERSION_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return files.promoteVersion(FILE_ID, FILE_VERSION_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -634,7 +1055,7 @@ describe('Files', function() {
 			FILENAME = 'abc.txt',
 			CONTENT = new Buffer('someContent');
 
-		it('should call BoxClient.upload() with the correct non-callback params', function() {
+		it('should call BoxClient.upload() with the correct params when called', function() {
 			var expectedFormData = {
 				attributes: JSON.stringify({
 					name: FILENAME,
@@ -646,23 +1067,38 @@ describe('Files', function() {
 				}
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('upload').withArgs('/files/content', null, expectedFormData);
-			files.uploadFile(PARENT_FOLDER_ID, FILENAME, CONTENT, sandbox.stub());
+			files.uploadFile(PARENT_FOLDER_ID, FILENAME, CONTENT);
 		});
 
-		it('should wrap the given callback (without calling it) using BoxClient.defaultResponseHandler() and pass the wrapped callback to BoxClient.upload()', function() {
-			var filesCallbackMock = sandbox.mock().never(),
-				boxClientCallbackMock = sandbox.mock().never();
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler')
-				.withExactArgs(filesCallbackMock)
-				.returns(boxClientCallbackMock);
+			sandbox.stub(boxClientFake, 'upload').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.upload).returnsArg(0);
+			files.uploadFile(PARENT_FOLDER_ID, FILENAME, CONTENT);
+		});
 
-			sandbox.mock(boxClientFake).expects('upload')
-				.withExactArgs(sinon.match.any, sinon.match.any, sinon.match.any, boxClientCallbackMock);
+		it('should pass results to callback when callback is present', function(done) {
 
-			files.uploadFile(PARENT_FOLDER_ID, FILENAME, CONTENT, filesCallbackMock);
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'upload').yieldsAsync(null, response);
+			files.uploadFile(PARENT_FOLDER_ID, FILENAME, CONTENT, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'upload').returns(Promise.resolve(response));
+			return files.uploadFile(PARENT_FOLDER_ID, FILENAME, CONTENT)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -670,7 +1106,7 @@ describe('Files', function() {
 
 		var CONTENT = new Buffer('someContent');
 
-		it('should call BoxClient.upload() with the correct non-callback params', function() {
+		it('should call BoxClient.upload() with the correct params when called', function() {
 			var expectedFormData = {
 				content: {
 					value: CONTENT,
@@ -678,94 +1114,266 @@ describe('Files', function() {
 				}
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('upload').withArgs('/files/1234/content', null, expectedFormData);
-			files.uploadNewFileVersion(FILE_ID, CONTENT, sandbox.stub());
+			files.uploadNewFileVersion(FILE_ID, CONTENT);
 		});
 
-		it('should wrap the given callback (without calling it) using BoxClient.defaultResponseHandler() and pass the wrapped callback to BoxClient.upload()', function() {
-			var filesCallbackMock = sandbox.mock().never(),
-				boxClientCallbackMock = sandbox.mock().never();
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler')
-				.withExactArgs(filesCallbackMock)
-				.returns(boxClientCallbackMock);
+			sandbox.stub(boxClientFake, 'upload').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.upload).returnsArg(0);
+			files.uploadNewFileVersion(FILE_ID, CONTENT);
+		});
 
-			sandbox.mock(boxClientFake).expects('upload')
-				.withExactArgs(sinon.match.any, sinon.match.any, sinon.match.any, boxClientCallbackMock);
+		it('should pass results to callback when callback is present', function(done) {
 
-			files.uploadNewFileVersion(FILE_ID, CONTENT, filesCallbackMock);
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'upload').yieldsAsync(null, response);
+			files.uploadNewFileVersion(FILE_ID, CONTENT, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'upload').returns(Promise.resolve(response));
+			return files.uploadNewFileVersion(FILE_ID, CONTENT)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('getAllMetadata()', function() {
 
-		it('should make GET call to fetch metadata', function(done) {
+		it('should make GET call to fetch metadata', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').yields();
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/files/1234/metadata', null);
-			files.getAllMetadata(FILE_ID, done);
+			files.getAllMetadata(FILE_ID);
+		});
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			files.getAllMetadata(FILE_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			files.getAllMetadata(FILE_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return files.getAllMetadata(FILE_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('getMetadata()', function() {
 
-		it('should make GET call to fetch metadata', function(done) {
+		it('should make GET call to fetch metadata', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').yields();
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/files/1234/metadata/global/properties', null);
-			files.getMetadata(FILE_ID, 'global', 'properties', done);
+			files.getMetadata(FILE_ID, 'global', 'properties');
+		});
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			files.getMetadata(FILE_ID, 'global', 'properties');
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			files.getMetadata(FILE_ID, 'global', 'properties', function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return files.getMetadata(FILE_ID, 'global', 'properties')
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('addMetadata()', function() {
 
-		it('should make POST call to add metadata', function(done) {
+		var metadata,
+			expectedParams;
 
-			var metadata = {
+		beforeEach(function() {
+
+			metadata = {
 				foo: 'bar'
 			};
 
-			var expectedParams = {
+			expectedParams = {
 				body: metadata
 			};
+		});
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').yields();
+		it('should make POST call to add metadata', function() {
+
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/files/1234/metadata/global/properties', expectedParams);
-			files.addMetadata(FILE_ID, 'global', 'properties', metadata, done);
+			files.addMetadata(FILE_ID, 'global', 'properties', metadata);
+		});
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			files.addMetadata(FILE_ID, 'global', 'properties', metadata);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			files.addMetadata(FILE_ID, 'global', 'properties', metadata, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return files.addMetadata(FILE_ID, 'global', 'properties', metadata)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('updateMetadata()', function() {
 
-		it('should make PUT call with JSON Patch to update metadata', function(done) {
+		var patch,
+			expectedParams;
 
-			var patch = [{
+		beforeEach(function() {
+
+			patch = [{
 				op: 'add',
 				path: '/foo',
 				value: 'bar'
 			}];
 
-			var expectedParams = {
+			expectedParams = {
 				body: patch,
 				headers: {
 					'Content-Type': 'application/json-patch+json'
 				}
 			};
+		});
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').yields();
+		it('should make PUT call with JSON Patch to update metadata', function() {
+
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/files/1234/metadata/global/properties', expectedParams);
-			files.updateMetadata(FILE_ID, 'global', 'properties', patch, done);
+			files.updateMetadata(FILE_ID, 'global', 'properties', patch);
+		});
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			files.updateMetadata(FILE_ID, 'global', 'properties', patch);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			files.updateMetadata(FILE_ID, 'global', 'properties', patch, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return files.updateMetadata(FILE_ID, 'global', 'properties', patch)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('deleteMetadata()', function() {
 
-		it('should make DELETE call to remove metadata', function(done) {
+		it('should make DELETE call to remove metadata', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').yields();
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs('/files/1234/metadata/global/properties', null);
-			files.deleteMetadata(FILE_ID, 'global', 'properties', done);
+			files.deleteMetadata(FILE_ID, 'global', 'properties');
+		});
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			files.deleteMetadata(FILE_ID, 'global', 'properties');
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			files.deleteMetadata(FILE_ID, 'global', 'properties', function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return files.deleteMetadata(FILE_ID, 'global', 'properties')
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -773,16 +1381,38 @@ describe('Files', function() {
 
 		it('should make DELETE call to remove file permanently', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs('/files/' + FILE_ID + '/trash', null);
 			files.deletePermanently(FILE_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/files/' + FILE_ID + '/trash').yieldsAsync();
-			files.deletePermanently(FILE_ID, done);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			files.deletePermanently(FILE_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			files.deletePermanently(FILE_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return files.deletePermanently(FILE_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -790,16 +1420,38 @@ describe('Files', function() {
 
 		it('should make GET request to retrieve all tasks for given file', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/files/' + FILE_ID + '/tasks', testParamsWithQs);
 			files.getTasks(FILE_ID, testQS);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/files/' + FILE_ID + '/tasks', testParamsWithQs).yieldsAsync();
-			files.getTasks(FILE_ID, testQS, done);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			files.getTasks(FILE_ID, testQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			files.getTasks(FILE_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return files.getTasks(FILE_ID, testQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -807,17 +1459,39 @@ describe('Files', function() {
 
 		it('should make GET request to get trashed file when called', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/files/' + FILE_ID + '/trash', testParamsWithQs);
 			files.getTrashedFile(FILE_ID, testQS);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/files/' + FILE_ID + '/trash', testParamsWithQs).yieldsAsync();
-			files.getTrashedFile(FILE_ID, testQS, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			files.getTrashedFile(FILE_ID, testQS);
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			files.getTrashedFile(FILE_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return files.getTrashedFile(FILE_ID, testQS)
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 	describe('getEmbedLink()', function() {
@@ -830,30 +1504,44 @@ describe('Files', function() {
 
 		it('should make GET request to create embed link', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
-			sandbox.mock(boxClientFake).expects('get').withArgs('/files/' + FILE_ID, expectedParams);
-			files.getEmbedLink(FILE_ID);
-		});
-
-		it('should return the embed link when a 200 ok response is returned', function(done) {
 			var embedLink = { expiring_embed_link: {url: 'https://app.box.com/preview/expiring_embed/1234'}},
 				response = {statusCode: 200, body: embedLink};
 
-			sandbox.stub(boxClientFake, 'get').withArgs('/files/' + FILE_ID).yieldsAsync(null, response);
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.mock(boxClientFake).expects('get').withArgs('/files/' + FILE_ID, expectedParams).returns(Promise.resolve(response));
+			files.getEmbedLink(FILE_ID);
+		});
+
+		it('should call callback with the embed link when a 200 ok response is returned', function(done) {
+			var embedLink = { expiring_embed_link: {url: 'https://app.box.com/preview/expiring_embed/1234'}},
+				response = {statusCode: 200, body: embedLink};
+
+			sandbox.stub(boxClientFake, 'get').withArgs('/files/' + FILE_ID).returns(Promise.resolve(response));
 			files.getEmbedLink(FILE_ID, function(err, data) {
-				assert.ok(!err);
+				assert.ifError(err);
 				assert.equal(data, embedLink.expiring_embed_link.url);
 				done();
 			});
 		});
 
-		it('should return a response error when API returns non-200 result', function(done) {
+		it('should return promise resolving to the embed link when a 200 ok response is returned', function() {
+			var embedLink = { expiring_embed_link: {url: 'https://app.box.com/preview/expiring_embed/1234'}},
+				response = {statusCode: 200, body: embedLink};
+
+			sandbox.stub(boxClientFake, 'get').withArgs('/files/' + FILE_ID).returns(Promise.resolve(response));
+			return files.getEmbedLink(FILE_ID)
+				.then(data => {
+					assert.equal(data, embedLink.expiring_embed_link.url);
+				});
+		});
+
+		it('should call callback with a response error when API returns non-200 result', function(done) {
 
 			var response = {
 				statusCode: 404
 			};
 
-			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
 
 			files.getEmbedLink(FILE_ID, function(err) {
 
@@ -863,17 +1551,44 @@ describe('Files', function() {
 			});
 		});
 
-		it('should return a response error when API call returns error', function(done) {
+		it('should return promise that rejects with a response error when API returns non-200 result', function() {
+
+			var response = {
+				statusCode: 404
+			};
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+
+			return files.getEmbedLink(FILE_ID)
+				.catch(err => {
+					assert.instanceOf(err, Error);
+					assert.propertyVal(err, 'statusCode', response.statusCode);
+				});
+		});
+
+		it('should call callback with error when API call returns error', function(done) {
 
 			var error = new Error('API Failure');
 
-			sandbox.stub(boxClientFake, 'get').yieldsAsync(error);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.reject(error));
 
 			files.getEmbedLink(FILE_ID, function(err) {
 
 				assert.equal(err, error);
 				done();
 			});
+		});
+
+		it('should return promise that rejects when API call returns error', function() {
+
+			var error = new Error('API Failure');
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.reject(error));
+
+			return files.getEmbedLink(FILE_ID)
+				.catch(err => {
+					assert.equal(err, error);
+				});
 		});
 	});
 
@@ -904,7 +1619,7 @@ describe('Files', function() {
 
 			expectedParams.body.lock.expires_at = expiresAt;
 			expectedParams.body.lock.is_download_prevented = isDownloadPrevented;
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/files/' + FILE_ID, expectedParams);
 			files.lock(FILE_ID, options);
 		});
@@ -916,7 +1631,7 @@ describe('Files', function() {
 			};
 
 			expectedParams.body.lock.expires_at = expiresAt;
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/files/' + FILE_ID, expectedParams);
 			files.lock(FILE_ID, options);
 		});
@@ -928,23 +1643,45 @@ describe('Files', function() {
 			};
 
 			expectedParams.body.lock.is_download_prevented = isDownloadPrevented;
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/files/' + FILE_ID, expectedParams);
 			files.lock(FILE_ID, options);
 		});
 
 		it('should make PUT request with mandatory parameters to set the lock properties when neither optional parameter is passed', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/files/' + FILE_ID, expectedParams);
 			files.lock(FILE_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs('/files/' + FILE_ID).yieldsAsync();
-			files.lock(FILE_ID, null, done);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			files.lock(FILE_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			files.lock(FILE_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return files.lock(FILE_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -964,16 +1701,38 @@ describe('Files', function() {
 
 		it('should make PUT request to clear the lock properties', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/files/' + FILE_ID, expectedParams);
 			files.unlock(FILE_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs('/files/' + FILE_ID).yieldsAsync();
-			files.unlock(FILE_ID, done);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			files.unlock(FILE_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			files.unlock(FILE_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return files.unlock(FILE_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -1002,7 +1761,7 @@ describe('Files', function() {
 				name: NEW_NAME,
 				parent: parent
 			};
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/files/' + FILE_ID, expectedParams);
 			files.restoreFromTrash(FILE_ID, options);
 		});
@@ -1014,7 +1773,7 @@ describe('Files', function() {
 			};
 
 			expectedParams.body.name = NEW_NAME;
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/files/' + FILE_ID, expectedParams);
 			files.restoreFromTrash(FILE_ID, options);
 		});
@@ -1026,24 +1785,45 @@ describe('Files', function() {
 			};
 
 			expectedParams.body.parent = parent;
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/files/' + FILE_ID, expectedParams);
 			files.restoreFromTrash(FILE_ID, options);
 		});
 
 		it('should make POST request with an empty body to restore a file when neither optional parameter is passed', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/files/' + FILE_ID, {body: {}});
 			files.restoreFromTrash(FILE_ID);
 		});
 
+		it('should wrap with default handler when called', function() {
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			files.restoreFromTrash(FILE_ID);
+		});
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').yieldsAsync();
-			files.restoreFromTrash(FILE_ID, null, done);
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			files.restoreFromTrash(FILE_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return files.restoreFromTrash(FILE_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -1051,16 +1831,38 @@ describe('Files', function() {
 
 		it('should make GET request to retrieve older file versions', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/files/' + FILE_ID + '/versions', testParamsWithQs);
 			files.getVersions(FILE_ID, testQS);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/files/' + FILE_ID + '/versions').yieldsAsync();
-			files.getVersions(FILE_ID, testQS, done);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			files.getVersions(FILE_ID, testQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			files.getVersions(FILE_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return files.getVersions(FILE_ID, testQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -1068,15 +1870,15 @@ describe('Files', function() {
 
 		it('should make GET request to get file watermark info when called', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
-			sandbox.mock(boxClientFake).expects('get').withArgs('/files/' + FILE_ID + '/watermark', testParamsWithQs);
+			sandbox.mock(boxClientFake).expects('get').withArgs('/files/' + FILE_ID + '/watermark', testParamsWithQs)
+				.returns(Promise.resolve({statusCode: 200, body: {}}));
 			files.getWatermark(FILE_ID, testQS);
 		});
 
 		it('should call callback with error when API call returns error', function(done) {
 
 			var apiError = new Error('failed');
-			sandbox.stub(boxClientFake, 'get').withArgs('/files/' + FILE_ID + '/watermark').yieldsAsync(apiError);
+			sandbox.stub(boxClientFake, 'get').withArgs('/files/' + FILE_ID + '/watermark').returns(Promise.reject(apiError));
 			files.getWatermark(FILE_ID, null, function(err) {
 
 				assert.equal(err, apiError);
@@ -1084,15 +1886,35 @@ describe('Files', function() {
 			});
 		});
 
+		it('should return promise that rejects when API call returns error', function() {
+
+			var apiError = new Error('failed');
+			sandbox.stub(boxClientFake, 'get').withArgs('/files/' + FILE_ID + '/watermark').returns(Promise.reject(apiError));
+			return files.getWatermark(FILE_ID)
+				.catch(err => {
+					assert.equal(err, apiError);
+				});
+		});
+
 		it('should call callback with error when API call returns non-200 status code', function(done) {
 
 			var res = {statusCode: 404};
-			sandbox.stub(boxClientFake, 'get').withArgs('/files/' + FILE_ID + '/watermark').yieldsAsync(null, res);
+			sandbox.stub(boxClientFake, 'get').withArgs('/files/' + FILE_ID + '/watermark').returns(Promise.resolve(res));
 			files.getWatermark(FILE_ID, null, function(err) {
 
 				assert.instanceOf(err, Error);
 				done();
 			});
+		});
+
+		it('should return promise that rejects when API call returns non-200 status code', function() {
+
+			var res = {statusCode: 404};
+			sandbox.stub(boxClientFake, 'get').withArgs('/files/' + FILE_ID + '/watermark').returns(Promise.resolve(res));
+			return files.getWatermark(FILE_ID)
+				.catch(err => {
+					assert.instanceOf(err, Error);
+				});
 		});
 
 		it('should call callback with watermark data when API call succeeds', function(done) {
@@ -1106,7 +1928,7 @@ describe('Files', function() {
 				statusCode: 200,
 				body: {watermark}
 			};
-			sandbox.stub(boxClientFake, 'get').withArgs('/files/' + FILE_ID + '/watermark').yieldsAsync(null, res);
+			sandbox.stub(boxClientFake, 'get').withArgs('/files/' + FILE_ID + '/watermark').returns(Promise.resolve(res));
 			files.getWatermark(FILE_ID, null, function(err, data) {
 
 				assert.isNull(err, 'Error should be absent');
@@ -1115,6 +1937,23 @@ describe('Files', function() {
 			});
 		});
 
+		it('should return promise resolving to watermark data when API call succeeds', function() {
+
+			var watermark = {
+				created_at: '2016-01-01T12:55:34-08:00',
+				modified_at: '2016-01-01T12:55:34-08:00'
+			};
+
+			var res = {
+				statusCode: 200,
+				body: {watermark}
+			};
+			sandbox.stub(boxClientFake, 'get').withArgs('/files/' + FILE_ID + '/watermark').returns(Promise.resolve(res));
+			return files.getWatermark(FILE_ID)
+				.then(data => {
+					assert.equal(data, watermark);
+				});
+		});
 	});
 
 	describe('applyWatermark()', function() {
@@ -1132,16 +1971,38 @@ describe('Files', function() {
 
 		it('should make PUT request to apply watermark on a file', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/files/' + FILE_ID + '/watermark', expectedParams);
 			files.applyWatermark(FILE_ID, null);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs('/files/' + FILE_ID + '/watermark').yieldsAsync();
-			files.applyWatermark(FILE_ID, null, done);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			files.applyWatermark(FILE_ID, null);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			files.applyWatermark(FILE_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return files.applyWatermark(FILE_ID, null)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -1149,34 +2010,77 @@ describe('Files', function() {
 
 		it('should make DELETE call to remove watermark', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs('/files/' + FILE_ID + '/watermark', null);
 			files.removeWatermark(FILE_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/files/' + FILE_ID + '/watermark').yieldsAsync();
-			files.removeWatermark(FILE_ID, done);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			files.removeWatermark(FILE_ID);
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			files.removeWatermark(FILE_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return files.removeWatermark(FILE_ID)
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 	describe('deleteVersion()', function() {
 
 		it('should make DELETE request to delete a file version to the trash', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs('/files/' + FILE_ID + '/versions/' + FILE_VERSION_ID, null);
 			files.deleteVersion(FILE_ID, FILE_VERSION_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/files/' + FILE_ID + '/versions/' + FILE_VERSION_ID).yieldsAsync();
-			files.deleteVersion(FILE_ID, FILE_VERSION_ID, done);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			files.deleteVersion(FILE_ID, FILE_VERSION_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			files.deleteVersion(FILE_ID, FILE_VERSION_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return files.deleteVersion(FILE_ID, FILE_VERSION_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -1184,16 +2088,38 @@ describe('Files', function() {
 
 		it('should make GET request to get file collaborations when called', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/files/1234/collaborations', testParamsWithQs);
 			files.getCollaborations(FILE_ID, testQS);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/files/1234/collaborations', testParamsWithQs).yieldsAsync();
-			files.getCollaborations(FILE_ID, testQS, done);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			files.getCollaborations(FILE_ID, testQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			files.getCollaborations(FILE_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return files.getCollaborations(FILE_ID, testQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 

--- a/tests/lib/managers/folders-test.js
+++ b/tests/lib/managers/folders-test.js
@@ -9,6 +9,7 @@
 var assert = require('chai').assert,
 	sinon = require('sinon'),
 	mockery = require('mockery'),
+	Promise = require('bluebird'),
 	leche = require('leche');
 
 var BoxClient = require('../../../lib/box-client');
@@ -65,40 +66,112 @@ describe('Folders', function() {
 
 	describe('get()', function() {
 		it('should make GET request to get folder info when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/folders/1234', testParamsWithQs);
 			folders.get(FOLDER_ID, testQS);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/folders/1234', testParamsWithQs).yieldsAsync();
-			folders.get(FOLDER_ID, testQS, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			folders.get(FOLDER_ID, testQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			folders.get(FOLDER_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return folders.get(FOLDER_ID, testQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('getItems()', function() {
 		it('should make GET request to get folder items when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/folders/1234/items', testParamsWithQs);
 			folders.getItems(FOLDER_ID, testQS);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/folders/1234/items', testParamsWithQs).yieldsAsync();
-			folders.getItems(FOLDER_ID, testQS, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			folders.getItems(FOLDER_ID, testQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			folders.getItems(FOLDER_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return folders.getItems(FOLDER_ID, testQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('getCollaborations()', function() {
 		it('should make GET request to get folder collaborations when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/folders/1234/collaborations', testParamsWithQs);
 			folders.getCollaborations(FOLDER_ID, testQS);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/folders/1234/collaborations', testParamsWithQs).yieldsAsync();
-			folders.getCollaborations(FOLDER_ID, testQS, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			folders.getCollaborations(FOLDER_ID, testQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			folders.getCollaborations(FOLDER_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return folders.getCollaborations(FOLDER_ID, testQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -116,14 +189,38 @@ describe('Folders', function() {
 			};
 
 		it('should make POST request to create a new folder when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
 			sandbox.mock(boxClientFake).expects('post').withArgs('/folders', expectedParams);
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			folders.create(PARENT_FOLDER_ID, NEW_FOLDER_NAME);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/folders').yieldsAsync();
-			folders.create(PARENT_FOLDER_ID, NEW_FOLDER_NAME, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			folders.create(PARENT_FOLDER_ID, NEW_FOLDER_NAME);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			folders.create(PARENT_FOLDER_ID, NEW_FOLDER_NAME, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return folders.create(PARENT_FOLDER_ID, NEW_FOLDER_NAME)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -139,7 +236,7 @@ describe('Folders', function() {
 			};
 
 		it('should make POST request to copy the folder when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/folders/1234/copy', expectedParams);
 			folders.copy(FOLDER_ID, NEW_PARENT_ID);
 		});
@@ -150,30 +247,75 @@ describe('Folders', function() {
 
 			expectedParams.body.name = name;
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/folders/1234/copy', expectedParams);
 			folders.copy(FOLDER_ID, NEW_PARENT_ID, {name});
 		});
 
-		it('should call the defaultResponseHandler wrapped callback when response is returned', function(done) {
-			var callbackMock = sandbox.mock().never();
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withExactArgs(callbackMock).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/folders/1234/copy').yieldsAsync();
-			folders.copy(FOLDER_ID, NEW_PARENT_ID, callbackMock);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			folders.copy(FOLDER_ID, NEW_PARENT_ID);
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			folders.copy(FOLDER_ID, NEW_PARENT_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return folders.copy(FOLDER_ID, NEW_PARENT_ID)
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 	describe('update()', function() {
 		it('should make PUT request to update folder info when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/folders/1234', testParamsWithBody);
 			folders.update(FOLDER_ID, testBody);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs('/folders/1234', testParamsWithBody).yieldsAsync();
-			folders.update(FOLDER_ID, testBody, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			folders.update(FOLDER_ID, testBody);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			folders.update(FOLDER_ID, testBody, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return folders.update(FOLDER_ID, testBody)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -189,9 +331,8 @@ describe('Folders', function() {
 			};
 
 			var foldersMock = sandbox.mock(folders);
-			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).yieldsAsync(null, folder);
-			foldersMock.expects('update').withArgs(FOLDER_ID, {collections: [{id: COLLECTION_ID}]}).yieldsAsync(null, folder);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
+			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).returns(Promise.resolve(folder));
+			foldersMock.expects('update').withArgs(FOLDER_ID, {collections: [{id: COLLECTION_ID}]}).returns(Promise.resolve(folder));
 
 			folders.addToCollection(FOLDER_ID, COLLECTION_ID, done);
 		});
@@ -204,9 +345,8 @@ describe('Folders', function() {
 			};
 
 			var foldersMock = sandbox.mock(folders);
-			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).yieldsAsync(null, folder);
-			foldersMock.expects('update').withArgs(FOLDER_ID, {collections: [{id: '111'},{id: COLLECTION_ID}]}).yieldsAsync(null, folder);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
+			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).returns(Promise.resolve(folder));
+			foldersMock.expects('update').withArgs(FOLDER_ID, {collections: [{id: '111'},{id: COLLECTION_ID}]}).returns(Promise.resolve(folder));
 
 			folders.addToCollection(FOLDER_ID, COLLECTION_ID, done);
 		});
@@ -219,11 +359,45 @@ describe('Folders', function() {
 			};
 
 			var foldersMock = sandbox.mock(folders);
-			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).yieldsAsync(null, folder);
-			foldersMock.expects('update').withArgs(FOLDER_ID, {collections: [{id: COLLECTION_ID},{id: '111'}]}).yieldsAsync(null, folder);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
+			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).returns(Promise.resolve(folder));
+			foldersMock.expects('update').withArgs(FOLDER_ID, {collections: [{id: COLLECTION_ID},{id: '111'}]}).returns(Promise.resolve(folder));
 
 			folders.addToCollection(FOLDER_ID, COLLECTION_ID, done);
+		});
+
+		it('should call callback with updated folder when API calls succeed', function(done) {
+
+			var folder = {
+				id: FOLDER_ID,
+				collections: [{id: COLLECTION_ID},{id: '111'}]
+			};
+
+			sandbox.stub(folders, 'get').returns(Promise.resolve(folder));
+			sandbox.stub(folders, 'update').returns(Promise.resolve(folder));
+
+			folders.addToCollection(FOLDER_ID, COLLECTION_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, folder);
+				done();
+			});
+		});
+
+		it('should return promise resolving to the updated folder when API calls succeed', function() {
+
+			var folder = {
+				id: FOLDER_ID,
+				collections: [{id: COLLECTION_ID},{id: '111'}]
+			};
+
+			sandbox.stub(folders, 'get').returns(Promise.resolve(folder));
+			sandbox.stub(folders, 'update').returns(Promise.resolve(folder));
+
+			return folders.addToCollection(FOLDER_ID, COLLECTION_ID)
+				.then(data => {
+
+					assert.equal(data, folder);
+				});
 		});
 
 		it('should call callback with error when getting current collections fails', function(done) {
@@ -231,15 +405,28 @@ describe('Folders', function() {
 			var error = new Error('Failed get');
 
 			var foldersMock = sandbox.mock(folders);
-			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).yieldsAsync(error);
+			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).returns(Promise.reject(error));
 			foldersMock.expects('update').never();
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
 
 			folders.addToCollection(FOLDER_ID, COLLECTION_ID, function(err) {
 
 				assert.equal(err, error);
 				done();
 			});
+		});
+
+		it('should return promise that rejects when getting current collections fails', function() {
+
+			var error = new Error('Failed get');
+
+			var foldersMock = sandbox.mock(folders);
+			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).returns(Promise.reject(error));
+			foldersMock.expects('update').never();
+
+			return folders.addToCollection(FOLDER_ID, COLLECTION_ID)
+				.catch(err => {
+					assert.equal(err, error);
+				});
 		});
 
 		it('should call callback with error when adding the collection fails', function(done) {
@@ -252,15 +439,33 @@ describe('Folders', function() {
 			var error = new Error('Failed update');
 
 			var foldersMock = sandbox.mock(folders);
-			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).yieldsAsync(null, folder);
-			foldersMock.expects('update').withArgs(FOLDER_ID, {collections: [{id: COLLECTION_ID},{id: '111'}]}).yieldsAsync(error);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
+			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).returns(Promise.resolve(folder));
+			foldersMock.expects('update').withArgs(FOLDER_ID, {collections: [{id: COLLECTION_ID},{id: '111'}]}).returns(Promise.reject(error));
 
 			folders.addToCollection(FOLDER_ID, COLLECTION_ID, function(err) {
 
 				assert.equal(err, error);
 				done();
 			});
+		});
+
+		it('should return promise that rejects when adding the collection fails', function() {
+
+			var folder = {
+				id: FOLDER_ID,
+				collections: [{id: COLLECTION_ID},{id: '111'}]
+			};
+
+			var error = new Error('Failed update');
+
+			var foldersMock = sandbox.mock(folders);
+			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).returns(Promise.resolve(folder));
+			foldersMock.expects('update').withArgs(FOLDER_ID, {collections: [{id: COLLECTION_ID},{id: '111'}]}).returns(Promise.reject(error));
+
+			return folders.addToCollection(FOLDER_ID, COLLECTION_ID)
+				.catch(err => {
+					assert.equal(err, error);
+				});
 		});
 	});
 
@@ -276,9 +481,8 @@ describe('Folders', function() {
 			};
 
 			var foldersMock = sandbox.mock(folders);
-			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).yieldsAsync(null, folder);
-			foldersMock.expects('update').withArgs(FOLDER_ID, {collections: []}).yieldsAsync(null, folder);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
+			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).returns(Promise.resolve(folder));
+			foldersMock.expects('update').withArgs(FOLDER_ID, {collections: []}).returns(Promise.resolve(folder));
 
 			folders.removeFromCollection(FOLDER_ID, COLLECTION_ID, done);
 		});
@@ -291,9 +495,8 @@ describe('Folders', function() {
 			};
 
 			var foldersMock = sandbox.mock(folders);
-			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).yieldsAsync(null, folder);
-			foldersMock.expects('update').withArgs(FOLDER_ID, {collections: []}).yieldsAsync(null, folder);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
+			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).returns(Promise.resolve(folder));
+			foldersMock.expects('update').withArgs(FOLDER_ID, {collections: []}).returns(Promise.resolve(folder));
 
 			folders.removeFromCollection(FOLDER_ID, COLLECTION_ID, done);
 		});
@@ -306,9 +509,8 @@ describe('Folders', function() {
 			};
 
 			var foldersMock = sandbox.mock(folders);
-			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).yieldsAsync(null, folder);
-			foldersMock.expects('update').withArgs(FOLDER_ID, {collections: [{id: '111'}]}).yieldsAsync(null, folder);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
+			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).returns(Promise.resolve(folder));
+			foldersMock.expects('update').withArgs(FOLDER_ID, {collections: [{id: '111'}]}).returns(Promise.resolve(folder));
 
 			folders.removeFromCollection(FOLDER_ID, COLLECTION_ID, done);
 		});
@@ -321,11 +523,44 @@ describe('Folders', function() {
 			};
 
 			var foldersMock = sandbox.mock(folders);
-			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).yieldsAsync(null, folder);
-			foldersMock.expects('update').withArgs(FOLDER_ID, {collections: [{id: '111'},{id: '222'}]}).yieldsAsync(null, folder);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
+			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).returns(Promise.resolve(folder));
+			foldersMock.expects('update').withArgs(FOLDER_ID, {collections: [{id: '111'},{id: '222'}]}).returns(Promise.resolve(folder));
 
 			folders.removeFromCollection(FOLDER_ID, COLLECTION_ID, done);
+		});
+
+		it('should call callback with the updated folder when API calls succeed', function(done) {
+
+			var folder = {
+				id: FOLDER_ID,
+				collections: [{id: '111'},{id: '222'}]
+			};
+
+			sandbox.stub(folders, 'get').returns(Promise.resolve(folder));
+			sandbox.stub(folders, 'update').returns(Promise.resolve(folder));
+
+			folders.removeFromCollection(FOLDER_ID, COLLECTION_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, folder);
+				done();
+			});
+		});
+
+		it('should return promise resolving to the updated folder when API calls succeed', function() {
+
+			var folder = {
+				id: FOLDER_ID,
+				collections: [{id: '111'},{id: '222'}]
+			};
+
+			sandbox.stub(folders, 'get').returns(Promise.resolve(folder));
+			sandbox.stub(folders, 'update').returns(Promise.resolve(folder));
+
+			return folders.removeFromCollection(FOLDER_ID, COLLECTION_ID)
+				.then(data => {
+					assert.equal(data, folder);
+				});
 		});
 
 		it('should call callback with error when getting current collections fails', function(done) {
@@ -333,9 +568,8 @@ describe('Folders', function() {
 			var error = new Error('Failed get');
 
 			var foldersMock = sandbox.mock(folders);
-			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).yieldsAsync(error);
+			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).returns(Promise.reject(error));
 			foldersMock.expects('update').never();
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
 
 			folders.removeFromCollection(FOLDER_ID, COLLECTION_ID, function(err) {
 
@@ -344,7 +578,7 @@ describe('Folders', function() {
 			});
 		});
 
-		it('should call callback with error when adding the collection fails', function(done) {
+		it('should return promise that rejects when adding the collection fails', function() {
 
 			var folder = {
 				id: FOLDER_ID,
@@ -354,15 +588,13 @@ describe('Folders', function() {
 			var error = new Error('Failed update');
 
 			var foldersMock = sandbox.mock(folders);
-			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).yieldsAsync(null, folder);
-			foldersMock.expects('update').withArgs(FOLDER_ID, {collections: [{id: '111'}]}).yieldsAsync(error);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
+			foldersMock.expects('get').withArgs(FOLDER_ID, {fields: 'collections'}).returns(Promise.resolve(folder));
+			foldersMock.expects('update').withArgs(FOLDER_ID, {collections: [{id: '111'}]}).returns(Promise.resolve(error));
 
-			folders.removeFromCollection(FOLDER_ID, COLLECTION_ID, function(err) {
-
-				assert.equal(err, error);
-				done();
-			});
+			return folders.removeFromCollection(FOLDER_ID, COLLECTION_ID)
+				.catch(err => {
+					assert.equal(err, error);
+				});
 		});
 	});
 
@@ -378,117 +610,341 @@ describe('Folders', function() {
 			};
 
 		it('should make PUT request to update the folder parent ID when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/folders/1234', expectedParams);
 			folders.move(FOLDER_ID, NEW_PARENT_ID);
 		});
 
-		it('should call the defaultResponseHandler wrapped callback when response is returned', function(done) {
-			var callbackMock = sandbox.mock().never();
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withExactArgs(callbackMock).returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs('/folders/1234').yieldsAsync();
-			folders.move(FOLDER_ID, testBody, callbackMock);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			folders.move(FOLDER_ID, NEW_PARENT_ID);
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			folders.move(FOLDER_ID, NEW_PARENT_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return folders.move(FOLDER_ID, NEW_PARENT_ID)
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 	describe('delete()', function() {
 		it('should make DELETE request to update folder info when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs('/folders/1234', testParamsWithQs);
 			folders.delete(FOLDER_ID, testQS);
 		});
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/folders/1234', testParamsWithQs).yieldsAsync();
-			folders.delete(FOLDER_ID, testQS, done);
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			folders.delete(FOLDER_ID, testQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			folders.delete(FOLDER_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return folders.delete(FOLDER_ID, testQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('getAllMetadata()', function() {
 
-		it('should make GET call to fetch metadata', function(done) {
+		it('should make GET call to fetch metadata', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').yields();
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/folders/1234/metadata', null);
-			folders.getAllMetadata(FOLDER_ID, done);
+			folders.getAllMetadata(FOLDER_ID);
+		});
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			folders.getAllMetadata(FOLDER_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			folders.getAllMetadata(FOLDER_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return folders.getAllMetadata(FOLDER_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('getMetadata()', function() {
 
-		it('should make GET call to fetch metadata', function(done) {
+		it('should make GET call to fetch metadata', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').yields();
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/folders/1234/metadata/global/properties', null);
-			folders.getMetadata(FOLDER_ID, 'global', 'properties', done);
+			folders.getMetadata(FOLDER_ID, 'global', 'properties');
+		});
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			folders.getMetadata(FOLDER_ID, 'global', 'properties');
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			folders.getMetadata(FOLDER_ID, 'global', 'properties', function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return folders.getMetadata(FOLDER_ID, 'global', 'properties')
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('addMetadata()', function() {
 
-		it('should make POST call to add metadata', function(done) {
+		var metadata,
+			expectedParams;
 
-			var metadata = {
+		beforeEach(function() {
+
+			metadata = {
 				foo: 'bar'
 			};
 
-			var expectedParams = {
+			expectedParams = {
 				body: metadata
 			};
+		});
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').yields();
+		it('should make POST call to add metadata', function() {
+
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/folders/1234/metadata/global/properties', expectedParams);
-			folders.addMetadata(FOLDER_ID, 'global', 'properties', metadata, done);
+			folders.addMetadata(FOLDER_ID, 'global', 'properties', metadata);
+		});
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			folders.addMetadata(FOLDER_ID, 'global', 'properties', metadata);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			folders.addMetadata(FOLDER_ID, 'global', 'properties', metadata, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return folders.addMetadata(FOLDER_ID, 'global', 'properties', metadata)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('updateMetadata()', function() {
 
-		it('should make PUT call with JSON Patch to update metadata', function(done) {
+		var patch,
+			expectedParams;
 
-			var patch = [{
+		beforeEach(function() {
+
+			patch = [{
 				op: 'add',
 				path: '/foo',
 				value: 'bar'
 			}];
 
-			var expectedParams = {
+			expectedParams = {
 				body: patch,
 				headers: {
 					'Content-Type': 'application/json-patch+json'
 				}
 			};
+		});
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').yields();
+		it('should make PUT call with JSON Patch to update metadata', function() {
+
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/folders/1234/metadata/global/properties', expectedParams);
-			folders.updateMetadata(FOLDER_ID, 'global', 'properties', patch, done);
+			folders.updateMetadata(FOLDER_ID, 'global', 'properties', patch);
+		});
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			folders.updateMetadata(FOLDER_ID, 'global', 'properties', patch);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			folders.updateMetadata(FOLDER_ID, 'global', 'properties', patch, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return folders.updateMetadata(FOLDER_ID, 'global', 'properties', patch)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('deleteMetadata()', function() {
 
-		it('should make DELETE call to remove metadata', function(done) {
+		it('should make DELETE call to remove metadata', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').yields();
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs('/folders/1234/metadata/global/properties', null);
-			folders.deleteMetadata(FOLDER_ID, 'global', 'properties', done);
+			folders.deleteMetadata(FOLDER_ID, 'global', 'properties');
+		});
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			folders.deleteMetadata(FOLDER_ID, 'global', 'properties');
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			folders.deleteMetadata(FOLDER_ID, 'global', 'properties', function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return folders.deleteMetadata(FOLDER_ID, 'global', 'properties')
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('getTrashedFolder()', function() {
 		it('should make GET request to get trashed folder when called', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/folders/' + FOLDER_ID + '/trash', testParamsWithQs);
 			folders.getTrashedFolder(FOLDER_ID, testQS);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/folders/' + FOLDER_ID + '/trash', testParamsWithQs).yieldsAsync();
-			folders.getTrashedFolder(FOLDER_ID, testQS, done);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			folders.getTrashedFolder(FOLDER_ID, testQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			folders.getTrashedFolder(FOLDER_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return folders.getTrashedFolder(FOLDER_ID, testQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -518,7 +974,7 @@ describe('Folders', function() {
 				name: NAME,
 				parent: parent
 			};
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/folders/' + FOLDER_ID, expectedParams);
 			folders.restoreFromTrash(FOLDER_ID, options);
 		});
@@ -528,7 +984,7 @@ describe('Folders', function() {
 			var options = {name: NAME};
 
 			expectedParams.body.name = NAME;
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/folders/' + FOLDER_ID, expectedParams);
 			folders.restoreFromTrash(FOLDER_ID, options);
 		});
@@ -540,58 +996,100 @@ describe('Folders', function() {
 			};
 
 			expectedParams.body.parent = parent;
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/folders/' + FOLDER_ID, expectedParams);
 			folders.restoreFromTrash(FOLDER_ID, options);
 		});
 
 		it('should make POST request with an empty body to restore a folder when neither optional parameter is passed', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/folders/' + FOLDER_ID, {body: {}});
 			folders.restoreFromTrash(FOLDER_ID, null);
 		});
 
+		it('should wrap with default handler when called', function() {
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			folders.restoreFromTrash(FOLDER_ID);
+		});
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').yieldsAsync();
-			folders.restoreFromTrash(FOLDER_ID, null, done);
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			folders.restoreFromTrash(FOLDER_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return folders.restoreFromTrash(FOLDER_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('deletePermanently()', function() {
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/folders/' + FOLDER_ID + '/trash').yieldsAsync();
-			folders.deletePermanently(FOLDER_ID, done);
-		});
-
 		it('should make DELETE call to remove folder permanently', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs('/folders/' + FOLDER_ID + '/trash', null);
 			folders.deletePermanently(FOLDER_ID);
 		});
 
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			folders.deletePermanently(FOLDER_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			folders.deletePermanently(FOLDER_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return folders.deletePermanently(FOLDER_ID)
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 	describe('getWatermark()', function() {
 
-		it('should make GET request to get folder watermark info when called', function() {
+		it('should make GET request to get file watermark info when called', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
-			sandbox.mock(boxClientFake).expects('get').withArgs('/folders/' + FOLDER_ID + '/watermark', testParamsWithQs);
+			sandbox.mock(boxClientFake).expects('get').withArgs('/folders/' + FOLDER_ID + '/watermark', testParamsWithQs)
+				.returns(Promise.resolve({statusCode: 200, body: {}}));
 			folders.getWatermark(FOLDER_ID, testQS);
 		});
 
 		it('should call callback with error when API call returns error', function(done) {
 
 			var apiError = new Error('failed');
-			sandbox.stub(boxClientFake, 'get').withArgs('/folders/' + FOLDER_ID + '/watermark').yieldsAsync(apiError);
+			sandbox.stub(boxClientFake, 'get').withArgs('/folders/' + FOLDER_ID + '/watermark').returns(Promise.reject(apiError));
 			folders.getWatermark(FOLDER_ID, null, function(err) {
 
 				assert.equal(err, apiError);
@@ -599,15 +1097,35 @@ describe('Folders', function() {
 			});
 		});
 
+		it('should return promise that rejects when API call returns error', function() {
+
+			var apiError = new Error('failed');
+			sandbox.stub(boxClientFake, 'get').withArgs('/folders/' + FOLDER_ID + '/watermark').returns(Promise.reject(apiError));
+			return folders.getWatermark(FOLDER_ID)
+				.catch(err => {
+					assert.equal(err, apiError);
+				});
+		});
+
 		it('should call callback with error when API call returns non-200 status code', function(done) {
 
 			var res = {statusCode: 404};
-			sandbox.stub(boxClientFake, 'get').withArgs('/folders/' + FOLDER_ID + '/watermark').yieldsAsync(null, res);
+			sandbox.stub(boxClientFake, 'get').withArgs('/folders/' + FOLDER_ID + '/watermark').returns(Promise.resolve(res));
 			folders.getWatermark(FOLDER_ID, null, function(err) {
 
 				assert.instanceOf(err, Error);
 				done();
 			});
+		});
+
+		it('should return promise that rejects when API call returns non-200 status code', function() {
+
+			var res = {statusCode: 404};
+			sandbox.stub(boxClientFake, 'get').withArgs('/folders/' + FOLDER_ID + '/watermark').returns(Promise.resolve(res));
+			return folders.getWatermark(FOLDER_ID)
+				.catch(err => {
+					assert.instanceOf(err, Error);
+				});
 		});
 
 		it('should call callback with watermark data when API call succeeds', function(done) {
@@ -621,7 +1139,7 @@ describe('Folders', function() {
 				statusCode: 200,
 				body: {watermark}
 			};
-			sandbox.stub(boxClientFake, 'get').withArgs('/folders/' + FOLDER_ID + '/watermark').yieldsAsync(null, res);
+			sandbox.stub(boxClientFake, 'get').withArgs('/folders/' + FOLDER_ID + '/watermark').returns(Promise.resolve(res));
 			folders.getWatermark(FOLDER_ID, null, function(err, data) {
 
 				assert.isNull(err, 'Error should be absent');
@@ -630,6 +1148,23 @@ describe('Folders', function() {
 			});
 		});
 
+		it('should return promise resolving to watermark data when API call succeeds', function() {
+
+			var watermark = {
+				created_at: '2016-01-01T12:55:34-08:00',
+				modified_at: '2016-01-01T12:55:34-08:00'
+			};
+
+			var res = {
+				statusCode: 200,
+				body: {watermark}
+			};
+			sandbox.stub(boxClientFake, 'get').withArgs('/folders/' + FOLDER_ID + '/watermark').returns(Promise.resolve(res));
+			return folders.getWatermark(FOLDER_ID)
+				.then(data => {
+					assert.equal(data, watermark);
+				});
+		});
 	});
 
 	describe('applyWatermark()', function() {
@@ -645,18 +1180,40 @@ describe('Folders', function() {
 			};
 		});
 
-		it('should make PUT request to apply watermark on a folder', function() {
+		it('should make PUT request to apply watermark on a file', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/folders/' + FOLDER_ID + '/watermark', expectedParams);
 			folders.applyWatermark(FOLDER_ID, null);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs('/folders/' + FOLDER_ID + '/watermark').yieldsAsync();
-			folders.applyWatermark(FOLDER_ID, null, done);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			folders.applyWatermark(FOLDER_ID, null);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			folders.applyWatermark(FOLDER_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return folders.applyWatermark(FOLDER_ID, null)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -664,18 +1221,38 @@ describe('Folders', function() {
 
 		it('should make DELETE call to remove watermark', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs('/folders/' + FOLDER_ID + '/watermark', null);
 			folders.removeWatermark(FOLDER_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/folders/' + FOLDER_ID + '/watermark').yieldsAsync();
-			folders.removeWatermark(FOLDER_ID, done);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			folders.removeWatermark(FOLDER_ID);
 		});
 
-	});
+		it('should pass results to callback when callback is present', function(done) {
 
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			folders.removeWatermark(FOLDER_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return folders.removeWatermark(FOLDER_ID)
+				.then(data => assert.equal(data, response));
+		});
+	});
 });

--- a/tests/lib/managers/groups-test.js
+++ b/tests/lib/managers/groups-test.js
@@ -9,6 +9,7 @@
 // ------------------------------------------------------------------------------
 var sinon = require('sinon'),
 	mockery = require('mockery'),
+	assert = require('chai').assert,
 	leche = require('leche');
 
 var BoxClient = require('../../../lib/box-client');
@@ -61,7 +62,7 @@ describe('Groups', function() {
 				}
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/groups', expectedParams);
 			groups.create(name, null);
 		});
@@ -80,15 +81,38 @@ describe('Groups', function() {
 				}
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/groups', expectedParams);
 			groups.create(name, options);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/groups').yieldsAsync();
-			groups.create('Test group', null, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			groups.create('test');
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			groups.create('test', null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return groups.create('test')
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -100,7 +124,7 @@ describe('Groups', function() {
 				qs: null
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/groups/' + GROUP_ID, expectedParams);
 			groups.get(GROUP_ID, null);
 		});
@@ -117,46 +141,93 @@ describe('Groups', function() {
 				}
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/groups/' + GROUP_ID, expectedParams);
 			groups.get(GROUP_ID, options);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/groups/' + GROUP_ID).yieldsAsync();
-			groups.get(GROUP_ID, null, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			groups.get(GROUP_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			groups.get(GROUP_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return groups.get(GROUP_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('update()', function() {
 
-		it('should make PUT request to update the group when called', function() {
+		var options,
+			expectedParams;
 
-			var options = {
+		beforeEach(function() {
+
+			options = {
 				name: 'Test group 2',
 				description: 'Another test group'
 			};
 
-			var expectedParams = {
+			expectedParams = {
 				body: options
 			};
+		});
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+		it('should make PUT request to update the group when called', function() {
+
+
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/groups/' + GROUP_ID, expectedParams);
 			groups.update(GROUP_ID, options);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			var options = {
-				name: 'Test group 2',
-				description: 'Another test group'
-			};
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			groups.update(GROUP_ID, options);
+		});
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs('/groups/' + GROUP_ID).yieldsAsync();
-			groups.update(GROUP_ID, options, done);
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			groups.update(GROUP_ID, options, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return groups.update(GROUP_ID, options)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -164,16 +235,38 @@ describe('Groups', function() {
 
 		it('should make DELETE request to delete the group when called', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs('/groups/' + GROUP_ID, null);
 			groups.delete(GROUP_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/groups/' + GROUP_ID).yieldsAsync();
-			groups.delete(GROUP_ID, done);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			groups.delete(GROUP_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			groups.delete(GROUP_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return groups.delete(GROUP_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -194,9 +287,9 @@ describe('Groups', function() {
 				}
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/group_memberships', expectedParams);
-			groups.addUser(GROUP_ID, USER_ID, null);
+			groups.addUser(GROUP_ID, USER_ID);
 		});
 
 		it('should make POST request to create group membership when called with optional parameters', function() {
@@ -217,15 +310,38 @@ describe('Groups', function() {
 				}
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/group_memberships', expectedParams);
 			groups.addUser(GROUP_ID, USER_ID, options);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/group_memberships').yieldsAsync();
-			groups.addUser(GROUP_ID, USER_ID, null, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			groups.addUser(GROUP_ID, USER_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			groups.addUser(GROUP_ID, USER_ID, {}, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return groups.addUser(GROUP_ID, USER_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -239,7 +355,7 @@ describe('Groups', function() {
 				qs: null
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/group_memberships/' + MEMBERSHIP_ID, expectedParams);
 			groups.getMembership(MEMBERSHIP_ID, null);
 		});
@@ -256,15 +372,38 @@ describe('Groups', function() {
 				}
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/group_memberships/' + MEMBERSHIP_ID, expectedParams);
 			groups.getMembership(MEMBERSHIP_ID, options);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/group_memberships/' + MEMBERSHIP_ID).yieldsAsync();
-			groups.getMembership(MEMBERSHIP_ID, null, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			groups.getMembership(MEMBERSHIP_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			groups.getMembership(MEMBERSHIP_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return groups.getMembership(MEMBERSHIP_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -272,30 +411,54 @@ describe('Groups', function() {
 
 		var MEMBERSHIP_ID = '639457';
 
-		it('should make PUT request to update the membership when called', function() {
+		var options,
+			expectedParams;
 
-			var options = {
+		beforeEach(function() {
+
+			options = {
 				role: 'member'
 			};
 
-			var expectedParams = {
+			expectedParams = {
 				body: options
 			};
+		});
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+		it('should make PUT request to update the membership when called', function() {
+
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/group_memberships/' + MEMBERSHIP_ID, expectedParams);
 			groups.updateMembership(MEMBERSHIP_ID, options);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			var options = {
-				role: 'member'
-			};
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			groups.updateMembership(MEMBERSHIP_ID, options);
+		});
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs('/group_memberships/' + MEMBERSHIP_ID).yieldsAsync();
-			groups.updateMembership(MEMBERSHIP_ID, options, done);
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			groups.updateMembership(MEMBERSHIP_ID, options, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return groups.updateMembership(MEMBERSHIP_ID, options)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -305,16 +468,38 @@ describe('Groups', function() {
 
 		it('should make DELETE request to delete the membership when called', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs('/group_memberships/' + MEMBERSHIP_ID);
 			groups.removeMembership(MEMBERSHIP_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/group_memberships/' + MEMBERSHIP_ID).yieldsAsync();
-			groups.removeMembership(MEMBERSHIP_ID, done);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			groups.removeMembership(MEMBERSHIP_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			groups.removeMembership(MEMBERSHIP_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return groups.removeMembership(MEMBERSHIP_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -327,7 +512,7 @@ describe('Groups', function() {
 				qs: null
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/groups/' + GROUP_ID + '/memberships', expectedParams);
 			groups.getMemberships(GROUP_ID, null);
 		});
@@ -342,15 +527,38 @@ describe('Groups', function() {
 				qs: options
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/groups/' + GROUP_ID + '/memberships', expectedParams);
 			groups.getMemberships(GROUP_ID, options);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/groups/' + GROUP_ID + '/memberships').yieldsAsync();
-			groups.getMemberships(GROUP_ID, null, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			groups.getMemberships(GROUP_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			groups.getMemberships(GROUP_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return groups.getMemberships(GROUP_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -363,7 +571,7 @@ describe('Groups', function() {
 				qs: null
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/groups', expectedParams);
 			groups.getAll(null);
 		});
@@ -378,15 +586,38 @@ describe('Groups', function() {
 				qs: options
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/groups', expectedParams);
 			groups.getAll(options);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/groups').yieldsAsync();
-			groups.getAll(null, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			groups.getAll();
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			groups.getAll(null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return groups.getAll()
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -399,7 +630,7 @@ describe('Groups', function() {
 				qs: null
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/groups/' + GROUP_ID + '/collaborations', expectedParams);
 			groups.getCollaborations(GROUP_ID, null);
 		});
@@ -414,15 +645,38 @@ describe('Groups', function() {
 				qs: options
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/groups/' + GROUP_ID + '/collaborations', expectedParams);
 			groups.getCollaborations(GROUP_ID, options);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/groups/' + GROUP_ID + '/collaborations').yieldsAsync();
-			groups.getCollaborations(GROUP_ID, null, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			groups.getCollaborations(GROUP_ID, null);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			groups.getCollaborations(GROUP_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return groups.getCollaborations(GROUP_ID, null)
+				.then(data => assert.equal(data, response));
 		});
 	});
 

--- a/tests/lib/managers/legal-hold-policies-test.js
+++ b/tests/lib/managers/legal-hold-policies-test.js
@@ -8,6 +8,7 @@
 // ------------------------------------------------------------------------------
 var sinon = require('sinon'),
 	mockery = require('mockery'),
+	assert = require('chai').assert,
 	leche = require('leche');
 
 var BoxClient = require('../../../lib/box-client');
@@ -63,7 +64,7 @@ describe('LegalHoldPolicies', function() {
 
 		it('should make POST request to create a new policy when called without optional parameters', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/legal_hold_policies', expectedParams);
 			legalHoldPolicies.create(POLICY_NAME);
 		});
@@ -73,16 +74,38 @@ describe('LegalHoldPolicies', function() {
 			var description = 'For the 2016 IRS audit';
 			expectedParams.body.description = description;
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/legal_hold_policies', expectedParams);
 			legalHoldPolicies.create(POLICY_NAME, {description});
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/legal_hold_policies').yieldsAsync();
-			legalHoldPolicies.create(POLICY_NAME, null, done);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			legalHoldPolicies.create(POLICY_NAME);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			legalHoldPolicies.create(POLICY_NAME, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return legalHoldPolicies.create(POLICY_NAME)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -92,62 +115,125 @@ describe('LegalHoldPolicies', function() {
 
 			var qs = {fields: 'policy_name,id'};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/legal_hold_policies/' + POLICY_ID, {qs});
 			legalHoldPolicies.get(POLICY_ID, qs);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			var qs = {fields: 'policy_name,id'};
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			legalHoldPolicies.get(POLICY_ID);
+		});
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/legal_hold_policies/' + POLICY_ID, {qs}).yieldsAsync();
-			legalHoldPolicies.get(POLICY_ID, qs, done);
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			legalHoldPolicies.get(POLICY_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return legalHoldPolicies.get(POLICY_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('update()', function() {
 
+		var options;
+
+		beforeEach(function() {
+
+			options = {
+				description: 'NOTE: Do not remove until litigation is concluded!'
+			};
+		});
 
 		it('should make PUT request to update policy info when called', function() {
 
-			var options = {
-				description: 'NOTE: Do not remove until litigation is concluded!'
-			};
-
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/legal_hold_policies/' + POLICY_ID, {body: options});
 			legalHoldPolicies.update(POLICY_ID, options);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			var options = {
-				description: 'NOTE: Do not remove until litigation is concluded!'
-			};
-
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs('/legal_hold_policies/' + POLICY_ID, {body: options}).yieldsAsync();
-			legalHoldPolicies.update(POLICY_ID, options, done);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			legalHoldPolicies.update(POLICY_ID, options);
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			legalHoldPolicies.update(POLICY_ID, options, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return legalHoldPolicies.update(POLICY_ID, options)
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 	describe('delete()', function() {
 
 		it('should make DELETE request to delete policy when called', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs('/legal_hold_policies/' + POLICY_ID);
 			legalHoldPolicies.delete(POLICY_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/legal_hold_policies/' + POLICY_ID).yieldsAsync();
-			legalHoldPolicies.delete(POLICY_ID, done);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			legalHoldPolicies.delete(POLICY_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			legalHoldPolicies.delete(POLICY_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return legalHoldPolicies.delete(POLICY_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -157,18 +243,38 @@ describe('LegalHoldPolicies', function() {
 
 			var qs = {policy_name: 'Lawsuit'};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/legal_hold_policies', {qs});
 			legalHoldPolicies.getAll(qs);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			var qs = {policy_name: 'Lawsuit'};
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			legalHoldPolicies.getAll();
+		});
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/legal_hold_policies', {qs}).yieldsAsync();
-			legalHoldPolicies.getAll(qs, done);
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			legalHoldPolicies.getAll(null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return legalHoldPolicies.getAll()
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -178,18 +284,38 @@ describe('LegalHoldPolicies', function() {
 
 			var qs = {assign_to_type: 'user'};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/legal_hold_policies/' + POLICY_ID + '/assignments', {qs});
 			legalHoldPolicies.getAssignments(POLICY_ID, qs);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			var qs = {assign_to_type: 'user'};
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			legalHoldPolicies.getAssignments(POLICY_ID);
+		});
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/legal_hold_policies/' + POLICY_ID + '/assignments', {qs}).yieldsAsync();
-			legalHoldPolicies.getAssignments(POLICY_ID, qs, done);
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			legalHoldPolicies.getAssignments(POLICY_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return legalHoldPolicies.getAssignments(POLICY_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -214,16 +340,38 @@ describe('LegalHoldPolicies', function() {
 
 		it('should make POST request to assign policy when called', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/legal_hold_policy_assignments', expectedParams);
 			legalHoldPolicies.assign(POLICY_ID, ASSIGN_TYPE, ASSIGN_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/legal_hold_policy_assignments', expectedParams).yieldsAsync();
-			legalHoldPolicies.assign(POLICY_ID, ASSIGN_TYPE, ASSIGN_ID, done);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			legalHoldPolicies.assign(POLICY_ID, ASSIGN_TYPE, ASSIGN_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			legalHoldPolicies.assign(POLICY_ID, ASSIGN_TYPE, ASSIGN_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return legalHoldPolicies.assign(POLICY_ID, ASSIGN_TYPE, ASSIGN_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -235,18 +383,38 @@ describe('LegalHoldPolicies', function() {
 
 			var qs = {fields: 'type,id,legal_hold_policy'};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/legal_hold_policy_assignments/' + ASSIGNMENT_ID, {qs});
 			legalHoldPolicies.getAssignment(ASSIGNMENT_ID, qs);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			var qs = {fields: 'type,id,legal_hold_policy'};
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			legalHoldPolicies.getAssignment(ASSIGNMENT_ID);
+		});
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/legal_hold_policy_assignments/' + ASSIGNMENT_ID, {qs}).yieldsAsync();
-			legalHoldPolicies.getAssignment(ASSIGNMENT_ID, qs, done);
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			legalHoldPolicies.getAssignment(ASSIGNMENT_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return legalHoldPolicies.getAssignment(ASSIGNMENT_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -256,16 +424,38 @@ describe('LegalHoldPolicies', function() {
 
 		it('should make DELETE request to delete assignment when called', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs('/legal_hold_policy_assignments/' + ASSIGNMENT_ID);
 			legalHoldPolicies.deleteAssignment(ASSIGNMENT_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/legal_hold_policy_assignments/' + ASSIGNMENT_ID).yieldsAsync();
-			legalHoldPolicies.deleteAssignment(ASSIGNMENT_ID, done);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			legalHoldPolicies.deleteAssignment(ASSIGNMENT_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			legalHoldPolicies.deleteAssignment(ASSIGNMENT_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return legalHoldPolicies.deleteAssignment(ASSIGNMENT_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -277,18 +467,38 @@ describe('LegalHoldPolicies', function() {
 
 			var qs = {fields: 'type,id,file_version'};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/file_version_legal_holds/' + LEGAL_HOLD_ID, {qs});
 			legalHoldPolicies.getFileVersionLegalHold(LEGAL_HOLD_ID, qs);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			var qs = {fields: 'type,id,file_version'};
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			legalHoldPolicies.getFileVersionLegalHold(LEGAL_HOLD_ID);
+		});
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/file_version_legal_holds/' + LEGAL_HOLD_ID, {qs}).yieldsAsync();
-			legalHoldPolicies.getFileVersionLegalHold(LEGAL_HOLD_ID, qs, done);
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			legalHoldPolicies.getFileVersionLegalHold(LEGAL_HOLD_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return legalHoldPolicies.getFileVersionLegalHold(LEGAL_HOLD_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -300,20 +510,38 @@ describe('LegalHoldPolicies', function() {
 				policy_id: POLICY_ID
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/file_version_legal_holds', {qs});
 			legalHoldPolicies.getAllFileVersionLegalHolds(POLICY_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			var qs = {
-				policy_id: POLICY_ID
-			};
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			legalHoldPolicies.getAllFileVersionLegalHolds(POLICY_ID);
+		});
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/file_version_legal_holds', {qs}).yieldsAsync();
-			legalHoldPolicies.getAllFileVersionLegalHolds(POLICY_ID, null, done);
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			legalHoldPolicies.getAllFileVersionLegalHolds(POLICY_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return legalHoldPolicies.getAllFileVersionLegalHolds(POLICY_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 

--- a/tests/lib/managers/metadata-test.js
+++ b/tests/lib/managers/metadata-test.js
@@ -8,6 +8,7 @@
 // ------------------------------------------------------------------------------
 var sinon = require('sinon'),
 	mockery = require('mockery'),
+	assert = require('chai').assert,
 	leche = require('leche');
 
 var BoxClient = require('../../../lib/box-client');
@@ -56,52 +57,118 @@ describe('Metadata', function() {
 	});
 
 	describe('getTemplateSchema()', function() {
-		it('should make GET request to get schema', function(done) {
+		it('should make GET request to get schema', function() {
 
 			var expectedAPIPath = '/metadata_templates/enterprise/productSpec/schema';
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs(expectedAPIPath, null);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').yields();
-			metadata.getTemplateSchema('enterprise', 'productSpec', done);
+			metadata.getTemplateSchema('enterprise', 'productSpec');
+		});
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			metadata.getTemplateSchema('enterprise', 'productSpec');
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			metadata.getTemplateSchema('enterprise', 'productSpec', function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return metadata.getTemplateSchema('enterprise', 'productSpec')
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('getTemplates()', function() {
-		it('should make a GET request to retrieve metadata templates', function(done) {
+		it('should make a GET request to retrieve metadata templates', function() {
 
 			var expectedAPIPath = '/metadata_templates/enterprise';
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs(expectedAPIPath, null);
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').yields();
-			metadata.getTemplates('enterprise', done);
+			metadata.getTemplates('enterprise');
+		});
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			metadata.getTemplates('enterprise');
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			metadata.getTemplates('enterprise', function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return metadata.getTemplates('enterprise')
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('createTemplate()', function() {
 
-		it('should make a POST request to create metadata template when called', function(done) {
+		var name,
+			fields,
+			options;
 
-			var name = 'Vendor Contract',
-				fields = [
-					{
-						type: 'string',
-						key: 'category',
-						displayName: 'Category'
-					},
-					{
-						type: 'enum',
-						key: 'fy',
-						displayName: 'FY',
-						options: [
-							{key: 'FY11'},
-							{key: 'FY12'},
-							{key: 'FY13'},
-							{key: 'FY14'},
-							{key: 'FY15'}
-						]
-					}
-				],
-				options = {
-					hidden: true
-				};
+		beforeEach(function() {
+
+			name = 'Vendor Contract';
+			fields = [
+				{
+					type: 'string',
+					key: 'category',
+					displayName: 'Category'
+				},
+				{
+					type: 'enum',
+					key: 'fy',
+					displayName: 'FY',
+					options: [
+						{key: 'FY11'},
+						{key: 'FY12'},
+						{key: 'FY13'},
+						{key: 'FY14'},
+						{key: 'FY15'}
+					]
+				}
+			];
+			options = {
+				hidden: true
+			};
+		});
+
+		it('should make a POST request to create metadata template when called', function() {
+
 
 			var expectedParams = {
 				body: {
@@ -112,35 +179,101 @@ describe('Metadata', function() {
 				}
 			};
 
-			sandbox.mock(boxClientFake).expects('post').withArgs('/metadata_templates/schema', expectedParams).yieldsAsync();
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
-			metadata.createTemplate(name, fields, options, done);
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.mock(boxClientFake).expects('post').withArgs('/metadata_templates/schema', expectedParams);
+			metadata.createTemplate(name, fields, options);
+		});
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			metadata.createTemplate(name, fields, options);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			metadata.createTemplate(name, fields, options, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return metadata.createTemplate(name, fields, options)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('updateTemplate()', function() {
 
-		it('should make PUT call to update template when called', function(done) {
+		var scope,
+			template,
+			operations;
 
-			var scope = 'enterprise',
-				template = 'vendorContract',
-				operations = [
-					{
-						op: 'editField',
-						fieldKey: 'category',
-						data: {
-							displayName: 'Contract Category'
-						}
+		beforeEach(function() {
+
+			scope = 'enterprise';
+			template = 'vendorContract';
+			operations = [
+				{
+					op: 'editField',
+					fieldKey: 'category',
+					data: {
+						displayName: 'Contract Category'
 					}
-				];
+				}
+			];
+		});
+
+		it('should make PUT call to update template when called', function() {
+
 
 			var expectedParams = {
 				body: operations
 			};
 
-			sandbox.mock(boxClientFake).expects('put').withArgs('/metadata_templates/' + scope + '/' + template + '/schema', expectedParams).yieldsAsync();
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
-			metadata.updateTemplate(scope, template, operations, done);
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.mock(boxClientFake).expects('put').withArgs('/metadata_templates/' + scope + '/' + template + '/schema', expectedParams);
+			metadata.updateTemplate(scope, template, operations);
+		});
+
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			metadata.updateTemplate(scope, template, operations);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			metadata.updateTemplate(scope, template, operations, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return metadata.updateTemplate(scope, template, operations)
+				.then(data => assert.equal(data, response));
 		});
 	});
 });

--- a/tests/lib/managers/retention-policies-test.js
+++ b/tests/lib/managers/retention-policies-test.js
@@ -8,6 +8,7 @@
 // ------------------------------------------------------------------------------
 var sinon = require('sinon'),
 	mockery = require('mockery'),
+	assert = require('chai').assert,
 	leche = require('leche');
 
 var BoxClient = require('../../../lib/box-client');
@@ -67,7 +68,7 @@ describe('RetentionPolicies', function() {
 
 		it('should make POST request to create a new policy when called without optional parameters', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/retention_policies', expectedParams);
 			retentionPolicies.create(POLICY_NAME, POLICY_TYPE, DISPOSITION_ACTION);
 		});
@@ -77,16 +78,38 @@ describe('RetentionPolicies', function() {
 			expectedParams.body.retention_length = 30;
 			expectedParams.body.policy_type = 'finite';
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/retention_policies', expectedParams);
 			retentionPolicies.create(POLICY_NAME, 'finite', DISPOSITION_ACTION, {retention_length: 30});
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/retention_policies').yieldsAsync();
-			retentionPolicies.create(POLICY_NAME, POLICY_TYPE, DISPOSITION_ACTION, null, done);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			retentionPolicies.create(POLICY_NAME, 'finite', DISPOSITION_ACTION, {retention_length: 30});
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			retentionPolicies.create(POLICY_NAME, 'finite', DISPOSITION_ACTION, {retention_length: 30}, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return retentionPolicies.create(POLICY_NAME, 'finite', DISPOSITION_ACTION, {retention_length: 30})
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -96,42 +119,85 @@ describe('RetentionPolicies', function() {
 
 			var qs = {fields: 'policy_name,id'};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/retention_policies/' + POLICY_ID, {qs});
 			retentionPolicies.get(POLICY_ID, qs);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			var qs = {fields: 'policy_name,id'};
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			retentionPolicies.get(POLICY_ID);
+		});
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/retention_policies/' + POLICY_ID, {qs}).yieldsAsync();
-			retentionPolicies.get(POLICY_ID, qs, done);
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			retentionPolicies.get(POLICY_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return retentionPolicies.get(POLICY_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('update()', function() {
 
+		var options;
+
+		beforeEach(function() {
+
+			options = {retention_length: 60};
+		});
 
 		it('should make PUT request to update policy info when called', function() {
 
-			var options = {retention_length: 60};
-
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/retention_policies/' + POLICY_ID, {body: options});
 			retentionPolicies.update(POLICY_ID, options);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			var options = {retention_length: 60};
-
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs('/retention_policies/' + POLICY_ID, {body: options}).yieldsAsync();
-			retentionPolicies.update(POLICY_ID, options, done);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			retentionPolicies.update(POLICY_ID, options);
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			retentionPolicies.update(POLICY_ID, options, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return retentionPolicies.update(POLICY_ID, options)
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 	describe('getAll()', function() {
@@ -140,18 +206,38 @@ describe('RetentionPolicies', function() {
 
 			var qs = {policy_type: 'enterprise'};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/retention_policies', {qs});
 			retentionPolicies.getAll(qs);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			var qs = {type: 'enterprise'};
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			retentionPolicies.getAll();
+		});
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/retention_policies', {qs}).yieldsAsync();
-			retentionPolicies.getAll(qs, done);
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			retentionPolicies.getAll(null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return retentionPolicies.getAll()
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -161,18 +247,38 @@ describe('RetentionPolicies', function() {
 
 			var qs = {type: 'enterprise'};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/retention_policies/' + POLICY_ID + '/assignments', {qs});
 			retentionPolicies.getAssignments(POLICY_ID, qs);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			var qs = {type: 'enterprise'};
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			retentionPolicies.getAssignments(POLICY_ID);
+		});
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/retention_policies/' + POLICY_ID + '/assignments', {qs}).yieldsAsync();
-			retentionPolicies.getAssignments(POLICY_ID, qs, done);
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			retentionPolicies.getAssignments(POLICY_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return retentionPolicies.getAssignments(POLICY_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -197,16 +303,38 @@ describe('RetentionPolicies', function() {
 
 		it('should make POST request to assign policy when called', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/retention_policy_assignments', expectedParams);
 			retentionPolicies.assign(POLICY_ID, ASSIGN_TYPE, ASSIGN_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/retention_policy_assignments', expectedParams).yieldsAsync();
-			retentionPolicies.assign(POLICY_ID, ASSIGN_TYPE, ASSIGN_ID, done);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			retentionPolicies.assign(POLICY_ID, ASSIGN_TYPE, ASSIGN_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			retentionPolicies.assign(POLICY_ID, ASSIGN_TYPE, ASSIGN_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return retentionPolicies.assign(POLICY_ID, ASSIGN_TYPE, ASSIGN_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -218,18 +346,38 @@ describe('RetentionPolicies', function() {
 
 			var qs = {fields: 'type,id,retention_policy'};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/retention_policy_assignments/' + ASSIGNMENT_ID, {qs});
 			retentionPolicies.getAssignment(ASSIGNMENT_ID, qs);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			var qs = {fields: 'type,id,retention_policy'};
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			retentionPolicies.getAssignment(ASSIGNMENT_ID);
+		});
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/retention_policy_assignments/' + ASSIGNMENT_ID, {qs}).yieldsAsync();
-			retentionPolicies.getAssignment(ASSIGNMENT_ID, qs, done);
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			retentionPolicies.getAssignment(ASSIGNMENT_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return retentionPolicies.getAssignment(ASSIGNMENT_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -241,18 +389,38 @@ describe('RetentionPolicies', function() {
 
 			var qs = {fields: 'type,id,disposition_at'};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/file_version_retentions/' + RETENTION_ID, {qs});
 			retentionPolicies.getFileVersionRetention(RETENTION_ID, qs);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			var qs = {fields: 'type,id,disposition_at'};
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			retentionPolicies.getFileVersionRetention(RETENTION_ID);
+		});
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/file_version_retentions/' + RETENTION_ID, {qs}).yieldsAsync();
-			retentionPolicies.getFileVersionRetention(RETENTION_ID, qs, done);
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			retentionPolicies.getFileVersionRetention(RETENTION_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return retentionPolicies.getFileVersionRetention(RETENTION_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -265,21 +433,38 @@ describe('RetentionPolicies', function() {
 				disposition_before: '2017-01-01T00:00:00+00:00'
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/file_version_retentions', {qs});
 			retentionPolicies.getAllFileVersionRetentions(qs);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			var qs = {
-				file_id: '1234565',
-				disposition_before: '2017-01-01T00:00:00+00:00'
-			};
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			retentionPolicies.getAllFileVersionRetentions();
+		});
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/file_version_retentions', {qs}).yieldsAsync();
-			retentionPolicies.getAllFileVersionRetentions(qs, done);
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			retentionPolicies.getAllFileVersionRetentions(null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return retentionPolicies.getAllFileVersionRetentions()
+				.then(data => assert.equal(data, response));
 		});
 	});
 

--- a/tests/lib/managers/search-test.js
+++ b/tests/lib/managers/search-test.js
@@ -58,29 +58,55 @@ describe('Search', function() {
 
 	describe('query()', function() {
 
-		it('should make GET request to search the API and propagate results when called', function(done) {
-			var searchQuery = 'fakeQuery',
-				fakeQs = { fakeQsKey: 'fakeQsValue' },
-				fakeParamsWithQs = {qs: fakeQs};
+		var searchQuery,
+			fakeQs,
+			fakeParamsWithQs;
 
-			fakeParamsWithQs.qs.search = searchQuery;
-			sandbox.mock(boxClientFake).expects('get').withArgs('/search', fakeParamsWithQs).yieldsAsync();
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
-			search.query(searchQuery, fakeQs, done);
+		beforeEach(function() {
+
+			searchQuery = 'fakeQuery';
+			fakeQs = { fakeQsKey: 'fakeQsValue' };
+			fakeParamsWithQs = {qs: fakeQs};
 		});
 
-		it('should call defaultResponseHandler to wrap callback when called', function(done) {
-			var searchQuery = 'fakeQuery',
-				fakeQs = { fakeQsKey: 'fakeQsValue' },
-				fakeParamsWithQs = {qs: fakeQs};
+		it('should make GET request to search the API when called', function() {
 
 			fakeParamsWithQs.qs.search = searchQuery;
-			sandbox.stub(boxClientFake, 'get').yieldsAsync();
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			search.query(searchQuery, fakeQs, done);
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.mock(boxClientFake).expects('get').withArgs('/search', fakeParamsWithQs);
+			search.query(searchQuery, fakeQs);
 		});
 
-		it('should properly encode metadata filters when called with mdfilters option', function(done) {
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			search.query(searchQuery, fakeQs);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			search.query(searchQuery, fakeQs, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return search.query(searchQuery, fakeQs)
+				.then(data => assert.equal(data, response));
+		});
+
+		it('should properly encode metadata filters when called with mdfilters option', function() {
 
 			var options = {
 				mdfilters: [
@@ -99,12 +125,12 @@ describe('Search', function() {
 				}
 			};
 
-			sandbox.mock(boxClientFake).expects('get').withArgs('/search', expectedParams).yieldsAsync();
-			sandbox.stub(boxClientFake, 'defaultResponseHandler').returnsArg(0);
-			search.query('', options, done);
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.mock(boxClientFake).expects('get').withArgs('/search', expectedParams);
+			search.query('', options);
 		});
 
-		it('should call callback with error when mdfilters is invalid', function(done) {
+		it('should call callback with error when mdfilters is invalid and callback is passed', function(done) {
 
 			var options = {
 				mdfilters: {
@@ -123,6 +149,23 @@ describe('Search', function() {
 			});
 		});
 
+		it('should return promise that rejects when mdfilters is invalid', function() {
+
+			var options = {
+				mdfilters: {
+					templateKey: 'MyTemplate',
+					scope: 'enterprise',
+					filters: {}
+				}
+			};
+
+
+			sandbox.mock(boxClientFake).expects('get').never();
+			return search.query('', options)
+				.catch(err => {
+					assert.instanceOf(err, Error);
+				});
+		});
 	});
 
 });

--- a/tests/lib/managers/tasks-test.js
+++ b/tests/lib/managers/tasks-test.js
@@ -9,6 +9,7 @@
 var sinon = require('sinon'),
 	mockery = require('mockery'),
 	leche = require('leche'),
+	assert = require('chai').assert,
 	BoxClient = require('../../../lib/box-client');
 
 // ------------------------------------------------------------------------------
@@ -84,7 +85,7 @@ describe('Tasks', function() {
 			expectedParams.body.message = message;
 			expectedParams.body.due_at = dueAt;
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs(BASE_PATH, expectedParams);
 			tasks.create(FILE_ID, {message: message, due_at: dueAt});
 		});
@@ -92,7 +93,7 @@ describe('Tasks', function() {
 		it('should make POST request with message to create a task when just a message is passed', function() {
 			expectedParams.body.message = message;
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs(BASE_PATH, expectedParams);
 			tasks.create(FILE_ID, {message: message});
 		});
@@ -100,39 +101,83 @@ describe('Tasks', function() {
 		it('should make POST request with due_at to create a task when just a dueAt is passed', function() {
 			expectedParams.body.due_at = dueAt;
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs(BASE_PATH, expectedParams);
 			tasks.create(FILE_ID, {due_at: dueAt});
 		});
 
 		it('should make POST request with mandatory parameters to create a task when neither optional parameter is passed', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs(BASE_PATH, expectedParams);
 			tasks.create(FILE_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs(BASE_PATH).yieldsAsync();
-			tasks.create(FILE_ID, {message: message, dueAt: dueAt}, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			tasks.create(FILE_ID);
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			tasks.create(FILE_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return tasks.create(FILE_ID)
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 	describe('get()', function() {
 
 		it('should make GET request to get task info when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs(BASE_PATH + '/' + TASK_ID, testParamsWithQs);
 			tasks.get(TASK_ID, testQS);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs(BASE_PATH + '/' + TASK_ID).yieldsAsync();
-			tasks.get(TASK_ID, testQS, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			tasks.get(TASK_ID, testQS);
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			tasks.get(TASK_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return tasks.get(TASK_ID, testQS)
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 
@@ -151,22 +196,45 @@ describe('Tasks', function() {
 				body: options
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs(BASE_PATH + '/' + TASK_ID, expectedParams);
 			tasks.update(TASK_ID, options);
 		});
 
 		it('should make PUT request with mandatory parameters to update a task when no optional parameter is passed', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs(BASE_PATH + '/' + TASK_ID, {body: null});
 			tasks.update(TASK_ID, null);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs(BASE_PATH + '/' + TASK_ID).yieldsAsync();
-			tasks.update(TASK_ID, null, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			tasks.update(TASK_ID, null);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			tasks.update(TASK_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return tasks.update(TASK_ID, null)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -174,54 +242,117 @@ describe('Tasks', function() {
 
 		it('should make delete request to delete a task permanently when called', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs(BASE_PATH + '/' + TASK_ID);
 			tasks.delete(TASK_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs(BASE_PATH + '/' + TASK_ID).yieldsAsync();
-			tasks.delete(TASK_ID, done);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			tasks.delete(TASK_ID);
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			tasks.delete(TASK_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return tasks.delete(TASK_ID)
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 	describe('getAssignments()', function() {
 
 		it('should make GET request to get task assignments when called', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs(BASE_PATH + '/' + TASK_ID + '/assignments', testParamsWithQs);
 			tasks.getAssignments(TASK_ID, testQS);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs(BASE_PATH + '/' + TASK_ID + '/assignments').yieldsAsync();
-			tasks.getAssignments(TASK_ID, testQS, done);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			tasks.getAssignments(TASK_ID, testQS);
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			tasks.getAssignments(TASK_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return tasks.getAssignments(TASK_ID, testQS)
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 	describe('getAssignment()', function() {
 
 		it('should make GET request to get task assignment when called', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/task_assignments/' + ASSIGNMENT_ID, testParamsWithQs);
 			tasks.getAssignment(ASSIGNMENT_ID, testQS);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/task_assignments/' + ASSIGNMENT_ID).yieldsAsync();
-			tasks.getAssignment(ASSIGNMENT_ID, testQS, done);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			tasks.getAssignment(ASSIGNMENT_ID, testQS);
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			tasks.getAssignment(TASK_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return tasks.getAssignment(ASSIGNMENT_ID, testQS)
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 	describe('assignByUserID()', function() {
@@ -242,16 +373,38 @@ describe('Tasks', function() {
 				}
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/task_assignments', expectedParams);
 			tasks.assignByUserID(TASK_ID, USER_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/task_assignments').yieldsAsync();
-			tasks.assignByUserID(TASK_ID, USER_ID, done);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			tasks.assignByUserID(TASK_ID, USER_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			tasks.assignByUserID(TASK_ID, USER_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return tasks.assignByUserID(TASK_ID, USER_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -273,16 +426,38 @@ describe('Tasks', function() {
 				}
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/task_assignments', expectedParams);
 			tasks.assignByEmail(TASK_ID, EMAIL);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/task_assignments').yieldsAsync();
-			tasks.assignByEmail(TASK_ID, EMAIL, done);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			tasks.assignByEmail(TASK_ID, EMAIL);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			tasks.assignByEmail(TASK_ID, EMAIL, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return tasks.assignByEmail(TASK_ID, EMAIL)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -290,27 +465,54 @@ describe('Tasks', function() {
 		var MESSAGE = 'Optional message for the test',
 			RESOLUTION_STATE = 'approved';
 
-		it('should make PUT request with all parameters to update a task when called', function() {
+		var options;
 
-			var options = {
+		beforeEach(function() {
+
+			options = {
 				message: MESSAGE,
 				resolution_state: RESOLUTION_STATE
 			};
+		});
+
+		it('should make PUT request with all parameters to update a task when called', function() {
 
 			var expectedParams = {
 				body: options
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/task_assignments/' + ASSIGNMENT_ID, expectedParams);
 			tasks.updateAssignment(ASSIGNMENT_ID, options);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs('/task_assignments/' + ASSIGNMENT_ID).yieldsAsync();
-			tasks.updateAssignment(ASSIGNMENT_ID, {}, done);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			tasks.updateAssignment(ASSIGNMENT_ID, options);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			tasks.updateAssignment(ASSIGNMENT_ID, options, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return tasks.updateAssignment(ASSIGNMENT_ID, options)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -318,18 +520,39 @@ describe('Tasks', function() {
 
 		it('should make delete request to delete a task permanently when called', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs('/task_assignments/' + ASSIGNMENT_ID);
 			tasks.deleteAssignment(ASSIGNMENT_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
+		it('should wrap with default handler when called', function() {
 
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/task_assignments/' + ASSIGNMENT_ID).yieldsAsync();
-			tasks.deleteAssignment(ASSIGNMENT_ID, done);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			tasks.deleteAssignment(ASSIGNMENT_ID);
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			tasks.deleteAssignment(ASSIGNMENT_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return tasks.deleteAssignment(ASSIGNMENT_ID)
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 });

--- a/tests/lib/managers/users-test.js
+++ b/tests/lib/managers/users-test.js
@@ -8,6 +8,7 @@
 // ------------------------------------------------------------------------------
 var sinon = require('sinon'),
 	mockery = require('mockery'),
+	assert = require('chai').assert,
 	leche = require('leche');
 
 var BoxClient = require('../../../lib/box-client');
@@ -65,82 +66,168 @@ describe('Users', function() {
 
 	describe('get()', function() {
 		it('should make GET request to get user info when called', function() {
-			var id = '1234';
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
-			sandbox.mock(boxClientFake).expects('get').withArgs('/users/1234', testParamsWithQs);
-			users.get(id, testQS);
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.mock(boxClientFake).expects('get').withArgs('/users/' + USER_ID, testParamsWithQs);
+			users.get(USER_ID, testQS);
 		});
 
 		it('should make GET request to get info for current user when passed "me" ID', function() {
-			var id = 'me';
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/users/me', testParamsWithQs);
-			users.get(id, testQS);
+			users.get('me', testQS);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/users/' + USER_ID).yieldsAsync();
-			users.get(USER_ID, testQS, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get');
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			users.get(USER_ID, testQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			users.get(USER_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return users.get(USER_ID, testQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('update()', function() {
 		it('should make PUT request to update user info when called', function() {
-			var id = '908546';
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
-			sandbox.mock(boxClientFake).expects('put').withArgs('/users/908546', testParamsWithBody);
-			users.update(id, testBody);
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.mock(boxClientFake).expects('put').withArgs('/users/' + USER_ID, testParamsWithBody);
+			users.update(USER_ID, testBody);
 		});
 
 		it('should make PUT request to update current user info when passed "me" ID', function() {
-			var id = 'me';
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/users/me', testParamsWithBody);
-			users.update(id, testBody);
+			users.update('me', testBody);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'put').yieldsAsync();
-			users.update(USER_ID, testBody, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'put');
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			users.update(USER_ID, testQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			users.update(USER_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return users.update(USER_ID, testQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('delete()', function() {
 
 		it('should make DELETE request to delete user when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs('/users/' + USER_ID, testParamsWithQs);
 			users.delete(USER_ID, testQS);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/users/' + USER_ID).yieldsAsync();
-			users.delete(USER_ID, null, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'del');
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			users.delete(USER_ID, testQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			users.delete(USER_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return users.delete(USER_ID, testQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('getEmailAliases()', function() {
 		it('should make GET request to retrieve user email aliases when called', function() {
-			var id = '6493';
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
-			sandbox.mock(boxClientFake).expects('get').withArgs('/users/6493/email_aliases');
-			users.getEmailAliases(id);
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.mock(boxClientFake).expects('get').withArgs('/users/' + USER_ID + '/email_aliases');
+			users.getEmailAliases(USER_ID);
 		});
 
 		it('should make GET request to retrieve current user email aliases when passed "me" ID', function() {
-			var id = 'me';
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/users/me/email_aliases');
-			users.getEmailAliases(id);
+			users.getEmailAliases('me');
 		});
 
-		it('should wrap callback in default response handler when called', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').yieldsAsync();
-			users.getEmailAliases(USER_ID, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get');
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			users.getEmailAliases(USER_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			users.getEmailAliases(USER_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return users.getEmailAliases(USER_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -148,37 +235,59 @@ describe('Users', function() {
 		var email = 'horatio@nelson.com';
 
 		it('should make POST request to add email alias to user when called', function() {
-			var	id = '4567',
-				expectedBody = {
-					email: email,
-					is_confirmed: false
-				};
+			var expectedBody = {
+				email: email,
+				is_confirmed: false
+			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
-			sandbox.mock(boxClientFake).expects('post').withArgs('/users/4567/email_aliases', {
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.mock(boxClientFake).expects('post').withArgs('/users/' + USER_ID + '/email_aliases', {
 				body: expectedBody
 			});
-			users.addEmailAlias(id, email);
+			users.addEmailAlias(USER_ID, email);
 		});
 
 		it('should make POST request to add email alias to current user when passed "me" id', function() {
-			var id = 'me',
-				expectedBody = {
-					email: email,
-					is_confirmed: false
-				};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			var expectedBody = {
+				email: email,
+				is_confirmed: false
+			};
+
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/users/me/email_aliases', {
 				body: expectedBody
 			});
-			users.addEmailAlias(id, email);
+			users.addEmailAlias('me', email);
 		});
 
-		it('should wrap callback in default response handler when called', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').yieldsAsync();
-			users.addEmailAlias(USER_ID, email, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post');
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			users.addEmailAlias(USER_ID, email);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			users.addEmailAlias(USER_ID, email, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return users.addEmailAlias(USER_ID, email)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -186,25 +295,47 @@ describe('Users', function() {
 		var aliasID = '23455';
 
 		it('should make DELETE call to remove email alias when called', function() {
-			var userID = '7890';
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
-			sandbox.mock(boxClientFake).expects('del').withArgs('/users/7890/email_aliases/23455');
-			users.removeEmailAlias(userID, aliasID);
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.mock(boxClientFake).expects('del').withArgs('/users/' + USER_ID + '/email_aliases/' + aliasID);
+			users.removeEmailAlias(USER_ID, aliasID);
 		});
 
 		it('should make DELETE call to remove email alias from current user when passed "me" ID', function() {
-			var userID = 'me';
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
-			sandbox.mock(boxClientFake).expects('del').withArgs('/users/me/email_aliases/23455');
-			users.removeEmailAlias(userID, aliasID);
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.mock(boxClientFake).expects('del').withArgs('/users/me/email_aliases/' + aliasID);
+			users.removeEmailAlias('me', aliasID);
 		});
 
-		it('should wrap callback without default response handler when called', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'del').yieldsAsync();
-			users.removeEmailAlias('me', aliasID, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'del');
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			users.removeEmailAlias(USER_ID, aliasID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			users.removeEmailAlias(USER_ID, aliasID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var id = '1234';
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return users.removeEmailAlias(id, aliasID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -216,7 +347,7 @@ describe('Users', function() {
 				qs: null
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/users/' + USER_ID + '/memberships', expectedParams);
 			users.getGroupMemberships(USER_ID, null);
 		});
@@ -231,15 +362,38 @@ describe('Users', function() {
 				qs: options
 			};
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/users/' + USER_ID + '/memberships', expectedParams);
 			users.getGroupMemberships(USER_ID, options);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/users/' + USER_ID + '/memberships').yieldsAsync();
-			users.getGroupMemberships(USER_ID, null, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get');
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			users.getGroupMemberships(USER_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			users.getGroupMemberships(USER_ID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return users.getGroupMemberships(USER_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 });

--- a/tests/lib/managers/web-links-test.js
+++ b/tests/lib/managers/web-links-test.js
@@ -9,6 +9,7 @@
 var sinon = require('sinon'),
 	mockery = require('mockery'),
 	leche = require('leche'),
+	assert = require('chai').assert,
 	BoxClient = require('../../../lib/box-client');
 
 // ------------------------------------------------------------------------------
@@ -84,7 +85,7 @@ describe('WebLinks', function() {
 			expectedParams.body.name = name;
 			expectedParams.body.description = description;
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs(BASE_PATH, expectedParams);
 			weblinks.create(url, parentID, {name: name, description: description});
 		});
@@ -92,7 +93,7 @@ describe('WebLinks', function() {
 		it('should make POST request with name to create a web link when just a name is passed', function() {
 			expectedParams.body.name = name;
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs(BASE_PATH, expectedParams);
 			weblinks.create(url, parentID, {name: name});
 		});
@@ -100,37 +101,82 @@ describe('WebLinks', function() {
 		it('should make POST request with description to create a web link when just a description is passed', function() {
 			expectedParams.body.description = description;
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs(BASE_PATH, expectedParams);
 			weblinks.create(url, parentID, {description: description});
 		});
 
 		it('should make POST request with mandatory parameters to create a web link when neither optional parameter is passed', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs(BASE_PATH, expectedParams);
 			weblinks.create(url, parentID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs(BASE_PATH).yieldsAsync();
-			weblinks.create(url, parentID, {name: name, description: description}, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			weblinks.create(url, parentID);
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			weblinks.create(url, parentID, null, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return weblinks.create(url, parentID)
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 	describe('get()', function() {
 
 		it('should make GET request to get a web link when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs(BASE_PATH + '/' + WEB_LINK_ID, testParamsWithQs);
 			weblinks.get(WEB_LINK_ID, testQS);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs(BASE_PATH + '/' + WEB_LINK_ID).yieldsAsync();
-			weblinks.get(WEB_LINK_ID, null, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			weblinks.get(WEB_LINK_ID, testQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			weblinks.get(WEB_LINK_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return weblinks.get(WEB_LINK_ID, testQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -151,7 +197,7 @@ describe('WebLinks', function() {
 			expectedParams.body.name = name;
 			expectedParams.body.description = description;
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs(BASE_PATH + '/' + WEB_LINK_ID, expectedParams);
 			weblinks.update(WEB_LINK_ID, {name: name, description: description});
 		});
@@ -159,7 +205,7 @@ describe('WebLinks', function() {
 		it('should make PUT request with name to update a weblink when just a name is passed', function() {
 			expectedParams.body.name = name;
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs(BASE_PATH + '/' + WEB_LINK_ID, expectedParams);
 			weblinks.update(WEB_LINK_ID, {name: name});
 		});
@@ -167,31 +213,76 @@ describe('WebLinks', function() {
 		it('should make PUT request with description to update a weblink when just a description is passed', function() {
 			expectedParams.body.description = description;
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs(BASE_PATH + '/' + WEB_LINK_ID, expectedParams);
 			weblinks.update(WEB_LINK_ID, {description: description});
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs(BASE_PATH + '/' + WEB_LINK_ID).yieldsAsync();
-			weblinks.update(WEB_LINK_ID, {name: name, description: description}, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			weblinks.update(WEB_LINK_ID, {description: description});
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			weblinks.update(WEB_LINK_ID, {name}, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return weblinks.update(WEB_LINK_ID, {description: description})
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 	describe('delete()', function() {
 
 		it('should make DELETE request to delete a web link when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs(BASE_PATH + '/' + WEB_LINK_ID, null);
 			weblinks.delete(WEB_LINK_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs(BASE_PATH + '/' + WEB_LINK_ID).yieldsAsync();
-			weblinks.delete(WEB_LINK_ID, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			weblinks.delete(WEB_LINK_ID);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			weblinks.delete(WEB_LINK_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return weblinks.delete(WEB_LINK_ID)
+				.then(data => assert.equal(data, response));
 		});
 	});
 

--- a/tests/lib/managers/webhooks-test.js
+++ b/tests/lib/managers/webhooks-test.js
@@ -68,30 +68,76 @@ describe('Webhooks', function() {
 
 		it('should make POST call to create webhook', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('post').withArgs('/webhooks', expectedParams);
 			webhooks.create(ID, TYPE, ADDRESS, TRIGGERS);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'post').withArgs('/webhooks').yieldsAsync();
-			webhooks.create(ID, TYPE, ADDRESS, TRIGGERS, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.post).returnsArg(0);
+			webhooks.create(ID, TYPE, ADDRESS, TRIGGERS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').yieldsAsync(null, response);
+			webhooks.create(ID, TYPE, ADDRESS, TRIGGERS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return webhooks.create(ID, TYPE, ADDRESS, TRIGGERS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
 	describe('get()', function() {
 
 		it('should make GET request to get Webhook info when called', function() {
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/webhooks/1234', testParamsWithQs);
 			webhooks.get(WEBHOOKS_ID, testQS);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs('/webhooks/1234', testParamsWithQs).yieldsAsync();
-			webhooks.get(WEBHOOKS_ID, testQS, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			webhooks.get(WEBHOOKS_ID, testQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			webhooks.get(WEBHOOKS_ID, testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return webhooks.get(WEBHOOKS_ID, testQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -99,16 +145,38 @@ describe('Webhooks', function() {
 
 		it('should make GET call to fetch all webhooks', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('get').withArgs('/webhooks', testParamsWithQs);
 			webhooks.getAll(testQS);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'get').withArgs(testParamsWithQs).yieldsAsync();
-			webhooks.getAll(testQS, done);
-			done();
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.get).returnsArg(0);
+			webhooks.getAll(testQS);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').yieldsAsync(null, response);
+			webhooks.getAll(testQS, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return webhooks.getAll(testQS)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -124,15 +192,38 @@ describe('Webhooks', function() {
 		};
 		it('should make PUT call to update webhook', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('put').withArgs('/webhooks/1234');
 			webhooks.update(WEBHOOKS_ID, param);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'put').withArgs('/webhooks/1234').yieldsAsync();
-			webhooks.update(WEBHOOKS_ID, param, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.put).returnsArg(0);
+			webhooks.update(WEBHOOKS_ID, param);
+		});
+
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').yieldsAsync(null, response);
+			webhooks.update(WEBHOOKS_ID, param, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'put').returns(Promise.resolve(response));
+			return webhooks.update(WEBHOOKS_ID, param)
+				.then(data => assert.equal(data, response));
 		});
 	});
 
@@ -140,17 +231,39 @@ describe('Webhooks', function() {
 
 		it('should make DELETE call to remove webhook', function() {
 
-			sandbox.stub(boxClientFake, 'defaultResponseHandler');
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
 			sandbox.mock(boxClientFake).expects('del').withArgs('/webhooks/1234');
 			webhooks.delete(WEBHOOKS_ID);
 		});
 
-		it('should call BoxClient defaultResponseHandler method with the callback when response is returned', function(done) {
-			sandbox.mock(boxClientFake).expects('defaultResponseHandler').withArgs(done).returns(done);
-			sandbox.stub(boxClientFake, 'del').withArgs('/webhooks/1234').yieldsAsync();
-			webhooks.delete(WEBHOOKS_ID, done);
+		it('should wrap with default handler when called', function() {
+
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve());
+			sandbox.mock(boxClientFake).expects('wrapWithDefaultHandler').withArgs(boxClientFake.del).returnsArg(0);
+			webhooks.delete(WEBHOOKS_ID);
 		});
 
+		it('should pass results to callback when callback is present', function(done) {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').yieldsAsync(null, response);
+			webhooks.delete(WEBHOOKS_ID, function(err, data) {
+
+				assert.ifError(err);
+				assert.equal(data, response);
+				done();
+			});
+		});
+
+		it('should return promise resolving to results when called', function() {
+
+			var response = {};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'del').returns(Promise.resolve(response));
+			return webhooks.delete(WEBHOOKS_ID)
+				.then(data => assert.equal(data, response));
+		});
 	});
 
 	describe('validateMessage()', function() {
@@ -231,6 +344,11 @@ describe('Webhooks', function() {
 			const clock = sinon.useFakeTimers(DATE_IN_PAST);
 			assert.ok(!Webhooks.validateMessage(BODY, HEADERS_WITH_WRONG_SIGNATURE_ALGORITHM, PRIMARY_SIGNATURE_KEY, SECONDARY_SIGNATURE_KEY));
 			clock.restore();
+		});
+
+		it('should attach validation method to manager instance', function() {
+
+			assert.equal(Webhooks.validateMessage, webhooks.validateMessage);
 		});
 	});
 });


### PR DESCRIPTION
Adding polyglot Promise support; all asynchronous SDK methods should support taking a callback as the last parameter and returning a promise.  This will allow us to start migrating users to Promises in a backwards-compatible manner ahead of a future major version release which could remove callback support.