### PR TITLE
Use more informative param names in docs and code

### DIFF
--- a/docs/collaboration-whitelist.md
+++ b/docs/collaboration-whitelist.md
@@ -30,11 +30,11 @@ Get a Whitelisted Domain's Information
 --------------------------------------
 
 A collaboration whitelist's information can be retrieved by ID with
-[`collaborationWhitelist.getWhitelistedDomain(domainID, qs, callback)`]
+[`collaborationWhitelist.getWhitelistedDomain(domainID, options, callback)`]
 (http://opensource.box.com/box-node-sdk/CollaborationWhitelist.html#getWhitelistedDomain).
 
 ```js
-client.collaborationWhitelist.getWhitelistedDomain('12345', qs, callback);
+client.collaborationWhitelist.getWhitelistedDomain('12345', {}, callback);
 ```
 
 Get Whitelisted Domains for an Enterprise
@@ -83,7 +83,7 @@ Get an Exempt User's Information
 --------------------------------
 
 To retrieve a specific collaboration whitelist's information for a user you can use
-[`collaborationWhitelist.getExemption(exemptionID, qs, callback)`]
+[`collaborationWhitelist.getExemption(exemptionID, options, callback)`]
 (http://opensource.box.com/box-node-sdk/CollaborationWhitelist.html#getExemption).
 
 ```js

--- a/docs/collaborations.md
+++ b/docs/collaborations.md
@@ -58,7 +58,7 @@ client.collaborations.createWithGroupID('56473', '987654', client.collaborationR
 Edit a Collaboration
 --------------------
 
-A collaboration can be edited by calling [`collaborations.update(collaborationID, options, callback)`](http://opensource.box.com/box-node-sdk/Collaborations.html#update)
+A collaboration can be edited by calling [`collaborations.update(collaborationID, updates, callback)`](http://opensource.box.com/box-node-sdk/Collaborations.html#update)
 with the fields to be updated.  For example, to change the role of a collaboration:
 
 ```js
@@ -77,7 +77,7 @@ client.collaborations.delete('56473', callback);
 Get a Collaboration's Information
 ---------------------------------
 
-Calling [`collaborations.get(collaborationID, qs, callback)`](http://opensource.box.com/box-node-sdk/Collaborations.html#get) on a
+Calling [`collaborations.get(collaborationID, options, callback)`](http://opensource.box.com/box-node-sdk/Collaborations.html#get) on a
 collaboration returns a snapshot of the collaboration's info.
 
 ```js
@@ -88,7 +88,7 @@ Get the Collaborations on a Folder
 ----------------------------------
 
 You can get all of the collaborations on a folder by calling
-[`folders.getCollaborations(folderID, qs, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#getCollaborations)
+[`folders.getCollaborations(folderID, options, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#getCollaborations)
 on the folder.
 
 ```js

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -22,7 +22,7 @@ Get the Items in a Collection
 -----------------------------
 
 Get a list of the items in a collection by passing the ID of the collection to
-[`collections.getItems(collectionID, qs, callback)`](http://opensource.box.com/box-node-sdk/Collections.html#getItems).
+[`collections.getItems(collectionID, options, callback)`](http://opensource.box.com/box-node-sdk/Collections.html#getItems).
 
 ```js
 client.collections.getItems('81934', {fields: 'name'}, callback);

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -14,7 +14,7 @@ Get a Comment's Information
 ---------------------------
 
 Calling
-[`comments.get(commentID, qs, callback)`](http://opensource.box.com/box-node-sdk/Comments.html#get)
+[`comments.get(commentID, options, callback)`](http://opensource.box.com/box-node-sdk/Comments.html#get)
 on a comment returns a snapshot of the comment's info.
 
 ```js
@@ -25,7 +25,7 @@ Get the Comments on a File
 --------------------------
 
 You can get all of the comments on a file by calling the
-[`files.getComments(fileID, qs, callback)`](http://opensource.box.com/box-node-sdk/Files.html#getComments) method.
+[`files.getComments(fileID, options, callback)`](http://opensource.box.com/box-node-sdk/Files.html#getComments) method.
 
 ```js
 client.files.getComments('98765', {fields: 'created_by,created_at,tagged_message'}, callback);
@@ -57,7 +57,7 @@ Change a Comment's Message
 --------------------------
 
 The message of a comment can be changed with the
-[`comments.update(commentID, options, callback)`](http://opensource.box.com/box-node-sdk/Comments.html#update)
+[`comments.update(commentID, updates, callback)`](http://opensource.box.com/box-node-sdk/Comments.html#update)
 method.
 
 ```js

--- a/docs/events.md
+++ b/docs/events.md
@@ -63,7 +63,7 @@ client.events.getCurrentStreamPosition(callback);
 ### Get Events
 
 To get the latest chunk of events, you can call
-[`events.get(qs, callback)`](http://opensource.box.com/box-node-sdk/Events.html#get).
+[`events.get(options, callback)`](http://opensource.box.com/box-node-sdk/Events.html#get).
 
 ```js
 client.events.get(null, callback);

--- a/docs/files.md
+++ b/docs/files.md
@@ -44,16 +44,15 @@ Get a File's Information
 ------------------------
 
 Calling
-[`files.get(fileID, qs, callback)`](http://opensource.box.com/box-node-sdk/Files.html#get)
+[`files.get(fileID, options, callback)`](http://opensource.box.com/box-node-sdk/Files.html#get)
 on a file returns a snapshot of the file's info.
 
 ```js
 client.files.get('75937', null, callback);
 ```
 
-Requesting information for only the fields you need with the `fields` query
-string parameter can improve performance and reduce the size of the network
-request.
+Requesting information for only the fields you need with the `fields` option
+can improve performance and reduce the size of the network request.
 
 ```js
 // Only get information about a few specific fields.
@@ -64,7 +63,7 @@ Update a File's Information
 ---------------------------
 
 Updating a file's information is done by calling
-[`files.update(fileID, options, callback)`](http://opensource.box.com/box-node-sdk/Files.html#update)
+[`files.update(fileID, updates, callback)`](http://opensource.box.com/box-node-sdk/Files.html#update)
 with the fields to be updated.
 
 ```js
@@ -74,15 +73,14 @@ client.files.update('75937', {name : 'New Name'}, callback);
 Get a File's Tasks
 ------------------
 Calling the
-[`files.getTasks(fileID, qs, callback)`](http://opensource.box.com/box-node-sdk/Files.html#getTasks)
+[`files.getTasks(fileID, options, callback)`](http://opensource.box.com/box-node-sdk/Files.html#getTasks)
 method will retrieve all of the tasks for given file.
 
 ```js
 client.files.getTasks('75937', null, callback);
 ```
-Requesting information for only the fields you need with the `fields` query
-string parameter can improve performance and reduce the size of the network
-request.
+Requesting information for only the fields you need with the `fields` option
+can improve performance and reduce the size of the network request.
 
 ```js
 // Only get information about a few specific fields.
@@ -93,7 +91,7 @@ Download a File
 ---------------
 
 A file can be downloaded by calling
-[`files.getReadStream(fileID, qs, callback)`](http://opensource.box.com/box-node-sdk/Files.html#getReadStream),
+[`files.getReadStream(fileID, options, callback)`](http://opensource.box.com/box-node-sdk/Files.html#getReadStream),
 which provides an instance of `stream.Readable` that will yield the file's contents.
 
 ```js
@@ -114,7 +112,7 @@ Get a File's Download URL
 -------------------------
 
 The download URL of a file an be retrieved by calling
-[`files.getDownloadURL(fileID, qs, callback)`](http://opensource.box.com/box-node-sdk/Files.html#getDownloadURL).
+[`files.getDownloadURL(fileID, options, callback)`](http://opensource.box.com/box-node-sdk/Files.html#getDownloadURL).
 It returns the URL as a string.
 
 ```js
@@ -378,7 +376,7 @@ Upload Preflight Check
 ----------------------
 
 The Preflight Check in the
-[`files.preflightUploadFile(parentFolderID, fileData, qs, callback)`](http://opensource.box.com/box-node-sdk/Files.html#preflightUploadFile)
+[`files.preflightUploadFile(parentFolderID, fileData, options, callback)`](http://opensource.box.com/box-node-sdk/Files.html#preflightUploadFile)
 method will verify that a file will be accepted by Box before
 you send all the bytes over the wire.  Preflight checks verify all permissions
 as if the file was actually uploaded including:
@@ -408,7 +406,7 @@ client.files.preflightUploadFile(
 ```
 
 For uploading a new version of a file, use the
-[`files.preflightUploadNewFileVersion(fileID, fileData, qs, callback)`](http://opensource.box.com/box-node-sdk/Files.html#preflightUploadNewFileVersion)
+[`files.preflightUploadNewFileVersion(fileID, fileData, options, callback)`](http://opensource.box.com/box-node-sdk/Files.html#preflightUploadNewFileVersion)
 method.
 
 ```js
@@ -472,14 +470,13 @@ client.files.deletePermanently('12345', callback);
 Get a Trashed File
 ------------------
 
-Information about a file in the trash can be retrieved with the [`files.getTrashedFile(fileID, qs, callback)`](http://opensource.box.com/box-node-sdk/Files.html#getTrashedFile) method.
+Information about a file in the trash can be retrieved with the [`files.getTrashedFile(fileID, options, callback)`](http://opensource.box.com/box-node-sdk/Files.html#getTrashedFile) method.
 ```js
-client.files.getTrashedFile('12345', qs, callback);
+client.files.getTrashedFile('12345', {}, callback);
 ```
 
-Requesting information for only the fields you need with the `fields` query
-string parameter can improve performance and reduce the size of the network
-request.
+Requesting information for only the fields you need with the `fields` option
+can improve performance and reduce the size of the network request.
 
 ```js
 // Only get information about a few specific fields.
@@ -490,15 +487,14 @@ Get File Versions
 -----------------
 
 Retrieve a list of previous versions of a file by calling the
-[`files.getVersions(fileID, qs, callback)`](http://opensource.box.com/box-node-sdk/Files.html#getVersions).
+[`files.getVersions(fileID, options, callback)`](http://opensource.box.com/box-node-sdk/Files.html#getVersions).
 
 ```js
 client.files.getVersions('12345', null, callback);
 ```
 
-Requesting information for only the fields you need with the `fields` query
-string parameter can improve performance and reduce the size of the network
-request.
+Requesting information for only the fields you need with the `fields` option
+can improve performance and reduce the size of the network request.
 
 ```js
 // Only get information about a few specific fields.
@@ -534,8 +530,8 @@ Download a Previous Version of a File
 
 For users with premium accounts, previous versions of a file can be downloaded
 by calling
-[`files.getReadStream(fileID, qs, callback)`](http://opensource.box.com/box-node-sdk/Files.html#getReadStream)
-with a `version` query string parameter.
+[`files.getReadStream(fileID, options, callback)`](http://opensource.box.com/box-node-sdk/Files.html#getReadStream)
+with `options.version` specified.
 
 ```js
 var fs = require('fs');
@@ -565,8 +561,10 @@ client.files.deleteVersion('12345', '98768', callback)
 Create a Shared Link
 --------------------
 
-A shared link for a file can be generated by passing shared link parameters to
-[`files.update(fileID, options, callback)`](http://opensource.box.com/box-node-sdk/Files.html#update).
+A shared link for a file can be generated by passing an object containing the desired
+shared link access level to
+[`files.update(fileID, updates, callback)`](http://opensource.box.com/box-node-sdk/Files.html#update)
+in the `updates` parameter.
 
 ```js
 client.files.update('93745', {shared_link: client.accessLevels.DEFAULT}, callback)
@@ -585,7 +583,7 @@ Get Thumbnail
 -------------
 
 A thumbnail for a file can be retrieved by calling
-[`files.getThumbnail(fileID, qs, callback)`](http://opensource.box.com/box-node-sdk/Files.html#getThumbnail).
+[`files.getThumbnail(fileID, options, callback)`](http://opensource.box.com/box-node-sdk/Files.html#getThumbnail).
 
 ```js
 client.files.getThumbnail('12345', null, function(error, response) {
@@ -747,16 +745,15 @@ client.files.deleteMetadata('67890', client.metadata.scopes.GLOBAL, client.metad
 Get Watermark
 -------------
 To get watermark information for a file call the
-[`files.getWatermark(fileID, qs, callback)`](http://opensource.box.com/box-node-sdk/Files.html#getWatermark)
+[`files.getWatermark(fileID, options, callback)`](http://opensource.box.com/box-node-sdk/Files.html#getWatermark)
 method.
 
 ```js
 client.files.getWatermark('75937', null, callback);
 ```
 
-Requesting information for only the fields you need with the `fields` query
-string parameter can improve performance and reduce the size of the network
-request.
+Requesting information for only the fields you need with the `fields` option
+can improve performance and reduce the size of the network request.
 
 ```js
 // Only get information about a few specific fields.

--- a/docs/folders.md
+++ b/docs/folders.md
@@ -32,8 +32,8 @@ Get a Folder's Information
 --------------------------
 
 Folder information can be retrieved by calling the
-[`folders.get(folderID, queryString, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#get)
-method. Use the `queryString` parameter to specify the desired fields. Requesting
+[`folders.get(folderID, options, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#get)
+method. Use the `fields` option to specify the desired fields. Requesting
 information for only the fields you need can improve performance and reduce the
 size of the network request.
 
@@ -46,7 +46,8 @@ client.folders.get(
 ```
 
 The user's root folder can be accessed by calling the
-[`folders.get(folderID, queryString, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#get) method with the `folderID` value of 0.
+[`folders.get(folderID, options, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#get)
+method with the `folderID` value of 0.
 
 ```js
 client.folders.get(
@@ -60,7 +61,10 @@ client.folders.get(
 Get a Folder's Items
 --------------------
 
-Folder items can be retrieved by calling the [`folders.getItems(folderID, queryString, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#getItems) method. Use the `queryString` parameter to specify the desired fields and control the result set paging. Requesting information for only the fields you need can improve performance and reduce the size of the network request.
+Folder items can be retrieved by calling the
+[`folders.getItems(folderID, options, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#getItems)
+method. Use the `fields` option to specify the desired fields and control the result set paging.
+Requesting information for only the fields you need can improve performance and reduce the size of the network request.
 
 ```js
 client.folders.getItems(
@@ -78,7 +82,9 @@ client.folders.getItems(
 Update a Folder's Information
 -----------------------------
 
-Updating a folder's information is done by calling the [`folders.update(folderID, queryString, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#update) method. Use the `queryString` parameter to specify the fields to update, along with their new values.
+Updating a folder's information is done by calling the 
+[`folders.update(folderID, updates, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#update)
+method. Use the `updates` parameter to specify the fields to update and their new values.
 
 ```js
 client.folders.update('12345', {sync_state: 'synced'}, callback);
@@ -125,7 +131,7 @@ client.folders.move('12345', '67890', callback);
 Rename a Folder
 ---------------
 
-Use the [`folders.update(folderID, queryString, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#update) method to rename a folder by passing a new name for the folder in the `queryString`.
+Use the [`folders.update(folderID, updates, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#update) method to rename a folder by passing a new name for the folder in `updates.name`.
 
 ```js
 client.folders.update('12345', {name: 'New Name'}, callback);
@@ -135,7 +141,7 @@ client.folders.update('12345', {name: 'New Name'}, callback);
 Delete a Folder
 ---------------
 
-A folder can be deleted with the [`folders.delete(folderID, qs, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#delete) method.
+A folder can be deleted with the [`folders.delete(folderID, options, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#delete) method.
 
 ```js
 client.folders.delete('12345', {recursive: true}, callback);
@@ -145,7 +151,7 @@ client.folders.delete('12345', {recursive: true}, callback);
 Get a Trashed Folder
 ---------------
 
-Information about a folder in the trash can be retrieved with the [`folders.getTrashedFolder(folderID, qs, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#getTrashedFolder) method.
+Information about a folder in the trash can be retrieved with the [`folders.getTrashedFolder(folderID, options, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#getTrashedFolder) method.
 
 ```js
 client.folders.getTrashedFolder('12345', {fields: 'name,shared_link,permissions,collections,sync_state'},
@@ -189,7 +195,7 @@ Create a Shared Link for a Folder
 ---------------------------------
 
 You can create a shared link for a folder by calling the
-[`folders.update(folderID, queryString, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#update) method, passing a new `shared_link` value in the `queryString` parameter.
+[`folders.update(folderID, updates, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#update) method, passing a new `shared_link` value in the `updates` parameter.
 
 ```js
 client.folders.update(
@@ -210,7 +216,7 @@ A set of shared link access level constants are available through the SDK for co
 Get Collaborations for a Folder
 -----------------------------------
 
-The [`folders.getCollaborations(folderID, queryString, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#getCollaborations) method will return a collection of collaboration objects for a folder. Use the `queryString` parameter to specify the desired collaboration fields and control the result set paging.
+The [`folders.getCollaborations(folderID, options, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#getCollaborations) method will return a collection of collaboration objects for a folder. Use the `options` parameter to specify the desired collaboration fields and control the result set paging.
 
 ```js
 client.folders.getCollaborations(
@@ -224,7 +230,7 @@ client.folders.getCollaborations(
 );
 ```
 
-All collaborations can be returned by passing `null` for the `queryString` parameter.
+All collaborations can be returned by passing `null` for the `options` parameter.
 
 ```js
 client.folders.getCollaborations('12345', null, callback);
@@ -306,7 +312,7 @@ client.folders.deleteMetadata('67890', client.metadata.scopes.GLOBAL, client.met
 Get Watermark
 -------------
 To get watermark information for a folder call the
-[`folders.getWatermark(folderID, qs, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#getWatermark)
+[`folders.getWatermark(folderID, options, callback)`](http://opensource.box.com/box-node-sdk/Folders.html#getWatermark)
 method.
 
 ```js

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -38,9 +38,8 @@ method.
 client.groups.get('78346', null, callback);
 ```
 
-Requesting information for only the fields you need with the `fields` query
-string parameter can improve performance and reduce the size of the network
-request.
+Requesting information for only the fields you need with the `fields` option
+can improve performance and reduce the size of the network request.
 
 ```js
 client.groups.get('12345', {fields: 'name,description'}, callback);
@@ -50,8 +49,8 @@ Update Group
 ------------
 
 To change the properties of a group object, call the
-[`groups.update(groupID, options, callback)`](http://opensource.box.com/box-node-sdk/Groups.html#update)
-method with `options` being the set of properties to update.
+[`groups.update(groupID, updates, callback)`](http://opensource.box.com/box-node-sdk/Groups.html#update)
+method with `updates` being the set of properties to update.
 
 ```js
 client.groups.update('873645', {name: 'New group name'}, callback);
@@ -91,9 +90,8 @@ method.
 client.groups.getMembership('38456', null, callback);
 ```
 
-Requesting information for only the fields you need with the `fields` query
-string parameter can improve performance and reduce the size of the network
-request.
+Requesting information for only the fields you need with the `fields` option
+can improve performance and reduce the size of the network request.
 
 ```js
 // Get a list of users in the group and when they were added
@@ -105,7 +103,7 @@ Update Membership
 
 To update a membership record, call the
 [`groups.updateMembership(membershipID, options, callback)`](http://opensource.box.com/box-node-sdk/Groups.html#updateMembership)
-method with `options` being the properties to update.
+method with `updates` being the properties to update.
 
 ```js
 // Promote a user to group admin

--- a/docs/legal-hold-policies.md
+++ b/docs/legal-hold-policies.md
@@ -31,16 +31,15 @@ client.legalHoldPolicies.create('IRS Audit', null, callback);
 Get Legal Hold Policy
 --------------------
 
-To retrieve information about a specific legal hold policy, call the [`legalHoldPolicies.get(policyID, qs, callback)`](http://opensource.box.com/box-node-sdk/LegalHoldPolicies.html#get)
+To retrieve information about a specific legal hold policy, call the [`legalHoldPolicies.get(policyID, options, callback)`](http://opensource.box.com/box-node-sdk/LegalHoldPolicies.html#get)
 method.
 
 ```js
 client.legalHoldPolicies.get('12345', null, callback);
 ```
 
-Requesting information for only the fields you need with the `fields` query
-string parameter can improve performance and reduce the size of the network
-request.
+Requesting information for only the fields you need with the `fields` option
+can improve performance and reduce the size of the network request.
 
 ```js
 client.legalHoldPolicies.get('12345', {fields: 'policy_name,created_at,created_by'}, callback);
@@ -49,8 +48,9 @@ client.legalHoldPolicies.get('12345', {fields: 'policy_name,created_at,created_b
 Update Legal Hold Policy
 ------------------------
 
-To update or modify an existing legal hold policy, call the [`legalHoldPolicies.update(policyID, options, callback)`](http://opensource.box.com/box-node-sdk/LegalHoldPolicies.html#update)
-method where `options` is the set of key-value pairs to be updated on the policy object.
+To update or modify an existing legal hold policy, call the
+[`legalHoldPolicies.update(policyID, updates, callback)`](http://opensource.box.com/box-node-sdk/LegalHoldPolicies.html#update)
+method where `updates` is the set of key-value pairs to be updated on the policy object.
 
 ```js
 client.legalHoldPolicies.update('893465', {release_notes: 'Retired'}, callback);
@@ -72,7 +72,7 @@ Get Enterprise Legal Hold Policies
 ----------------------------------
 
 To retrieve all of the legal hold policies for the given enterprise, call the
-[`legalHoldPolicies.getAll(qs, callback)`](http://opensource.box.com/box-node-sdk/LegalHoldPolicies.html#getAll) method.
+[`legalHoldPolicies.getAll(options, callback)`](http://opensource.box.com/box-node-sdk/LegalHoldPolicies.html#getAll) method.
 
 ```js
 client.legalHoldPolicies.getAll({policy_name: 'Important'}, callback);
@@ -82,7 +82,7 @@ Get Legal Hold Policy Assignments
 ---------------------------------
 
 To get a list of all legal hold policy assignments associated with a specified legal hold policy,
-call the [`legalHoldPolicies.getAssignments(policyID, qs, callback)`](http://opensource.box.com/box-node-sdk/LegalHoldPolicies.html#getAssignments)
+call the [`legalHoldPolicies.getAssignments(policyID, options, callback)`](http://opensource.box.com/box-node-sdk/LegalHoldPolicies.html#getAssignments)
 method.
 
 ```js
@@ -115,16 +115,15 @@ Get Legal Hold Policy Assignment
 --------------------------------
 
 To retrieve information about a legal hold policy assignment, call the
-[`legalHoldPolicies.getAssignment(assignmentID, qs, callback)`](http://opensource.box.com/box-node-sdk/LegalHoldPolicies.html#getAssignment)
+[`legalHoldPolicies.getAssignment(assignmentID, options, callback)`](http://opensource.box.com/box-node-sdk/LegalHoldPolicies.html#getAssignment)
 method.
 
 ```js
 client.legalHoldPolicies.getAssignment('8762345', null, callback);
 ```
 
-Requesting information for only the fields you need with the `fields` query
-string parameter can improve performance and reduce the size of the network
-request.
+Requesting information for only the fields you need with the `fields` option
+can improve performance and reduce the size of the network request.
 
 ```js
 client.legalHoldPolicies.getAssignment('8762345', {fields: 'id,assigned_by,assigned_at'}, callback);
@@ -135,16 +134,15 @@ Get File Version Legal Hold
 
 A file version legal hold is a record for a held file version.  To get information
 for a specific file version legal hold record, call the
-[`legalHoldPolicies.getFileVersionLegalHold(legalHoldID, qs, callback)`](http://opensource.box.com/box-node-sdk/LegalHoldPolicies.html#getFileVersionLegalHold)
+[`legalHoldPolicies.getFileVersionLegalHold(legalHoldID, options, callback)`](http://opensource.box.com/box-node-sdk/LegalHoldPolicies.html#getFileVersionLegalHold)
 method.
 
 ```js
 client.legalHoldPolicies.getFileVersionLegalHold('23645789', null, callback);
 ```
 
-Requesting information for only the fields you need with the `fields` query
-string parameter can improve performance and reduce the size of the network
-request.
+Requesting information for only the fields you need with the `fields` option
+can improve performance and reduce the size of the network request.
 
 ```js
 client.legalHoldPolicies.getFileVersionLegalHold('8762345', {fields: 'id,file'}, callback);
@@ -154,7 +152,7 @@ Get File Version Legal Holds
 ----------------------------
 
 To retrieve a list of all file version legal holds for a given policy, call the
-[`legalHoldPolicies.getAllFileVersionLegalHolds(policyID, qs, callback)`](http://opensource.box.com/box-node-sdk/LegalHoldPolicies.html#getAllFileVersionLegalHolds)
+[`legalHoldPolicies.getAllFileVersionLegalHolds(policyID, options, callback)`](http://opensource.box.com/box-node-sdk/LegalHoldPolicies.html#getAllFileVersionLegalHolds)
 method.
 
 ```js

--- a/docs/retention-policies.md
+++ b/docs/retention-policies.md
@@ -29,16 +29,15 @@ client.retentionPolicies.create('Important Files!', client.retentionPolicies.pol
 Get Retention Policy
 --------------------
 
-To retrieve information about a specific retention policy, call the [`retentionPolicies.get(policyID, qs, callback)`](http://opensource.box.com/box-node-sdk/RetentionPolicies.html#get)
+To retrieve information about a specific retention policy, call the [`retentionPolicies.get(policyID, options, callback)`](http://opensource.box.com/box-node-sdk/RetentionPolicies.html#get)
 method.
 
 ```js
 client.retentionPolicies.get('12345', null, callback);
 ```
 
-Requesting information for only the fields you need with the `fields` query
-string parameter can improve performance and reduce the size of the network
-request.
+Requesting information for only the fields you need with the `fields` option
+can improve performance and reduce the size of the network request.
 
 ```js
 client.retentionPolicies.get('12345', {fields: 'policy_name,created_at,created_by'}, callback);
@@ -47,8 +46,8 @@ client.retentionPolicies.get('12345', {fields: 'policy_name,created_at,created_b
 Update Retention Policy
 -----------------------
 
-To update or modify an existing retention policy, call the [`retentionPolicies.update(policyID, options, callback)`](http://opensource.box.com/box-node-sdk/RetentionPolicies.html#update)
-method where `options` is the set of key-value pairs to be updated on the policy object.
+To update or modify an existing retention policy, call the [`retentionPolicies.update(policyID, updates, callback)`](http://opensource.box.com/box-node-sdk/RetentionPolicies.html#update)
+method where `updates` is the set of key-value pairs to be updated on the policy object.
 
 ```js
 client.retentionPolicies.update('893465', {status: 'retired'}, callback);
@@ -57,7 +56,7 @@ client.retentionPolicies.update('893465', {status: 'retired'}, callback);
 Get Enterprise Retention Policies
 ---------------------------------
 
-To retrieve all of the retention policies for the given enterprise, call the [`retentionPolicies.getAll(qs, callback)`](http://opensource.box.com/box-node-sdk/RetentionPolicies.html#getAll) method.
+To retrieve all of the retention policies for the given enterprise, call the [`retentionPolicies.getAll(options, callback)`](http://opensource.box.com/box-node-sdk/RetentionPolicies.html#getAll) method.
 
 ```js
 client.retentionPolicies.getAll({policy_name: 'Important'}, callback);
@@ -67,7 +66,7 @@ Get Retention Policy Assignments
 --------------------------------
 
 To get a list of all retention policy assignments associated with a specified retention policy,
-call the [`retentionPolicies.getAssignments(policyID, qs, callback)`](http://opensource.box.com/box-node-sdk/RetentionPolicies.html#getAssignments)
+call the [`retentionPolicies.getAssignments(policyID, options, callback)`](http://opensource.box.com/box-node-sdk/RetentionPolicies.html#getAssignments)
 method.
 
 ```js
@@ -92,16 +91,15 @@ Get Retention Policy Assignment
 -------------------------------
 
 To retrieve information about a retention policy assignment, call the
-[`retentionPolicies.getAssignment(assignmentID, qs, callback)`](http://opensource.box.com/box-node-sdk/RetentionPolicies.html#getAssignment)
+[`retentionPolicies.getAssignment(assignmentID, options, callback)`](http://opensource.box.com/box-node-sdk/RetentionPolicies.html#getAssignment)
 method.
 
 ```js
 client.retentionPolicies.getAssignment('8762345', null, callback);
 ```
 
-Requesting information for only the fields you need with the `fields` query
-string parameter can improve performance and reduce the size of the network
-request.
+Requesting information for only the fields you need with the `fields` option
+can improve performance and reduce the size of the network request.
 
 ```js
 client.retentionPolicies.getAssignment('8762345', {fields: 'id,assigned_by,assigned_at'}, callback);
@@ -112,16 +110,15 @@ Get File Version Retention
 
 A file version retention is a record for a retained file version.  To get information
 for a specific file version retention record, call the
-[`retentionPolicies.getFileVersionRetention(retentionID, qs, callback)`](http://opensource.box.com/box-node-sdk/RetentionPolicies.html#getFileVersionRetention)
+[`retentionPolicies.getFileVersionRetention(retentionID, options, callback)`](http://opensource.box.com/box-node-sdk/RetentionPolicies.html#getFileVersionRetention)
 method.
 
 ```js
 client.retentionPolicies.getFileVersionRetention('23645789', null, callback);
 ```
 
-Requesting information for only the fields you need with the `fields` query
-string parameter can improve performance and reduce the size of the network
-request.
+Requesting information for only the fields you need with the `fields` option
+can improve performance and reduce the size of the network request.
 
 ```js
 client.retentionPolicies.getFileVersionRetention('8762345', {fields: 'id,winning_retention_policy'}, callback);
@@ -132,8 +129,8 @@ Get File Version Retentions
 
 To retrieve a list of all file version retentions for the given enterprise or to filter for
 some category of file version retention records, call the
-[`retentionPolicies.getAllFileVersionRetentions(qs, callback)`](http://opensource.box.com/box-node-sdk/RetentionPolicies.html#getAllFileVersionRetentions)
-method.  Filters are passed via the `qs` parameter.
+[`retentionPolicies.getAllFileVersionRetentions(options, callback)`](http://opensource.box.com/box-node-sdk/RetentionPolicies.html#getAllFileVersionRetentions)
+method.  Filters are passed via the `options` parameter.
 
 ```js
 // Get all retention records
@@ -142,9 +139,9 @@ client.retentionPolicies.getAllFileVersionRetentions(null, callback);
 
 ```js
 // Get only the retention records set to delete items before a certain date
-var filters = {
+var options = {
 	disposition_action: client.retentionPolicies.dispositionActions.PERMANENTLY_DELETE,
 	disposition_before: '2038-01-01T12:34:56-08:00'
 };
-client.retentionPolicies.getAllFileVersionRetentions(filters, callback);
+client.retentionPolicies.getAllFileVersionRetentions(options, callback);
 ```

--- a/docs/shared-items.md
+++ b/docs/shared-items.md
@@ -8,7 +8,7 @@ Shared Items represent files and folders on Box accessed via a shared link.
 Get a Shared Item
 -----------------
 
-To get the file or folder information for a shared link, call the [`sharedItems.get(url, password, queryString, callback)`](http://opensource.box.com/box-node-sdk/SharedItems.html#get) method. The `password` parameter should be passed as a `null` value if none is required.
+To get the file or folder information for a shared link, call the [`sharedItems.get(url, password, options, callback)`](http://opensource.box.com/box-node-sdk/SharedItems.html#get) method. The `password` parameter should be passed as a `null` value if none is required.
 
 ```js
 client.sharedItems.get(

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -32,15 +32,14 @@ client.tasks.create(
 Get a Task's Information
 ------------------------
 
-To get a task information call the [`tasks.get(taskID, qs, callback)`](http://opensource.box.com/box-node-sdk/Tasks.html#get) method.
+To get a task information call the [`tasks.get(taskID, options, callback)`](http://opensource.box.com/box-node-sdk/Tasks.html#get) method.
 
 ```js
 client.tasks.get('1234', null, callback);
 ```
 
-Requesting information for only the fields you need with the `fields` query
-string parameter can improve performance and reduce the size of the network
-request.
+Requesting information for only the fields you need with the `fields` option
+can improve performance and reduce the size of the network request.
 
 ```js
 client.tasks.get('1234', {fields: 'message,is_completed'}, callback);
@@ -50,8 +49,8 @@ Update a Task
 -------------
 
 To update a task call the
-[`tasks.update(taskID, options, callback)`](http://opensource.box.com/box-node-sdk/Tasks.html#update)
-method.
+[`tasks.update(taskID, updates, callback)`](http://opensource.box.com/box-node-sdk/Tasks.html#update)
+method with the set of fields to update and their new values.
 
 ```js
 client.tasks.update(
@@ -87,9 +86,8 @@ method.
 client.tasks.getAssignments('83476', null, callback);
 ```
 
-Requesting information for only the fields you need with the `fields` query
-string parameter can improve performance and reduce the size of the network
-request.
+Requesting information for only the fields you need with the `fields` option
+can improve performance and reduce the size of the network request.
 
 ```js
 client.tasks.getAssignments('83476', {fields: 'assigned_to'}, callback);
@@ -106,9 +104,8 @@ method with the ID of the assignment to get.
 client.tasks.getAssignment('83476', null, callback);
 ```
 
-Requesting information for only the fields you need with the `fields` query
-string parameter can improve performance and reduce the size of the network
-request.
+Requesting information for only the fields you need with the `fields` option
+can improve performance and reduce the size of the network request.
 
 ```js
 client.tasks.getAssignment('83476', {fields: 'item,assigned_to'}, callback);

--- a/docs/terms-of-service.md
+++ b/docs/terms-of-service.md
@@ -42,15 +42,14 @@ method.
 client.termsOfService.get('1234', null, callback);
 ```
 
-Requesting information for only the fields you need with the `option` query
-string parameter can improve performance and reduce the size of the network
-request.
+Requesting information for only the fields you need with the `fields` option
+can improve performance and reduce the size of the network request.
 
 Update a Terms of Service for an Enterprise
 -------------------------------------------
 
-To update a terms of service call the [`termsOfService.update(termsOfServicesID, options, callback)`](http://opensource.box.com/box-node-sdk/TermsOfService.html#update)
-method.
+To update a terms of service call the [`termsOfService.update(termsOfServicesID, updates, callback)`](http://opensource.box.com/box-node-sdk/TermsOfService.html#update)
+method with the fields to update and their new values.
 
 ```js
 client.termsOfService.update('1234', 

--- a/docs/users.md
+++ b/docs/users.md
@@ -15,15 +15,14 @@ Users represent an individual's account on Box.
 Get User's Information
 ----------------------------------
 
-To get a user call the [`users.get(userID, queryString, callback)`](http://opensource.box.com/box-node-sdk/Users.html#get) method.
+To get a user call the [`users.get(userID, options, callback)`](http://opensource.box.com/box-node-sdk/Users.html#get) method.
 
 ```js
 client.users.get('123', null, callback);
 ```
 
-Requesting information for only the fields you need with the `fields` query
-string parameter can improve performance and reduce the size of the network
-request.
+Requesting information for only the fields you need with the `fields` option
+can improve performance and reduce the size of the network request.
 
 ```js
 // Only get information about a few specific fields.
@@ -34,7 +33,7 @@ client.users.get('123', {fields: 'name,login'}, callback);
 Get the Current User's Information
 ----------------------------------
 
-To get the current user call the [`users.get(userID, queryString, callback)`](http://opensource.box.com/box-node-sdk/Users.html#get) method with the `CURRENT_USER_ID` constant.
+To get the current user call the [`users.get(userID, options, callback)`](http://opensource.box.com/box-node-sdk/Users.html#get) method with the `CURRENT_USER_ID` constant.
 
 ```js
 client.users.get(client.CURRENT_USER_ID, null, callback);
@@ -45,8 +44,8 @@ Update User
 -----------
 
 To update a user call the
-[`users.update(userID, options, callback)`](http://opensource.box.com/box-node-sdk/Users.html#update)
-method where `options` contains the fields to update.
+[`users.update(userID, updates, callback)`](http://opensource.box.com/box-node-sdk/Users.html#update)
+method where `updates` contains the fields to update.
 
 ```js
 client.users.update('123', {name: 'New Name', job_title: 'New Title', phone: '555-1111'}, callback);
@@ -64,7 +63,7 @@ Delete User
 -----------
 
 To delete a user call the
-[`users.delete(userID, qs, callback)`](http://opensource.box.com/box-node-sdk/Users.html#delete)
+[`users.delete(userID, options, callback)`](http://opensource.box.com/box-node-sdk/Users.html#delete)
 method.  If the user still has files in their account and the `force` parameter
 is not sent, an error is returned.
 

--- a/docs/web-links.md
+++ b/docs/web-links.md
@@ -34,9 +34,8 @@ Get a Web Link's information
 client.weblinks.get('1234', null, callback);
 ```
 
-Requesting information for only the fields you need with the `fields` query
-string parameter can improve performance and reduce the size of the network
-request.
+Requesting information for only the fields you need with the `fields` option
+can improve performance and reduce the size of the network request.
 
 ```js
 client.weblinks.get('1234', {fields: 'item_status,path_collection'}, callback);
@@ -45,8 +44,8 @@ client.weblinks.get('1234', {fields: 'item_status,path_collection'}, callback);
 Update a Web Link
 -----------------
 
-To update a web link call the [`weblinks.update(weblinkID, options, callback)`](http://opensource.box.com/box-node-sdk/Weblinks.html#update)
-method.
+To update a web link call the [`weblinks.update(weblinkID, updates, callback)`](http://opensource.box.com/box-node-sdk/Weblinks.html#update)
+method with the fields to update and their new values.
 
 ```js
 client.weblinks.update(

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -61,7 +61,7 @@ Get a Webhook's Information
 ---------------------------
 
 Retrieve information about a specific webhook by calling
-[`webhooks.get(webhookID, qs, callback)`](http://opensource.box.com/box-node-sdk/Webhooks.html#get)
+[`webhooks.get(webhookID, options, callback)`](http://opensource.box.com/box-node-sdk/Webhooks.html#get)
 to retrieve a webhook by ID.
 
 ```js
@@ -72,7 +72,7 @@ Get all Webhooks Information
 -----------------------------
 
 Get a list of all webhooks for the requesting application and user by calling the
-[`webhooks.getAll(qs, callback)`](http://opensource.box.com/box-node-sdk/Webhooks.html#getAll)
+[`webhooks.getAll(options, callback)`](http://opensource.box.com/box-node-sdk/Webhooks.html#getAll)
 method.  The maximum limit per page of results is 200, Box uses the default limit of 100.
 
 ```js
@@ -83,8 +83,8 @@ Update a Webhook
 ----------------
 
 Update a file or folder's webhook by calling
-[`webhooks.update(webhookID, options, callback)`](http://opensource.box.com/box-node-sdk/Webhooks.html#update)
-with the field you want to update as `options.address` or `options.trigger`.
+[`webhooks.update(webhookID, updates, callback)`](http://opensource.box.com/box-node-sdk/Webhooks.html#update)
+with the field you want to update as `updates.address` or `updates.trigger`.
 
 ```js
 client.webhooks.update('678901', {address: "https://NEWWEBSITE.com"}, callback);

--- a/lib/managers/collaboration-whitelist.js
+++ b/lib/managers/collaboration-whitelist.js
@@ -84,13 +84,13 @@ CollaborationWhitelist.prototype.addDomain = function(domain, direction, callbac
  * Method: GET
  *
  * @param {string} domainID - Box ID of the collaboration whitelist being requested
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the collaboration whitelist information if it was acquired successfully
  * @returns {Promise<Object>} A promise resolving to the collaboration whitelist object
  */
-CollaborationWhitelist.prototype.getWhitelistedDomain = function(domainID, qs, callback) {
+CollaborationWhitelist.prototype.getWhitelistedDomain = function(domainID, options, callback) {
 
-	var params = { qs };
+	var params = { qs: options };
 
 	var apiPath = urlPath(BASE_PATH, domainID);
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -166,14 +166,14 @@ CollaborationWhitelist.prototype.addExemption = function(userID, callback) {
  * Method: GET
  *
  * @param {string} exemptionID - The ID of the collaboration whitelist
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the collaboration whitelist information for a user if it was acquired successfully
  * @returns {Promise<Object>} A promise resolving to the collaboration whitelist object
  */
-CollaborationWhitelist.prototype.getExemption = function(exemptionID, qs, callback) {
+CollaborationWhitelist.prototype.getExemption = function(exemptionID, options, callback) {
 
 	var params = {
-		qs: qs
+		qs: options
 	};
 
 	var apiPath = urlPath(TARGET_ENTRY_PATH, exemptionID);

--- a/lib/managers/collaborations.js
+++ b/lib/managers/collaborations.js
@@ -38,13 +38,13 @@ function Collaborations(client) {
  * Method: GET
  *
  * @param {string} collaborationID - Box ID of the collaboration being requested
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the collaboration information if it was acquired successfully
  * @returns {Promise<Object>} A promise resolving to the collaboration object
  */
-Collaborations.prototype.get = function(collaborationID, qs, callback) {
+Collaborations.prototype.get = function(collaborationID, options, callback) {
 	var params = {
-		qs: qs
+		qs: options
 	};
 	var apiPath = urlPath(BASE_PATH, collaborationID);
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -75,13 +75,13 @@ Collaborations.prototype.getPending = function(callback) {
  * Method: PUT
  *
  * @param {string} collaborationID - Box ID of the collaboration being requested
- * @param {Object} options - Fields of the collaboration to be updated
+ * @param {Object} updates - Fields of the collaboration to be updated
  * @param {Function} [callback] - Passed the updated collaboration information if it was acquired successfully
  * @returns {Promise<Object>} A promise resolving to the updated collaboration object
  */
-Collaborations.prototype.update = function(collaborationID, options, callback) {
+Collaborations.prototype.update = function(collaborationID, updates, callback) {
 	var params = {
-		body: options
+		body: updates
 	};
 
 	var apiPath = urlPath(BASE_PATH, collaborationID);

--- a/lib/managers/collections.js
+++ b/lib/managers/collections.js
@@ -49,13 +49,13 @@ Collections.prototype.getAll = function(callback) {
  * Method: GET
  *
  * @param {string} collectionID - Box ID of the collection with items being requested
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the items information if they were acquired successfully
  * @returns {Promise<Object>} A promise resolving to the collection of items in the collection
  */
-Collections.prototype.getItems = function(collectionID, qs, callback) {
+Collections.prototype.getItems = function(collectionID, options, callback) {
 	var params = {
-		qs: qs
+		qs: options
 	};
 	var apiPath = urlPath(BASE_PATH, collectionID, 'items');
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);

--- a/lib/managers/comments.js
+++ b/lib/managers/comments.js
@@ -38,13 +38,13 @@ function Comments(client) {
  * Method: GET
  *
  * @param {string} commentID - Box ID of the comment being requested
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the comment information if it was acquired successfully
  * @returns {Promise<Object>} A promise resolving to the comment object
  */
-Comments.prototype.get = function(commentID, qs, callback) {
+Comments.prototype.get = function(commentID, options, callback) {
 	var params = {
-		qs: qs
+		qs: options
 	};
 	var apiPath = urlPath(BASE_PATH, commentID);
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -106,13 +106,13 @@ Comments.prototype.createTaggedComment = function(fileID, commentBody, callback)
  * Method: PUT
  *
  * @param {string} commentID - Box ID of the comment being requested
- * @param {Object} options - Fields to update on the comment
+ * @param {Object} updates - Fields to update on the comment
  * @param {Function} [callback] - Passed the updated comment information if it was acquired successfully
  * @returns {Promise<Object>} A promise resolving to the updated comment object
  */
-Comments.prototype.update = function(commentID, options, callback) {
+Comments.prototype.update = function(commentID, updates, callback) {
 	var params = {
-		body: options
+		body: updates
 	};
 
 	var apiPath = urlPath(BASE_PATH, commentID);

--- a/lib/managers/events.js
+++ b/lib/managers/events.js
@@ -87,14 +87,14 @@ Events.prototype.getCurrentStreamPosition = function(callback) {
  * API Endpoint: '/events'
  * Method: GET
  *
- * @param {Object} [qs] Query string options
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] Passed the current stream position if successful
  * @returns {Promise<Object>} A promise resolving to the collection of events
  */
-Events.prototype.get = function(qs, callback) {
+Events.prototype.get = function(options, callback) {
 
 	var params = {
-		qs: qs
+		qs: options
 	};
 	var apiPath = urlPath(BASE_PATH);
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);

--- a/lib/managers/files.js
+++ b/lib/managers/files.js
@@ -115,13 +115,13 @@ function Files(client) {
  * Method: GET
  *
  * @param {string} fileID - Box ID of the file being requested
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the file information if it was acquired successfully
  * @returns {Promise<Object>} A promise resolving to the file object
  */
-Files.prototype.get = function(fileID, qs, callback) {
+Files.prototype.get = function(fileID, options, callback) {
 	var params = {
-		qs: qs
+		qs: options
 	};
 	var apiPath = urlPath(BASE_PATH, fileID);
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -137,13 +137,13 @@ Files.prototype.get = function(fileID, qs, callback) {
  *   302 FOUND - Download is available. A Download URL is returned.
  *
  * @param {string} fileID - Box ID of the file being requested
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the download URL if request was successful.
  * @returns {Promise<string>} A promise resolving to the file's download URL
  */
-Files.prototype.getDownloadURL = function(fileID, qs, callback) {
+Files.prototype.getDownloadURL = function(fileID, options, callback) {
 	var params = {
-		qs: qs
+		qs: options
 	};
 
 	var apiPath = urlPath(BASE_PATH, fileID, '/content');
@@ -181,14 +181,14 @@ Files.prototype.getDownloadURL = function(fileID, qs, callback) {
  *   302 FOUND - Download is available. A Download stream is returned.
  *
  * @param {string} fileID - Box ID of the file being requested
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - passed the readable stream if request was successful
  * @returns {Promise<Readable>} A promise resolving for the file stream
  */
-Files.prototype.getReadStream = function(fileID, qs, callback) {
+Files.prototype.getReadStream = function(fileID, options, callback) {
 
 	// Get the download URL to download from
-	return this.getDownloadURL(fileID, qs)
+	return this.getDownloadURL(fileID, options)
 		// Return a read stream to download the file
 		.then(url => this.client.get(url, { streaming: true }))
 		.asCallback(callback);
@@ -205,13 +205,13 @@ Files.prototype.getReadStream = function(fileID, qs, callback) {
  *   302 FOUND - Unable to generate thumbnail. Returns a `location` URL for a generic placeholder thumbnail.
  *
  * @param {string} fileID - Box ID of the file being requested
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the thumbnail file or the URL to a placeholder thumbnail if successful.
  * @returns {Promise<Object>} A promise resolving to the thumbnail information
  */
-Files.prototype.getThumbnail = function(fileID, qs, callback) {
+Files.prototype.getThumbnail = function(fileID, options, callback) {
 	var params = {
-		qs: qs,
+		qs: options,
 		json: false
 	};
 
@@ -256,13 +256,13 @@ Files.prototype.getThumbnail = function(fileID, qs, callback) {
  * Method: GET
  *
  * @param {string} fileID - Box file id of the file
- * @param {Object} [qs] - Optional additional querystring to add to the request. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - passed the file comments if they were successfully acquired
  * @returns {Promise<Object>} A promise resolving to the collection of comments
  */
-Files.prototype.getComments = function(fileID, qs, callback) {
+Files.prototype.getComments = function(fileID, options, callback) {
 	var params = {
-		qs: qs
+		qs: options
 	};
 	var apiPath = urlPath(BASE_PATH, fileID, '/comments');
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -276,13 +276,13 @@ Files.prototype.getComments = function(fileID, qs, callback) {
  * Method: PUT
  *
  * @param {string} fileID - Box ID of the file being requested
- * @param {Object} options - File fields to update
+ * @param {Object} updates - File fields to update
  * @param {Function} [callback] - Passed the updated file information if it was acquired successfully
  * @returns {Promise<Object>} A promise resolving to the update file object
  */
-Files.prototype.update = function(fileID, options, callback) {
+Files.prototype.update = function(fileID, updates, callback) {
 	var params = {
-		body: options
+		body: updates
 	};
 
 	var apiPath = urlPath(BASE_PATH, fileID);
@@ -434,18 +434,18 @@ Files.prototype.delete = function(fileID, callback) {
  *
  * @param {string} parentFolderID - The id of the parent folder to upload to
  * @param {Object} [fileData] - Optional data about the file to be uploaded
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Called with upload data if successful, or err if the upload would not succeed
  * @returns {Promise<Object>} A promise resolving to the upload data
  */
-Files.prototype.preflightUploadFile = function(parentFolderID, fileData, qs, callback) {
+Files.prototype.preflightUploadFile = function(parentFolderID, fileData, options, callback) {
 	var params = {
 		body: {
 			parent: {
 				id: parentFolderID
 			}
 		},
-		qs: qs
+		qs: options
 	};
 
 	if (fileData) {
@@ -470,13 +470,13 @@ Files.prototype.preflightUploadFile = function(parentFolderID, fileData, qs, cal
  *
  * @param {string} fileID - The file ID to which a new version will be uploaded
  * @param {Object} [fileData] - Optional data about the file to be uploaded
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Called with upload data if successful, or err if the upload would not succeed
  * @returns {Promise<Object>} A promise resolving to the upload data
  */
-Files.prototype.preflightUploadNewFileVersion = function(fileID, fileData, qs, callback) {
+Files.prototype.preflightUploadNewFileVersion = function(fileID, fileData, options, callback) {
 	var params = {
-		qs: qs
+		qs: options
 	};
 
 	if (fileData) {
@@ -710,14 +710,14 @@ Files.prototype.deletePermanently = function(fileID, callback) {
  * Method: GET
  *
  * @param {string} fileID - The ID of the file being requested
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the trashed file information if successful, error otherwise
  * @returns {Promise<Object>} A promise resolving to the trashed file
  */
-Files.prototype.getTrashedFile = function(fileID, qs, callback) {
+Files.prototype.getTrashedFile = function(fileID, options, callback) {
 
 	var params = {
-		qs: qs
+		qs: options
 	};
 
 	var apiPath = urlPath(BASE_PATH, fileID, 'trash');
@@ -731,14 +731,14 @@ Files.prototype.getTrashedFile = function(fileID, qs, callback) {
  * Method: GET
  *
  * @param {string} fileID - The ID of the file to get tasks for
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the file tasks if successful, error otherwise
  * @returns {Promise<Object>} A promise resolving to a collections of tasks on the file
  */
-Files.prototype.getTasks = function(fileID, qs, callback) {
+Files.prototype.getTasks = function(fileID, options, callback) {
 
 	var params = {
-		qs: qs
+		qs: options
 	};
 
 	var apiPath = urlPath(BASE_PATH, fileID, '/tasks');
@@ -875,15 +875,15 @@ Files.prototype.restoreFromTrash = function(fileID, options, callback) {
  * Method: GET
  *
  * @param {string} fileID - The ID of the file to view version for
- * @param {Object} [qs] - Additional options for the request, can be left null in most cases
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed a list of previous file versions if successful, error otherwise
  * @returns {Promise<Object>} A promise resolving to the collection of file versions
  */
-Files.prototype.getVersions = function(fileID, qs, callback) {
+Files.prototype.getVersions = function(fileID, options, callback) {
 
 	var apiPath = urlPath(BASE_PATH, fileID, VERSIONS_SUBRESOURCE),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -896,15 +896,15 @@ Files.prototype.getVersions = function(fileID, qs, callback) {
  * Method: GET
  *
  * @param {string} fileID - The Box ID of the file to get watermark for
- * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the watermark information if successful, error otherwise
  * @returns {Promise<Object>} A promise resolving to the watermark info
  */
-Files.prototype.getWatermark = function(fileID, qs, callback) {
+Files.prototype.getWatermark = function(fileID, options, callback) {
 
 	var apiPath = urlPath(BASE_PATH, fileID, WATERMARK_SUBRESOURCE),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.get(apiPath, params)

--- a/lib/managers/folders.js
+++ b/lib/managers/folders.js
@@ -40,13 +40,13 @@ function Folders(client) {
  * Method: GET
  *
  * @param {string} folderID - Box ID of the folder being requested
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the folder information if it was acquired successfully
  * @returns {Promise<Object>} A promise resolving to the folder object
  */
-Folders.prototype.get = function(folderID, qs, callback) {
+Folders.prototype.get = function(folderID, options, callback) {
 	var params = {
-		qs: qs
+		qs: options
 	};
 	var apiPath = urlPath(BASE_PATH, folderID);
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -59,13 +59,13 @@ Folders.prototype.get = function(folderID, qs, callback) {
  * Method: GET
  *
  * @param {string} folderID - Box ID of the folder being requested
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the folder information if it was acquired successfully
  * @returns {Promise<Object>} A prmoise resolving to the collection of the items in the folder
  */
-Folders.prototype.getItems = function(folderID, qs, callback) {
+Folders.prototype.getItems = function(folderID, options, callback) {
 	var params = {
-		qs: qs
+		qs: options
 	};
 	var apiPath = urlPath(BASE_PATH, folderID, '/items');
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -78,13 +78,13 @@ Folders.prototype.getItems = function(folderID, qs, callback) {
  * Method: GET
  *
  * @param {string} folderID - Box ID of the folder being requested
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the folder information if it was acquired successfully
  * @returns {Promise<Object>} A promise resolving to the collection of collaborations
  */
-Folders.prototype.getCollaborations = function(folderID, qs, callback) {
+Folders.prototype.getCollaborations = function(folderID, options, callback) {
 	var params = {
-		qs: qs
+		qs: options
 	};
 	var apiPath = urlPath(BASE_PATH, folderID, '/collaborations');
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -155,13 +155,13 @@ Folders.prototype.copy = function(folderID, newParentID, options, callback) {
  * Method: PUT
  *
  * @param {string} folderID - The Box ID of the folder being requested
- * @param {Object} options - Folder fields to update
+ * @param {Object} updates - Folder fields to update
  * @param {Function} [callback] - Passed the updated folder information if it was acquired successfully
  * @returns {Promise<Object>} A promise resolving to the updated folder object
  */
-Folders.prototype.update = function(folderID, options, callback) {
+Folders.prototype.update = function(folderID, updates, callback) {
 	var params = {
-		body: options
+		body: updates
 	};
 
 	var apiPath = urlPath(BASE_PATH, folderID);
@@ -254,14 +254,14 @@ Folders.prototype.move = function(folderID, newParentID, callback) {
  * Method: DELETE
  *
  * @param {string} folderID - Box ID of the folder being requested
- * @param {Object} [qs] - Optional query string params, can be left null in most cases
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Empty response body passed if successful.
  * @returns {Promise<void>} A promise resolving to nothing
  */
-Folders.prototype.delete = function(folderID, qs, callback) {
+Folders.prototype.delete = function(folderID, options, callback) {
 
 	var params = {
-		qs: qs
+		qs: options
 	};
 
 	var apiPath = urlPath(BASE_PATH, folderID);
@@ -377,13 +377,13 @@ Folders.prototype.deleteMetadata = function(folderID, scope, template, callback)
  * Method: GET
  *
  * @param  {string} folderID  - The ID of the folder being requested
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param  {Funnction} [callback]  - Passed the folder information if it was acquired successfully
  * @returns {Promise<Object>} A promise resolving to the trashed folder object
  */
-Folders.prototype.getTrashedFolder = function(folderID, qs, callback) {
+Folders.prototype.getTrashedFolder = function(folderID, options, callback) {
 	var params = {
-		qs: qs
+		qs: options
 	};
 
 	var apiPath = urlPath(BASE_PATH, folderID, 'trash');
@@ -449,15 +449,15 @@ Folders.prototype.deletePermanently = function(folderID, callback) {
  * Method: GET
  *
  * @param {string} folderID - The Box ID of the folder to get watermark for
- * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the watermark information if successful, error otherwise
  * @returns {Promise<Object>} A promise resolving to the watermark info
  */
-Folders.prototype.getWatermark = function(folderID, qs, callback) {
+Folders.prototype.getWatermark = function(folderID, options, callback) {
 
 	var apiPath = urlPath(BASE_PATH, folderID, WATERMARK_SUBRESOURCE),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.get(apiPath, params)

--- a/lib/managers/groups.js
+++ b/lib/managers/groups.js
@@ -102,15 +102,15 @@ Groups.prototype.create = function(name, options, callback) {
  * Method: GET
  *
  * @param {string} groupID - The ID of the group to retrieve
- * @param {Object} [qs] - Additional options passed by query string, can be left null in most cases
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the group object if successful, error otherwise
  * @returns {Promise<Object>} A promise resolving to the group object
  */
-Groups.prototype.get = function(groupID, qs, callback) {
+Groups.prototype.get = function(groupID, options, callback) {
 
 	var apiPath = urlPath(BASE_PATH, groupID),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -123,15 +123,15 @@ Groups.prototype.get = function(groupID, qs, callback) {
  * Method: PUT
  *
  * @param {string} groupID - The ID of the group to update
- * @param {Object} [options] - Group fields to update
+ * @param {Object} updates - Group fields to update
  * @param {Function} [callback] - Passed the updated group object if successful, error otherwise
  * @returns {Promise<Object>} A promise resolving to the updated group object
  */
-Groups.prototype.update = function(groupID, options, callback) {
+Groups.prototype.update = function(groupID, updates, callback) {
 
 	var apiPath = urlPath(BASE_PATH, groupID),
 		params = {
-			body: options
+			body: updates
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
@@ -195,15 +195,15 @@ Groups.prototype.addUser = function(groupID, userID, options, callback) {
  * Method: GET
  *
  * @param {string} membershipID - The ID of the membership to fetch
- * @param {Object} [qs] - Optional parameters, can be left null in most cases
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the membership record if successful, error otherwise
  * @returns {Promise<Object>} A promise resolving to the membership object
  */
-Groups.prototype.getMembership = function(membershipID, qs, callback) {
+Groups.prototype.getMembership = function(membershipID, options, callback) {
 
 	var apiPath = urlPath(MEMBERSHIPS_PATH, membershipID),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);

--- a/lib/managers/legal-hold-policies.js
+++ b/lib/managers/legal-hold-policies.js
@@ -86,14 +86,14 @@ LegalHoldPolicies.prototype.create = function(name, options, callback) {
  * Method: GET
  *
  * @param {string} policyID - The Box ID of the legal hold policy being requested
- * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the policy information if it was acquired successfully, error otherwise
  * @returns {Promise<Object>} A promise resolving to the policy object
  */
-LegalHoldPolicies.prototype.get = function(policyID, qs, callback) {
+LegalHoldPolicies.prototype.get = function(policyID, options, callback) {
 	var apiPath = urlPath(BASE_PATH, policyID),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -106,18 +106,18 @@ LegalHoldPolicies.prototype.get = function(policyID, qs, callback) {
  * Method: PUT
  *
  * @param {string} policyID - The Box ID of the legal hold policy to update
- * @param {Object} options - The information to be updated
- * @param {string} [options.policy_name] - Name of Legal Hold Policy
- * @param {string} [options.description] - Description of Legal Hold Policy
- * @param {string} [options.release_notes] - Notes around why the policy was released
+ * @param {Object} updates - The information to be updated
+ * @param {string} [updates.policy_name] - Name of Legal Hold Policy
+ * @param {string} [updates.description] - Description of Legal Hold Policy
+ * @param {string} [updates.release_notes] - Notes around why the policy was released
  * @param {Function} [callback] - Passed the updated policy information if it was acquired successfully, error otherwise
  * @returns {Promise<Object>} A promise resolving to the updated policy
  */
-LegalHoldPolicies.prototype.update = function(policyID, options, callback) {
+LegalHoldPolicies.prototype.update = function(policyID, updates, callback) {
 
 	var apiPath = urlPath(BASE_PATH, policyID),
 		params = {
-			body: options
+			body: updates
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
@@ -129,17 +129,17 @@ LegalHoldPolicies.prototype.update = function(policyID, options, callback) {
  * API Endpoint: '/legal_hold_policies'
  * Method: GET
  *
- * @param {Object} [qs] - Additional options can be passed with the request via querystring
- * @param {string} [qs.policy_name] - A full or partial name to filter the legal hold policies by
- * @param {int} [qs.limit] - Limit result size to this number
- * @param {string} [qs.marker] - Paging marker, leave blank to start at the first page
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
+ * @param {string} [options.policy_name] - A full or partial name to filter the legal hold policies by
+ * @param {int} [options.limit] - Limit result size to this number
+ * @param {string} [options.marker] - Paging marker, leave blank to start at the first page
  * @param {Function} [callback] - Passed the policy objects if they were acquired successfully, error otherwise
  * @returns {Promise<Object>} A promise resolving to the collection of policies
  */
-LegalHoldPolicies.prototype.getAll = function(qs, callback) {
+LegalHoldPolicies.prototype.getAll = function(options, callback) {
 	var apiPath = urlPath(BASE_PATH),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -171,17 +171,17 @@ LegalHoldPolicies.prototype.delete = function(policyID, callback) {
  * Method: GET
  *
  * @param {string} policyID - The Box ID of the legal hold policy to get assignments for
- * @param {Object} [qs] - Additional options can be passed with the request via querystring
- * @param {LegalHoldPolicyAssignmentType} [qs.assign_to_type] - Filter assignments of this type only
-  * @param {string} [qs.assign_to_id] - Filter assignments to this ID only. Note that this will only show assignments applied directly to this entity.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
+ * @param {LegalHoldPolicyAssignmentType} [options.assign_to_type] - Filter assignments of this type only
+ * @param {string} [options.assign_to_id] - Filter assignments to this ID only. Note that this will only show assignments applied directly to this entity.
  * @param {Function} [callback] - Passed the assignment objects if they were acquired successfully, error otherwise
  * @returns {Promise<Object>} A promise resolving to the collection of policy assignments
  */
-LegalHoldPolicies.prototype.getAssignments = function(policyID, qs, callback) {
+LegalHoldPolicies.prototype.getAssignments = function(policyID, options, callback) {
 
 	var apiPath = urlPath(BASE_PATH, policyID, ASSIGNMENTS_SUBRESOURCE),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -222,15 +222,15 @@ LegalHoldPolicies.prototype.assign = function(policyID, assignType, assignID, ca
  * Method: GET
  *
  * @param {string} assignmentID - The Box ID of the policy assignment object to fetch
- * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the assignment object if it was acquired successfully, error otherwise
  * @returns {Promise<Object>} A promise resolving to the assignment object
  */
-LegalHoldPolicies.prototype.getAssignment = function(assignmentID, qs, callback) {
+LegalHoldPolicies.prototype.getAssignment = function(assignmentID, options, callback) {
 
 	var apiPath = urlPath(ASSIGNMENTS_PATH, assignmentID),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -262,15 +262,15 @@ LegalHoldPolicies.prototype.deleteAssignment = function(assignmentID, callback) 
  * Method: GET
  *
  * @param {string} legalHoldID - The ID for the file legal hold record to retrieve
- * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Pass the file version legal hold record if successful, error otherwise
  * @returns {Promise<Object>} A promise resolving to the legal hold record
  */
-LegalHoldPolicies.prototype.getFileVersionLegalHold = function(legalHoldID, qs, callback) {
+LegalHoldPolicies.prototype.getFileVersionLegalHold = function(legalHoldID, options, callback) {
 
 	var apiPath = urlPath(FILE_VERSION_LEGAL_HOLDS_PATH, legalHoldID),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -283,18 +283,16 @@ LegalHoldPolicies.prototype.getFileVersionLegalHold = function(legalHoldID, qs, 
  * Method: GET
  *
  * @param {string} policyID - ID of Legal Hold Policy to get File Version Legal Holds for
- * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Pass the file version legal holds records if successful, error otherwise
  * @returns {Promise<Object>} A promise resolving to the collection of all file version legal holds
  */
-LegalHoldPolicies.prototype.getAllFileVersionLegalHolds = function(policyID, qs, callback) {
+LegalHoldPolicies.prototype.getAllFileVersionLegalHolds = function(policyID, options, callback) {
 
 	var apiPath = urlPath(FILE_VERSION_LEGAL_HOLDS_PATH),
 		params = {
-			qs: qs || {}
+			qs: Object.assign({ policy_id: policyID }, options)
 		};
-
-	params.qs.policy_id = policyID;
 
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
 };

--- a/lib/managers/recent-items.js
+++ b/lib/managers/recent-items.js
@@ -35,16 +35,16 @@ function RecentItems(client) {
  * API Endpoint: '/recent_items'
  * Method: GET
  *
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
- * @param {string} [qs.limit] Maximum number of items to return
- * @param {string} [qs.marker] The position marker for marker-based paging
- * @param {string} [qs.fields] Comma-separated list of fields to include in the response
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
+ * @param {int} [options.limit] Maximum number of items to return
+ * @param {string} [options.marker] The position marker for marker-based paging
+ * @param {string} [options.fields] Comma-separated list of fields to include in the response
  * @param {Function} [callback] - Passed the items information if they were acquired successfully
  * @returns {Promise<Object>} A promise resolving to the collection of items in the collection
  */
-RecentItems.prototype.get = function(qs, callback) {
+RecentItems.prototype.get = function(options, callback) {
 	var params = {
-		qs: qs
+		qs: options
 	};
 	var apiPath = urlPath(BASE_PATH);
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);

--- a/lib/managers/retention-policies.js
+++ b/lib/managers/retention-policies.js
@@ -121,14 +121,14 @@ RetentionPolicies.prototype.create = function(name, type, action, options, callb
  * Method: GET
  *
  * @param {string} policyID - The Box ID of the retention policy being requested
- * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the policy information if it was acquired successfully, error otherwise
  * @returns {Promise<Object>} A promise resolving to the policy object
  */
-RetentionPolicies.prototype.get = function(policyID, qs, callback) {
+RetentionPolicies.prototype.get = function(policyID, options, callback) {
 	var apiPath = urlPath(BASE_PATH, policyID),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -141,18 +141,18 @@ RetentionPolicies.prototype.get = function(policyID, qs, callback) {
  * Method: PUT
  *
  * @param {string} policyID - The Box ID of the retention policy to update
- * @param {Object} options - The information to be updated
- * @param {string} [options.policy_name] - The name of the retention policy
- * @param {RetentionPolicyDispositionAction} [options.disposition_action] - The disposition action for the updated policy
- * @param {string} [options.status] - Used to retire a retention policy if status is set to retired
+ * @param {Object} updates - The information to be updated
+ * @param {string} [updates.policy_name] - The name of the retention policy
+ * @param {RetentionPolicyDispositionAction} [updates.disposition_action] - The disposition action for the updated policy
+ * @param {string} [updates.status] - Used to retire a retention policy if status is set to retired
  * @param {Function} [callback] - Passed the updated policy information if it was acquired successfully, error otherwise
  * @returns {Promise<Object>} A promise resolving to the updated policy object
  */
-RetentionPolicies.prototype.update = function(policyID, options, callback) {
+RetentionPolicies.prototype.update = function(policyID, updates, callback) {
 
 	var apiPath = urlPath(BASE_PATH, policyID),
 		params = {
-			body: options
+			body: updates
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
@@ -164,17 +164,17 @@ RetentionPolicies.prototype.update = function(policyID, options, callback) {
  * API Endpoint: '/retention_policies
  * Method: GET
  *
- * @param {Object} [qs] - Additional options can be passed with the request via querystring
- * @param {string} [qs.policy_name] - A full or partial name to filter the retention policies by
- * @param {RetentionPolicyType} [qs.policy_type] - A policy type to filter the retention policies by
- * @param {string} [qs.created_by_user_id] - A user id to filter the retention policies by
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
+ * @param {string} [options.policy_name] - A full or partial name to filter the retention policies by
+ * @param {RetentionPolicyType} [options.policy_type] - A policy type to filter the retention policies by
+ * @param {string} [options.created_by_user_id] - A user id to filter the retention policies by
  * @param {Function} [callback] - Passed the policy objects if they were acquired successfully, error otherwise
  * @returns {Promise<Object>} A promise resolving to the collection of policies
  */
-RetentionPolicies.prototype.getAll = function(qs, callback) {
+RetentionPolicies.prototype.getAll = function(options, callback) {
 	var apiPath = urlPath(BASE_PATH),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -187,16 +187,16 @@ RetentionPolicies.prototype.getAll = function(qs, callback) {
  * Method: GET
  *
  * @param {string} policyID - The Box ID of the retention policy to get assignments for
- * @param {Object} [qs] - Additional options can be passed with the request via querystring
- * @param {RetentionPolicyAssignmentType} [qs.type] - The type of the retention policy assignment to retrieve
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
+ * @param {RetentionPolicyAssignmentType} [options.type] - The type of the retention policy assignment to retrieve
  * @param {Function} [callback] - Passed the assignment objects if they were acquired successfully, error otherwise
  * @returns {Promise<Object>} A promise resolving to the collection of policy assignments
  */
-RetentionPolicies.prototype.getAssignments = function(policyID, qs, callback) {
+RetentionPolicies.prototype.getAssignments = function(policyID, options, callback) {
 
 	var apiPath = urlPath(BASE_PATH, policyID, ASSIGNMENTS_SUBRESOURCE),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -237,15 +237,15 @@ RetentionPolicies.prototype.assign = function(policyID, assignType, assignID, ca
  * Method: GET
  *
  * @param {string} assignmentID - The Box ID of the policy assignment object to fetch
- * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the assignment object if it was acquired successfully, error otherwise
  * @returns {Promise<Object>} A promise resolving to the assignment object
  */
-RetentionPolicies.prototype.getAssignment = function(assignmentID, qs, callback) {
+RetentionPolicies.prototype.getAssignment = function(assignmentID, options, callback) {
 
 	var apiPath = urlPath(ASSIGNMENTS_PATH, assignmentID),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -260,15 +260,15 @@ RetentionPolicies.prototype.getAssignment = function(assignmentID, qs, callback)
  * Method: GET
  *
  * @param {string} retentionID - The ID for the file retention record to retrieve
- * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Pass the file version retention record if successful, error otherwise
  * @returns {Promise<Object>} A promise resolving to the retention record
  */
-RetentionPolicies.prototype.getFileVersionRetention = function(retentionID, qs, callback) {
+RetentionPolicies.prototype.getFileVersionRetention = function(retentionID, options, callback) {
 
 	var apiPath = urlPath(FILE_VERSION_RETENTIONS_PATH, retentionID),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -282,23 +282,23 @@ RetentionPolicies.prototype.getFileVersionRetention = function(retentionID, qs, 
  * API Endpoint: '/file_version_retentions'
  * Method: GET
  *
- * @param {Object} [qs] - Additional options can be passed with the request via querystring
- * @param {string} [qs.file_id] - A file id to filter the file version retentions by
- * @param {string} [qs.file_version_id] - A file version id to filter the file version retentions by
- * @param {string} [qs.policy_id] - A policy id to filter the file version retentions by
- * @param {RetentionPolicyDispositionAction} [qs.disposition_action] - The disposition action of the retention policy to filter by
- * @param {string} [qs.disposition_before] - Filter by retention policies which will complete before a certain time
- * @param {string} [qs.disposition_after] - Filter by retention policies which will complete after a certain time
- * @param {int} [qs.limit] - The maximum number of items to return in a page
- * @param {string} [qs.marker] - Paging marker, left blank to begin paging from the beginning
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
+ * @param {string} [options.file_id] - A file id to filter the file version retentions by
+ * @param {string} [options.file_version_id] - A file version id to filter the file version retentions by
+ * @param {string} [options.policy_id] - A policy id to filter the file version retentions by
+ * @param {RetentionPolicyDispositionAction} [options.disposition_action] - The disposition action of the retention policy to filter by
+ * @param {string} [options.disposition_before] - Filter by retention policies which will complete before a certain time
+ * @param {string} [options.disposition_after] - Filter by retention policies which will complete after a certain time
+ * @param {int} [options.limit] - The maximum number of items to return in a page
+ * @param {string} [options.marker] - Paging marker, left blank to begin paging from the beginning
  * @param {Function} [callback] - Pass the file version retention record if successful, error otherwise
  * @returns {Promise<Object>} A promise resolving to the collection of retention records
  */
-RetentionPolicies.prototype.getAllFileVersionRetentions = function(qs, callback) {
+RetentionPolicies.prototype.getAllFileVersionRetentions = function(options, callback) {
 
 	var apiPath = urlPath(FILE_VERSION_RETENTIONS_PATH),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);

--- a/lib/managers/shared-items.js
+++ b/lib/managers/shared-items.js
@@ -40,13 +40,13 @@ function SharedItems(client) {
  *
  * @param {string} url - Shared Link URL
  * @param {string} [password] - Shared Link Password (null if no password)
- * @param {Object} [qs] - Optional additional querystring to add to the request. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - passed the shared item if it was successfully acquired
  * @returns {Promise<Object>} A promise resolving to the shared item object
  */
-SharedItems.prototype.get = function(url, password, qs, callback) {
+SharedItems.prototype.get = function(url, password, options, callback) {
 	var params = {
-		qs: qs,
+		qs: options,
 		headers: {
 			BoxApi: this.client.buildSharedItemAuthHeader(url, password)
 		}

--- a/lib/managers/tasks.js
+++ b/lib/managers/tasks.js
@@ -88,15 +88,15 @@ Tasks.prototype.create = function(fileID, options, callback) {
  * Method: GET
  *
  * @param {string} taskID - The Box ID of the task being requested
- * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the task information if it was acquired successfully, error otherwise
  * @returns {Promise<Object>} A promise resolving to the task object
  */
-Tasks.prototype.get = function(taskID, qs, callback) {
+Tasks.prototype.get = function(taskID, options, callback) {
 
 	var apiPath = urlPath(BASE_PATH, taskID),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -109,17 +109,17 @@ Tasks.prototype.get = function(taskID, qs, callback) {
  * Method: PUT
  *
  * @param {string} taskID - The Box ID of the task being updated
- * @param {Object} options - Additional parameters
- * @param {string} [options.message] - An optional message to include with the task
- * @param {string} [options.due_at] - The day at which this task is due
+ * @param {Object} updates - Fields of the task object to update
+ * @param {string} [updates.message] - An optional message to include with the task
+ * @param {string} [updates.due_at] - The day at which this task is due
  * @param {Function} [callback] - Passed the updated task information if it was acquired successfully, error otherwise
  * @returns {Promise<Object>} A promise resolving to the updated task object
  */
-Tasks.prototype.update = function(taskID, options, callback) {
+Tasks.prototype.update = function(taskID, updates, callback) {
 
 	var apiPath = urlPath(BASE_PATH, taskID),
 		params = {
-			body: options
+			body: updates
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);

--- a/lib/managers/terms-of-service.js
+++ b/lib/managers/terms-of-service.js
@@ -101,15 +101,15 @@ TermsOfService.prototype.create = function(termsOfServicesType, termsOfServicesS
  * Method: PUT
  *
  * @param {string} termsOfServicesID - The id of the custom terms of services to update
- * @param {Object} [options] - Additional options. Can be left null in most cases.
- * @param {TermsOfServicesStatus} [options.status] - Determine if the custom terms of service is scoped internall or externally to an enterprise
- * @param {string} [options.text] - Text field for message associated with custom terms of services
+ * @param {Object} updates - Fields ot the Terms of Service to update
+ * @param {TermsOfServicesStatus} [updates.status] - Determine if the custom terms of service is scoped internall or externally to an enterprise
+ * @param {string} [updates.text] - Text field for message associated with custom terms of services
  * @param {Function} [callback] - Passed the terms of services updated information if successful, error otherwise
  * @returns {Promise<Object>} A promise resolving to the terms of services object
  */
-TermsOfService.prototype.update = function(termsOfServicesID, options, callback) {
+TermsOfService.prototype.update = function(termsOfServicesID, updates, callback) {
 	var params = {
-		body: options
+		body: updates
 	};
 
 	var apiPath = urlPath(BASE_PATH, termsOfServicesID);

--- a/lib/managers/users.js
+++ b/lib/managers/users.js
@@ -43,15 +43,15 @@ Users.prototype.CURRENT_USER_ID = CURRENT_USER_ID;
  * API Endpoint: '/users/:id'
  * Method: GET
  *
- * @param {string} id - The ID of the user to retrieve
- * @param {Object} [qs] - Optional additional querystring to add to the request. Can be left null in most cases.
+ * @param {string} userID - The ID of the user to retrieve
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - passed the user info if it was acquired successfully
  * @returns {Promise<Object>} A promise resolving to the user object
  */
-Users.prototype.get = function(id, qs, callback) {
-	var apiPath = urlPath(BASE_PATH, id),
+Users.prototype.get = function(userID, options, callback) {
+	var apiPath = urlPath(BASE_PATH, userID),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -63,15 +63,15 @@ Users.prototype.get = function(id, qs, callback) {
  * API Endpoint: '/users/:id'
  * Method: PUT
  *
- * @param {string} id - The ID of the user to update
- * @param {Object} [options] - User fields to update
+ * @param {string} userID - The ID of the user to update
+ * @param {Object} updates - User fields to update
  * @param {Function} [callback] - Passed the updated user information if it was acquired successfully
  * @returns {Promise<Object>} A promise resolving to the updated user object
  */
-Users.prototype.update = function(id, options, callback) {
-	var apiPath = urlPath(BASE_PATH, id),
+Users.prototype.update = function(userID, updates, callback) {
+	var apiPath = urlPath(BASE_PATH, userID),
 		params = {
-			body: options
+			body: updates
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);
@@ -84,16 +84,16 @@ Users.prototype.update = function(id, options, callback) {
  * Method: DELETE
  *
  * @param {string} userID - The ID of the user to delete
- * @param {Object} [qs] - Optional additional querystring to add to the request. Can be left null in most cases.
- * @param {bool} [qs.notify] - Determines if the destination user should receive email notification of the transfer.
- * @param {bool} [qs.force] - Whether or not the user should be deleted even if this user still own files.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
+ * @param {bool} [options.notify] - Determines if the destination user should receive email notification of the transfer.
+ * @param {bool} [options.force] - Whether or not the user should be deleted even if this user still own files.
  * @param {Function} [callback] - Empty response body passed if successful, error otherwise
  * @returns {Promise<void>} A promise resolving to nothing
  */
-Users.prototype.delete = function(userID, qs ,callback) {
+Users.prototype.delete = function(userID, options ,callback) {
 	var apiPath = urlPath(BASE_PATH, userID),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.del)(apiPath, params, callback);
@@ -106,12 +106,12 @@ Users.prototype.delete = function(userID, qs ,callback) {
  * API Endpoint: '/users/:id/email_aliases'
  * Method: GET
  *
- * @param {string} id - The ID of the user to retrieve email alises for
+ * @param {string} userID - The ID of the user to retrieve email alises for
  * @param {Function} [callback] - Passed the email aliases if successful
  * @returns {Promise<Object>} A promise resolving to the collection of email aliases
  */
-Users.prototype.getEmailAliases = function(id, callback) {
-	var apiPath = urlPath(BASE_PATH, id, EMAIL_ALIASES_SUBRESOURCE);
+Users.prototype.getEmailAliases = function(userID, callback) {
+	var apiPath = urlPath(BASE_PATH, userID, EMAIL_ALIASES_SUBRESOURCE);
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, null, callback);
 };
 
@@ -121,14 +121,14 @@ Users.prototype.getEmailAliases = function(id, callback) {
  * API Endpoint: '/users/:id/email_aliases'
  * Method: POST
  *
- * @param {string} id - The ID of the user to add an email alias to
+ * @param {string} userID - The ID of the user to add an email alias to
  * @param {string} email - The email address to add
  * @param {Object} [options] - Optional parameters
  * @param {bool} [options.is_confirmed=false] Whether or not to attempt to auto-confirm the alias (for admins)
  * @param {Function} [callback] - Passed the new alias if successful
  * @returns {Promise<Object>} A promise resolving to the new email alias
  */
-Users.prototype.addEmailAlias = function(id, email, options, callback) {
+Users.prototype.addEmailAlias = function(userID, email, options, callback) {
 
 	options = options || {};
 	if (typeof options === 'function') {
@@ -136,7 +136,7 @@ Users.prototype.addEmailAlias = function(id, email, options, callback) {
 		options = {};
 	}
 
-	var apiPath = urlPath(BASE_PATH, id, EMAIL_ALIASES_SUBRESOURCE),
+	var apiPath = urlPath(BASE_PATH, userID, EMAIL_ALIASES_SUBRESOURCE),
 		params = {
 			body: {
 				email: email,

--- a/lib/managers/web-links.js
+++ b/lib/managers/web-links.js
@@ -66,14 +66,14 @@ WebLinks.prototype.create = function(url, parentID, options, callback) {
  * Method: GET
  *
  * @param {string} weblinkID - The Box ID of web link being requested
- * @param {Object} [qs] - Additional options can be passed with the request via querystring
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the web-link information if it was acquired successfully, error otherwise
  * @returns {Promise<Object>} A promise resolving to the weblink object
  */
-WebLinks.prototype.get = function(weblinkID, qs, callback) {
+WebLinks.prototype.get = function(weblinkID, options, callback) {
 	var apiPath = urlPath(BASE_PATH, weblinkID),
 		params = {
-			qs: qs
+			qs: options
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.get)(apiPath, params, callback);
@@ -86,16 +86,16 @@ WebLinks.prototype.get = function(weblinkID, qs, callback) {
  * Method: PUT
  *
  * @param {string} weblinkID - The Box ID of the web link being updated
- * @param {Object} options - Additional parameters
- * @param {string} [options.name] - Name for the web link. Will default to the URL if empty.
- * @param {string} [options.description] - Description of the web link. Will provide more context to users about the web link.
+ * @param {Object} updates - Fields of the weblink to update
+ * @param {string} [updates.name] - Name for the web link. Will default to the URL if empty.
+ * @param {string} [updates.description] - Description of the web link. Will provide more context to users about the web link.
  * @param {Function} [callback] - Passed the updated web-link information if it was acquired successfully, error otherwise
  * @returns {Promise<Object>} A promise resolving to the updated web link object
  */
-WebLinks.prototype.update = function(weblinkID, options, callback) {
+WebLinks.prototype.update = function(weblinkID, updates, callback) {
 	var apiPath = urlPath(BASE_PATH, weblinkID),
 		params = {
-			body: options
+			body: updates
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);

--- a/lib/managers/webhooks.js
+++ b/lib/managers/webhooks.js
@@ -222,13 +222,13 @@ Webhooks.prototype.create = function(targetID, targetType, notificationURL, trig
  * Method: GET
  *
  * @param {string} webhookID - ID of the webhook to retrieve
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
  * @param {Function} [callback] - Passed the webhook information if it was acquired successfully
  * @returns {Promise<Object>} A promise resolving to the webhook object
  */
-Webhooks.prototype.get = function(webhookID, qs, callback) {
+Webhooks.prototype.get = function(webhookID, options, callback) {
 	var params = {
-		qs: qs
+		qs: options
 	};
 
 	var apiPath = urlPath(BASE_PATH, webhookID);
@@ -241,15 +241,15 @@ Webhooks.prototype.get = function(webhookID, qs, callback) {
  * API Endpoint: '/webhooks'
  * Method: GET
  *
- * @param {Object} [qs] - Additional options can be passed with the request via querystring. Can be left null in most cases.
- * @param {int} [qs.limit=100] - The number of webhooks to return
- * @param {string} [qs.marker] - Pagination marker
+ * @param {Object} [options] - Additional options for the request. Can be left null in most cases.
+ * @param {int} [options.limit=100] - The number of webhooks to return
+ * @param {string} [options.marker] - Pagination marker
  * @param {Function} [callback] - Passed the list of webhooks if successful, error otherwise
  * @returns {Promise<Object>} A promise resolving to the collection of webhooks
  */
-Webhooks.prototype.getAll = function(qs, callback) {
+Webhooks.prototype.getAll = function(options, callback) {
 	var params = {
-		qs: qs
+		qs: options
 	};
 
 	var apiPath = urlPath(BASE_PATH);
@@ -263,16 +263,16 @@ Webhooks.prototype.getAll = function(qs, callback) {
  * Method: PUT
  *
  * @param {string} webhookID - The ID of the webhook to be updated
- * @param {Object} options - Webhook fields to update
- * @param {string} [options.address] - The new URL used by Box to send a notification when webhook is triggered
- * @param {WebhookTriggerType[]} [options.triggers] - The new events that triggers a notification
+ * @param {Object} updates - Webhook fields to update
+ * @param {string} [updates.address] - The new URL used by Box to send a notification when webhook is triggered
+ * @param {WebhookTriggerType[]} [updates.triggers] - The new events that triggers a notification
  * @param {Function} [callback] - Passed the updated webhook information if successful, error otherwise
  * @returns {Promise<Object>} A promise resolving to the updated webhook object
  */
-Webhooks.prototype.update = function(webhookID, options, callback) {
+Webhooks.prototype.update = function(webhookID, updates, callback) {
 	var apiPath = urlPath(BASE_PATH, webhookID),
 		params = {
-			body: options
+			body: updates
 		};
 
 	return this.client.wrapWithDefaultHandler(this.client.put)(apiPath, params, callback);


### PR DESCRIPTION
Switch all uses of `qs` and `queryString` to options to be more
generic (since the fact that these options are passed in the query
string is an implementation detail).  Also changes `options` in
update() methods to `updates` for clarity.