### PR TITLE
Fix token expiration window

### DIFF
--- a/lib/sessions/anonymous-session.js
+++ b/lib/sessions/anonymous-session.js
@@ -99,20 +99,13 @@ AnonymousSession.prototype._refreshAnonymousAccessToken = function(options, call
  * @returns {void}
  */
 AnonymousSession.prototype.getAccessToken = function(options, callback) {
+
 	// If the current token is expired, get a new token. All incoming
 	// requests will be held until a fresh token is retrieved.
-	if (!this.tokenInfo || !this.tokenManager.isAccessTokenValid(this.tokenInfo, this._config.expiredBufferMS)) {
+	var expirationBuffer = Math.max(this._config.expiredBufferMS, this._config.staleBufferMS);
+	if (!this.tokenInfo || !this.tokenManager.isAccessTokenValid(this.tokenInfo, expirationBuffer)) {
 		this._refreshAnonymousAccessToken(options, callback);
 		return;
-	}
-
-	// If the current token is getting stale, fire off a refresh in the background. We still return the
-	// current, valid access token below.
-	// A token object is considered stale before it expires, usually in the range of a few minutes.
-	// This gives the session a chance to optimistically refresh the session's tokens in the background without
-	// holding up the user request.
-	if (!this.tokenManager.isAccessTokenValid(this.tokenInfo, this._config.staleBufferMS)) {
-		this._refreshAnonymousAccessToken(options);
 	}
 
 	// Your token is not currently stale! Return the current access token.

--- a/lib/sessions/app-auth-session.js
+++ b/lib/sessions/app-auth-session.js
@@ -104,20 +104,13 @@ AppAuthSession.prototype._refreshAppAuthAccessToken = function(options, callback
  * @returns {void}
  */
 AppAuthSession.prototype.getAccessToken = function(options, callback) {
+
 	// If the current token is expired, get a new token. All incoming
 	// requests will be held until a fresh token is retrieved.
-	if (!this.tokenInfo || !this.tokenManager.isAccessTokenValid(this.tokenInfo, this._config.expiredBufferMS)) {
+	var expirationBuffer = Math.max(this._config.expiredBufferMS, this._config.staleBufferMS);
+	if (!this.tokenInfo || !this.tokenManager.isAccessTokenValid(this.tokenInfo, expirationBuffer)) {
 		this._refreshAppAuthAccessToken(options, callback);
 		return;
-	}
-
-	// If the current token is getting stale, fire off a refresh in the background. We still return the
-	// current, valid access token below.
-	// A token object is considered stale before it expires, usually in the range of a few minutes.
-	// This gives the session a chance to optimistically refresh the session's tokens in the background without
-	// holding up the user request.
-	if (!this.tokenManager.isAccessTokenValid(this.tokenInfo, this._config.staleBufferMS)) {
-		this._refreshAppAuthAccessToken(options);
 	}
 
 	// Your token is not currently stale! Return the current access token.

--- a/lib/sessions/persistent-session.js
+++ b/lib/sessions/persistent-session.js
@@ -240,19 +240,13 @@ PersistentSession.prototype._refreshTokens = function(options, callback) {
  * @returns {void}
  */
 PersistentSession.prototype.getAccessToken = function(options, callback) {
+
+
 	// If our tokens are expired, we need to refresh them before passing the access token to the callback
-	if (!this.tokenManager.isAccessTokenValid(this._tokenInfo, this._config.expiredBufferMS)) {
+	var expirationBuffer = Math.max(this._config.expiredBufferMS, this._config.staleBufferMS);
+	if (!this.tokenManager.isAccessTokenValid(this._tokenInfo, expirationBuffer)) {
 		this._refreshTokens(options, callback);
 		return;
-	}
-
-	// If our tokens are getting stale, fire off a refresh in the background. We can still return the current
-	// valid access token below.
-	// A token object is considered stale before it is considered expired, usually in the range of a few minutes.
-	// This gives the session a chance to optimistically refresh the session's tokens in the background without
-	// holding up a user request.
-	if (!this.tokenManager.isAccessTokenValid(this._tokenInfo, this._config.staleBufferMS)) {
-		this._refreshTokens(options);
 	}
 
 	// Current access token is still valid. Return it.

--- a/lib/util/config.js
+++ b/lib/util/config.js
@@ -39,8 +39,7 @@ var assert = require('assert'),
  * @property {int} [uploadRequestTimeoutMS] Timeout after which an upload request is aborted [Default: 60000]
  * @property {int} [retryIntervalMS] Time between auto-retries of the API call on a temp failure [Default: 2000]
  * @property {int} [numMaxRetries] Max # of times a temporarily-failed request should be retried before propagating a permanent failure [Default: 5]
- * @property {int} [expiredBufferMS] Time before expiration, in milliseconds, when we begin to treat tokens as expired [Default: 30 sec.]
- * @property {int} [staleBufferMS] Time before expiration, in milliseconds, when we begin to treat tokens as stale [Default: 3 min.]
+ * @property {int} [expiredBufferMS] Time before expiration, in milliseconds, when we begin to treat tokens as expired [Default: 3 min.]
  * @property {Object} [request] Request options
  * @property {boolean} [request.strictSSL] Set to false to disable strict SSL checking, which allows using Dev APIs [Default: true]
  * @property {?AppAuthConfig} appAuth Optional configuration for App Auth
@@ -56,8 +55,8 @@ var defaults = {
 	uploadRequestTimeoutMS: 60000,
 	retryIntervalMS: 2000,
 	numMaxRetries: 5,
-	expiredBufferMS: 30000,
-	staleBufferMS: 180000,
+	expiredBufferMS: 180000,
+	staleBufferMS: 0, // DEPRECATED -- token expiration buffer will be max(expiredBufferMS, staleBufferMS)
 	appAuth: undefined,
 	iterators: false,
 	enterpriseID: undefined,


### PR DESCRIPTION
Fix the 150-second window between token staleness and expiration
where two Persistent Clients sharing a TokenStore could cause
one of the clients to generate 401 errors for all calls.  This
change removes the distinction between "stale" and "expired" tokens
and deprecates the staleBufferMS config option in favor of a single
expiredBufferMS option.  The old option will still be honored, but
tokens will be considered expired at the maximum of the stale
and expired times.