### PR TITLE
Added comment reply and tagged comment reply

### DIFF
--- a/lib/managers/comments.js
+++ b/lib/managers/comments.js
@@ -62,7 +62,6 @@ Comments.prototype.get = function(commentID, options, callback) {
  * @returns {Promise<Object>} A promise resolving to the new comment object
  */
 Comments.prototype.create = function(fileID, commentBody, callback) {
-	// @TODO(bemerick) 2013-10-29: Don't hardcode this 'item'. Abstract to all commentable types...
 	var params = {
 		body: {
 			item: {
@@ -92,6 +91,54 @@ Comments.prototype.createTaggedComment = function(fileID, commentBody, callback)
 			item: {
 				type: 'file',
 				id: fileID
+			},
+			tagged_message: commentBody
+		}
+	};
+	return this.client.wrapWithDefaultHandler(this.client.post)(BASE_PATH, params, callback);
+};
+
+/**
+ * Posts a new comment as a reply to another comment.
+ *
+ * API Endpoint: '/comments
+ * Method: POST
+ *
+ * @param {string} commentID - Box file id of the file to comment on
+ * @param {string} commentBody - text of the comment
+ * @param {Function} [callback] - passed the new comment data if it was posted successfully
+ * @returns {Promise<Object>} A promise resolving to the new comment object
+ */
+Comments.prototype.reply = function(commentID, commentBody, callback) {
+	var params = {
+		body: {
+			item: {
+				type: 'comment',
+				id: commentID
+			},
+			message: commentBody
+		}
+	};
+	return this.client.wrapWithDefaultHandler(this.client.post)(BASE_PATH, params, callback);
+};
+
+/**
+ * Posts a new tagged comment as a reply to another comment.
+ *
+ * API Endpoint: '/comments
+ * Method: POST
+ *
+ * @param {string} commentID - Box file id of the file to comment on
+ * @param {string} commentBody - text of the tagged comment
+ * @param {Function} [callback] - passed the new tagged comment data if it was posted successfully
+ * @returns {Promise<Object>} A promise resolving to the new comment object
+ */
+Comments.prototype.createTaggedReply = function(commentID, commentBody, callback) {
+	var params = {
+		body: {
+			item: {
+				type: 'comment',
+				id: commentID
 			},
 			tagged_message: commentBody
 		}


### PR DESCRIPTION
Hi hi! Here's my first pull request EVER! Shout out to matt willer!

So, awkward part is that visual comment threading was lost in our move to Amsterdam, BUT we're bringing it back at a later date. So while this functionality is here in the SDK with this pull request, we should leave it undocumented for now until the webapp is updated.

Test script here - replace file and user ID/sub type as desired. Reads server auth/jwt params from a config.json file that is in the local directory, which is the same file you get when you create your public/private keys in the dev console.

`var BoxSDK = require('../box-node-sdk');

const fs = require('fs');

const boxConfig = JSON.parse(fs.readFileSync('CLI_config.json'));

var sdk = new BoxSDK({
  clientID: boxConfig.boxAppSettings.clientID,
  clientSecret: boxConfig.boxAppSettings.clientSecret,
  appAuth: {
		keyID: boxConfig.boxAppSettings.appAuth.publicKeyID,
		privateKey: boxConfig.boxAppSettings.appAuth.privateKey,
		passphrase: boxConfig.boxAppSettings.appAuth.passphrase
	}
});

var client = sdk.getAppAuthClient('user', '308127358');
var fileID = '283075147632';

client.comments.create(fileID, `Comment ${Date.now()}`, (err, data) => {
  if(data) {
    console.log(`Made ${data.id} as a first comment`);
    id = data.id
    return id
  } else {
    console.log(err);
  }
}).then( () => {
  client.comments.reply(id, `Reply to ${id}`, (err, data) => {
    if(data) {
      console.log(`Just made ${data.id} in response`);
    } else {
      console.log(err);
    }
  });
}).then( () => {
  client.comments.createTaggedComment(fileID, 'Im a tagged comment @[308127358:JPan]', (err, data) => {
    if(data) {
      console.log(`Made tagged comment ${data.id} as a first comment`);
      id = data.id
      return id
    } else {
      console.log(err);
    }
  }).then( () => {
    client.comments.createTaggedReply(id, 'Im a tagged reply @[308127358:JPan]', (err, data) => {
      if(data) {
        console.log(`Just made tagged comment ${data.id} in response`);
      } else {
        console.log(err);
      }
    });
  });
});
`