### PR TITLE
Fix chunked uploader on streams from request library

### DIFF
--- a/lib/managers/files.js
+++ b/lib/managers/files.js
@@ -32,6 +32,7 @@ var urlPath = require('../util/url-path'),
 	httpStatusCodes = require('http-status'),
 	crypto = require('crypto'),
 	Promise = require('bluebird'),
+	Readable = require('stream').Readable,
 	ChunkedUploader = require('../chunked-uploader');
 
 // -----------------------------------------------------------------------------
@@ -1228,6 +1229,12 @@ Files.prototype.getUploadSession = function(sessionID, callback) {
  * @returns {Promise<ChunkedUploader>} A promise resolving to the chunked uploader
  */
 Files.prototype.getChunkedUploader = function(folderID, size, name, file, options, callback) {
+
+	if (file instanceof Readable) {
+		// Need to pause the stream immediately to prevent certain libraries,
+		// e.g. request from placing the stream into flowing mode and consuming bytes
+		file.pause();
+	}
 
 	return this.createUploadSession(folderID, size, name)
 		.then(sessionInfo => new ChunkedUploader(this.client, sessionInfo, file, size, options))

--- a/tests/integration-test.js
+++ b/tests/integration-test.js
@@ -16,6 +16,7 @@ var assert = require('chai').assert,
 	fs = require('fs'),
 	path = require('path'),
 	crypto = require('crypto'),
+	request = require('request'),
 	jwt = require('jsonwebtoken');
 
 describe('Box Node SDK', function() {
@@ -1092,5 +1093,109 @@ describe('Box Node SDK', function() {
 			});
 		});
 		return Promise.all([folderPromise, filePromise, batchPromise]);
+	});
+
+	it('should correctly upload stream from request module when using chunked uploader', function(done) {
+
+		// This test takes a while to run due to all the bytes being shuffled around,
+		// bumping up the timeout so we don't see flaky behavior if it runs long
+		this.timeout(4000);
+
+		var filePath = path.resolve(__dirname, './fixtures/test.pdf');
+		var uploadSessionID = 'o8qc3n58q73b95ywort2q3t';
+		var partCounter = 0;
+		var partSize = 8388608;
+		var bytesUploaded = 0;
+
+		// eslint-disable-next-line no-sync
+		var fileSize = fs.statSync(filePath).size;
+		var numParts = Math.ceil(fileSize / partSize);
+		var fileName = 'test.pdf';
+
+		var fileResponse = {
+			total_count: 1,
+			entries: [
+				{
+					type: 'file',
+					id: '12348765',
+					name: fileName,
+					size: fileSize
+				}
+			]
+		};
+
+		nock('https://www.example.com')
+			.get('/test-file.pdf')
+			.replyWithFile(200, filePath);
+
+		nock('https://upload.box.com').post('/api/2.0/files/upload_sessions')
+			.matchHeader('Authorization', function(authHeader) {
+				assert.equal(authHeader, 'Bearer ' + TEST_ACCESS_TOKEN);
+				return true;
+			})
+			.reply(201, {
+				total_parts: numParts,
+				part_size: partSize,
+				session_endpoints: {
+					list_parts: 'https://upload.box.com/api/2.0/files/upload-session/07C4B58DF2D79928A787CCB99A5FF37E/parts',
+					commit: 'https://upload.box.com/api/2.0/files/upload-session/07C4B58DF2D79928A787CCB99A5FF37E/commit',
+					log_event: 'https://upload.box.com/api/2.0/files/upload-session/07C4B58DF2D79928A787CCB99A5FF37E/log',
+					upload_part: 'https://upload.box.com/api/2.0/files/upload-session/07C4B58DF2D79928A787CCB99A5FF37E',
+					status: 'https://upload.box.com/api/2.0/files/upload-session/07C4B58DF2D79928A787CCB99A5FF37E',
+					abort: 'https://upload.box.com/api/2.0/files/upload-session/07C4B58DF2D79928A787CCB99A5FF37E'
+				},
+				session_expires_at: '2017-04-25T05:30:23Z',
+				id: uploadSessionID,
+				type: 'upload_session',
+				num_parts_processed: 0
+			})
+			.put('/api/2.0/files/upload_sessions/' + uploadSessionID)
+			.times(numParts)
+			.reply((uri, requestBody) => {
+				// requestBody is a hex-encoded string, need to decode to get raw length
+				var rawRequestBody = new Buffer(requestBody, 'hex');
+				bytesUploaded += rawRequestBody.length;
+				var partID = '' + partCounter;
+				var response = {
+					part: {
+						part_id: '' + partCounter,
+						offset: partCounter * partSize,
+						size: rawRequestBody.length,
+						sha1: crypto.createHash('sha1').update(partID).digest('base64')
+					}
+				};
+				partCounter += 1;
+				return response;
+			})
+			.post('/api/2.0/files/upload_sessions/' + uploadSessionID + '/commit')
+			.matchHeader('Authorization', function(authHeader) {
+				assert.equal(authHeader, 'Bearer ' + TEST_ACCESS_TOKEN);
+				return true;
+			})
+			.reply(201, fileResponse);
+
+		var sdk = new BoxSDK({
+			clientID: TEST_CLIENT_ID,
+			clientSecret: TEST_CLIENT_SECRET
+		});
+		var client = sdk.getBasicClient(TEST_ACCESS_TOKEN);
+
+		request.get('https://www.example.com/test-file.pdf').on('response', responseStream => {
+
+			client.files.getChunkedUploader('1234', fileSize, fileName, responseStream)
+				.then(uploader => {
+
+					uploader.on('uploadComplete', file => {
+						assert.deepEqual(file, fileResponse);
+						assert.equal(bytesUploaded, fileSize);
+						done();
+					});
+
+					uploader.on('error', err => done(err));
+					uploader.on('chunkError', err => done(err));
+
+					uploader.start();
+				});
+		});
 	});
 });


### PR DESCRIPTION
It looks like request places the stream into flowing mode by
default sometime after the "response" event is fired. This causes
inconsistency in trying to read the stream manually later after the
upload session is created since some bytes may have already been
read from the stream. This appears to only be an issue with streams
from request; streams from e.g. fs.createReadStream() or manually
using the Node HTTP library to get an IncomingMessage directly
don't have this problem because nothing places them into flowing
mode. I suspect this is due to request providing both a stream
interface and a callback interface via the same function call — in
order to pass the full response to a callback it would need to
start reading data from the underlying IncomingMessage at some
point.  This fix pauses the stream BEFORE creating the upload
session to avoid this problem.

Fixes #207