### PR TITLE
Allow reconfiguring SDK instance root URL

### DIFF
--- a/lib/box-node-sdk.js
+++ b/lib/box-node-sdk.js
@@ -87,18 +87,32 @@ function BoxSDKNode(params) {
 		self.emit.apply(self, args);
 	});
 
+
 	// Setup the configuration with the given params
 	this.config = new Config(params);
+	this._eventBus = eventBus;
+	this._setup();
+}
+
+util.inherits(BoxSDKNode, EventEmitter);
+
+/**
+ * Setup the SDK instance by instantiating necessary objects with current
+ * configuration values.
+ *
+ * @param {EventEmitter} eventBus The event bus to use
+ * @returns {void}
+ * @private
+ */
+BoxSDKNode.prototype._setup = function() {
 
 	// Instantiate the request manager
-	this.requestManager = new APIRequestManager(this.config, eventBus);
+	this.requestManager = new APIRequestManager(this.config, this._eventBus);
 
 	// Initialize the rest of the SDK with the given configuration
 	this.tokenManager = new TokenManager(this.config, this.requestManager);
 	this.anonymousSession = new AnonymousAPISession(this.config, this.tokenManager);
-}
-
-util.inherits(BoxSDKNode, EventEmitter);
+};
 
 /**
  * Expose the BoxClient property enumerations to the SDK as a whole. This allows
@@ -170,6 +184,7 @@ BoxSDKNode.getPreconfiguredInstance = function(appConfig) {
  */
 BoxSDKNode.prototype.configure = function(params) {
 	this.config = this.config.extend(params);
+	this._setup();
 };
 
 /**

--- a/tests/integration-test.js
+++ b/tests/integration-test.js
@@ -37,6 +37,7 @@ describe('Box Node SDK', function() {
 		BoxSDK;
 
 	beforeEach(function() {
+		nock.disableNetConnect();
 		apiMock = nock(TEST_API_ROOT);
 
 		mockery.enable({
@@ -1289,5 +1290,72 @@ describe('Box Node SDK', function() {
 				});
 		});
 		/* eslint-enable promise/no-callback-in-promise */
+	});
+
+	it('should correctly reconfigure SDK instance', function() {
+
+		var folderID = '98740596456',
+			folderName = 'Test Folder',
+			tokenStoreFake = leche.create([
+				'read',
+				'write',
+				'clear'
+			]),
+			refreshToken = 'rt',
+			expiredTokenInfo = {
+				accessToken: 'expired_at',
+				refreshToken,
+				acquiredAtMS: Date.now() - 3600000,
+				accessTokenTTLMS: 60000
+			};
+
+		sandbox.mock(tokenStoreFake).expects('write')
+			.withArgs(sinon.match({
+				accessToken: TEST_ACCESS_TOKEN,
+				refreshToken: 'new_rt'
+			}))
+			.yieldsAsync();
+
+		var sdk = new BoxSDK({
+			clientID: TEST_CLIENT_ID,
+			clientSecret: TEST_CLIENT_SECRET,
+			maxNumRetries: 0,
+			retryIntervalMS: 1,
+			apiRootURL: 'https://example.com'
+		});
+
+		sdk.configure({
+			apiRootURL: TEST_API_ROOT
+		});
+
+		apiMock
+			.post('/oauth2/token', {
+				grant_type: 'refresh_token',
+				refresh_token: refreshToken,
+				client_id: TEST_CLIENT_ID,
+				client_secret: TEST_CLIENT_SECRET
+			})
+			.reply(200, {
+				access_token: TEST_ACCESS_TOKEN,
+				refresh_token: 'new_rt',
+				expires_in: 256
+			})
+			.get(`/2.0/folders/${folderID}`)
+			.matchHeader('Authorization', function(authHeader) {
+				assert.equal(authHeader, `Bearer ${TEST_ACCESS_TOKEN}`);
+				return true;
+			})
+			.reply(200, {
+				id: folderID,
+				name: folderName
+			});
+
+		var client = sdk.getPersistentClient(expiredTokenInfo, tokenStoreFake);
+
+		return client.folders.get(folderID)
+			.then(folder => {
+				assert.propertyVal(folder, 'id', folderID);
+				assert.propertyVal(folder, 'name', folderName);
+			});
 	});
 });


### PR DESCRIPTION
Certain SDK configuration properties need to be propagated to all
internal SDK objects (e.g. the TokenManager), which requires
re-instantiating those objects with the new Config object.  This
mostly affects widely-used configuration properties such as the
apiRootURL.