### PR TITLE
Fix paging iterator for missing next_marker cases

### DIFF
--- a/lib/util/paging-iterator.js
+++ b/lib/util/paging-iterator.js
@@ -72,7 +72,6 @@ class PagingIterator {
 			throw new Error('Cannot create paging iterator for non-paged response!');
 		}
 
-		this.done = false;
 
 		var data = response.body;
 
@@ -83,13 +82,14 @@ class PagingIterator {
 			this.nextField = PAGING_MODES.MARKER;
 			this.nextValue = data.next_marker;
 		} else {
-			// throw new Error('Unable to determine paging strategy for response!');
+			// Default to a finished marker collection when there's no field present,
+			// since some endpoints indicate completed paging this way
 			this.nextField = PAGING_MODES.MARKER;
 			this.nextValue = null;
-			this.done = true;
 		}
 
 		this.limit = data.limit || data.entries.length;
+		this.done = false;
 
 		var href = response.request.href.split('?')[0];
 		this.options = {

--- a/lib/util/paging-iterator.js
+++ b/lib/util/paging-iterator.js
@@ -72,6 +72,8 @@ class PagingIterator {
 			throw new Error('Cannot create paging iterator for non-paged response!');
 		}
 
+		this.done = false;
+
 		var data = response.body;
 
 		if (Number.isSafeInteger(data.offset)) {
@@ -81,11 +83,13 @@ class PagingIterator {
 			this.nextField = PAGING_MODES.MARKER;
 			this.nextValue = data.next_marker;
 		} else {
-			throw new Error('Unable to determine paging strategy for response!');
+			// throw new Error('Unable to determine paging strategy for response!');
+			this.nextField = PAGING_MODES.MARKER;
+			this.nextValue = null;
+			this.done = true;
 		}
 
 		this.limit = data.limit || data.entries.length;
-		this.done = false;
 
 		var href = response.request.href.split('?')[0];
 		this.options = {

--- a/tests/lib/util/paging-iterator-test.js
+++ b/tests/lib/util/paging-iterator-test.js
@@ -73,22 +73,34 @@ describe('PagingIterator', function() {
 			}, Error);
 		});
 
-		it('should throw an error when response paging strategy cannot be determined', function() {
+		it('should default to a finished collection when response paging strategy cannot be determined', function() {
 
+			var chunk = [{}];
 			var response = {
-				body: {
-					entries: []
-				},
 				request: {
+					href: 'https://api.box.com/2.0/items?limit=1',
+					uri: {
+						query: 'limit=1'
+					},
+					headers: {},
 					method: 'GET'
+				},
+				body: {
+					entries: chunk,
+					limit: 1
 				}
 			};
 
-			assert.throws(function() {
-				/* eslint-disable no-unused-vars*/
-				var iterator = new PagingIterator(response, clientFake);
-				/* eslint-enable no-unused-vars*/
-			}, Error);
+			var iterator = new PagingIterator(response, clientFake);
+
+			assert.propertyVal(iterator, 'limit', 1);
+			assert.propertyVal(iterator, 'done', true);
+			assert.propertyVal(iterator, 'buffer', chunk);
+			assert.propertyVal(iterator, 'nextField', 'marker');
+			assert.propertyVal(iterator, 'nextValue', null);
+			assert.nestedPropertyVal(iterator, 'options.qs.limit', 1);
+			assert.nestedPropertyVal(iterator, 'options.qs.marker', null);
+			assert.notNestedProperty(iterator, 'options.headers.Authorization');
 		});
 
 		it('should correctly set up iterator when response is limit/offset type', function() {


### PR DESCRIPTION
Some Box API endpoints do not return any `next_marker` field when the collection has finished paging; in this case, we should treat the collection as finished, buffer the data in the response, and let the user iterate over the buffer.