### PR TITLE
Bump jsonwebtoken version

### DIFF
--- a/lib/token-manager.js
+++ b/lib/token-manager.js
@@ -302,9 +302,7 @@ TokenManager.prototype = {
 			issuer: this.config.clientID,
 			jwtid: uuid.v4(),
 			noTimestamp: !this.config.appAuth.verifyTimestamp,
-			headers: {
-				kid: this.config.appAuth.keyID
-			}
+			keyid: this.config.appAuth.keyID
 		};
 		var keyParams = {
 			key: this.config.appAuth.privateKey,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "http-status": "^0.2.2",
-    "jsonwebtoken": "^5.7.0",
+    "jsonwebtoken": "^8.1.0",
     "merge-options": "0.0.64",
     "promise-queue": "^2.2.3",
     "request": "^2.74.0",

--- a/tests/lib/token-manager-test.js
+++ b/tests/lib/token-manager-test.js
@@ -383,9 +383,7 @@ describe('token-manager', function() {
 				subject: TEST_ID,
 				issuer: config.clientID,
 				noTimestamp: false,
-				headers: {
-					kid: TEST_KEY_ID
-				}
+				keyid: TEST_KEY_ID
 			};
 			sandbox.stub(tokenManager, 'getTokens').returns(Promise.resolve());
 			sandbox.mock(jwtFake).expects('sign').withArgs(expectedClaims, keyParams, sinon.match(expectedOptions)).returns(TEST_WEB_TOKEN);


### PR DESCRIPTION
We were previously relying on a loose semver range to provide the
correct version of the jwa library (we need at least v1.1.0).  The
correct version was in our semver range, but we would also accept
lower versions that gave buggy behavior.  This commit bumps us to
the latest version of jsonwebtoken, which itself requires the right
version of the lower-level jws and jwa libraries.

Fixes #186 