### PR TITLE
Allow for multiple scopes tokenexchange (fixes #173)

### DIFF
--- a/lib/token-manager.js
+++ b/lib/token-manager.js
@@ -362,7 +362,7 @@ TokenManager.prototype = {
 			grant_type: grantTypes.TOKEN_EXCHANGE,
 			subject_token_type: ACCESS_TOKEN_TYPE,
 			subject_token: accessToken,
-			scope: (typeof scopes === 'string' ? scopes : scopes.join(','))
+			scope: (typeof scopes === 'string' ? scopes : scopes.join(' '))
 		};
 
 		if (resource) {

--- a/tests/integration-test.js
+++ b/tests/integration-test.js
@@ -476,7 +476,7 @@ describe('Box Node SDK', function() {
 				assert.propertyVal(body, 'subject_token_type', 'urn:ietf:params:oauth:token-type:access_token');
 				assert.propertyVal(body, 'subject_token', TEST_ACCESS_TOKEN);
 				assert.propertyVal(body, 'resource', resource);
-				assert.propertyVal(body, 'scope', scopes.join(','));
+				assert.propertyVal(body, 'scope', scopes.join(' '));
 
 				return true;
 			})

--- a/tests/lib/token-manager-test.js
+++ b/tests/lib/token-manager-test.js
@@ -576,7 +576,7 @@ describe('token-manager', function() {
 				grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
 				subject_token_type: 'urn:ietf:params:oauth:token-type:access_token',
 				subject_token: TEST_ACCESS_TOKEN,
-				scope: 'item_preview,item_read'
+				scope: 'item_preview item_read'
 			};
 
 			var tokenInfo = {


### PR DESCRIPTION
Here is an example curl command for a working token exchange.

```
curl -X POST \
  https://api.box.com/oauth2/token \
  -F subject_token=<ACCESS_TOKEN> \
  -F subject_token_type=urn:ietf:params:oauth:token-type:access_token \
  -F 'scope=base_preview annotation_view_all annotation_edit' \
  -F grant_type=urn:ietf:params:oauth:grant-type:token-exchange \
  -F resource=https://api.box.com/2.0/files/<FILE_ID>
```

See how scopes use spaces, not commas.