### PR TITLE
Improve error object format

### DIFF
--- a/lib/managers/shared-items.js
+++ b/lib/managers/shared-items.js
@@ -65,7 +65,7 @@ SharedItems.prototype.get = function(url, password, options, callback) {
 			// 403 - Incorrect or missing password
 			// Propagate an error explaining that the password is either missing or incorrect
 			case httpStatusCodes.FORBIDDEN:
-				var errMessage = (password) ? 'password_incorrect' : 'password_missing';
+				var errMessage = (password) ? 'Incorrect shared link password' : 'Shared link password missing';
 				throw errors.buildResponseError(response, errMessage);
 
 				// Unexpected Response

--- a/lib/util/errors.js
+++ b/lib/util/errors.js
@@ -7,7 +7,7 @@
 // ------------------------------------------------------------------------------
 // Requirements
 // ------------------------------------------------------------------------------
-var util = require('util'),
+var qs = require('querystring'),
 	httpStatusCodes = require('http-status');
 
 
@@ -29,6 +29,25 @@ var util = require('util'),
  * @property {boolean} authExpired - always true
  */
 
+/**
+ * Request structure for error objects
+ * @param {Object} req The request object
+ * @constructor
+ * @private
+ */
+function Request(req) {
+	this.method = req.method;
+	this.url = {
+		protocol: req.uri.protocol,
+		host: req.uri.host,
+		path: req.uri.pathname,
+		query: qs.parse(req.uri.query),
+		fragment: req.uri.hash
+	};
+	this.httpVersion = req.response.httpVersion;
+	this.headers = req.headers;
+	this.body = req.body;
+}
 
 // ------------------------------------------------------------------------------
 // Public
@@ -54,9 +73,32 @@ module.exports = {
 	 */
 	buildResponseError(response, message) {
 		response = response || {};
-		var responseError = new Error(message);
+		message = message || 'API Response Error';
+
+		var statusCode = response.statusCode;
+		var requestID = '';
+		if (response.body && response.body.request_id) {
+			requestID = ` | ${response.body.request_id}`;
+		}
+
+		var apiMessage = '';
+		if (response.body && response.body.code) {
+			apiMessage += ` ${response.body.code}`;
+		}
+
+		if (response.body && response.body.message) {
+			apiMessage += ` - ${response.body.message}`;
+		}
+
+		var errorMessage = `${message} [${statusCode} ${httpStatusCodes[statusCode]}${requestID}]${apiMessage}`;
+		var responseError = new Error(errorMessage);
+
 		responseError.statusCode = response.statusCode;
 		responseError.response = response;
+		if (response.request) {
+			responseError.request = response.request ? new Request(response.request) : {};
+		}
+
 		return responseError;
 	},
 
@@ -69,7 +111,7 @@ module.exports = {
 	 */
 	buildAuthError(response, message) {
 
-		message = message || 'Expired Auth: Auth code or refresh token has expired.';
+		message = message || 'Expired Auth: Auth code or refresh token has expired';
 		var responseError = this.buildResponseError(response, message);
 		responseError.authExpired = true;
 		return responseError;
@@ -85,16 +127,7 @@ module.exports = {
 	 * @returns {Errors~ResponseError} an error describing the response error
 	 */
 	buildUnexpectedResponseError(response) {
-		response = response || {};
-		var responseErrorMessage = '';
-
-		if (response.body && (response.body.code || response.body.message)) {
-			responseErrorMessage = util.format(' (%s: "%s")', response.body.code, response.body.message);
-		}
-
-		var statusCode = response.statusCode,
-			unexpectedErrorMessage = util.format('Unexpected API Response [%d %s]%s', statusCode, httpStatusCodes[statusCode], responseErrorMessage);
-		return this.buildResponseError(response, unexpectedErrorMessage.trim());
+		return this.buildResponseError(response, 'Unexpected API Response');
 	},
 
 	/**

--- a/tests/lib/managers/shared-items-test.js
+++ b/tests/lib/managers/shared-items-test.js
@@ -113,14 +113,14 @@ describe('SharedItems', function() {
 				});
 		});
 
-		it('should call callback with a password_missing error when a password is given and a 403 FORBIDDEN response is returned', function(done) {
+		it('should call callback with a password missing error when a password is given and a 403 FORBIDDEN response is returned', function(done) {
 			var response = {statusCode: 403};
 
 			sandbox.stub(boxClientFake, 'buildSharedItemAuthHeader').returns(testAuthHeader);
 			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
 			sharedItems.get(testSharedItemURL, null, testQS, function(err) {
 				assert.instanceOf(err, Error);
-				assert.propertyVal(err, 'message', 'password_missing');
+				assert.propertyVal(err, 'message', 'Shared link password missing [403 Forbidden]');
 				assert.propertyVal(err, 'statusCode', response.statusCode);
 				done();
 			});
@@ -134,7 +134,7 @@ describe('SharedItems', function() {
 			return sharedItems.get(testSharedItemURL, null, testQS)
 				.catch(err => {
 					assert.instanceOf(err, Error);
-					assert.propertyVal(err, 'message', 'password_missing');
+					assert.propertyVal(err, 'message', 'Shared link password missing [403 Forbidden]');
 					assert.propertyVal(err, 'statusCode', response.statusCode);
 				});
 		});
@@ -146,7 +146,7 @@ describe('SharedItems', function() {
 			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
 			sharedItems.get(testSharedItemURL, testSharedItemPassword, testQS, function(err) {
 				assert.instanceOf(err, Error);
-				assert.propertyVal(err, 'message', 'password_incorrect');
+				assert.propertyVal(err, 'message', 'Incorrect shared link password [403 Forbidden]');
 				assert.propertyVal(err, 'statusCode', response.statusCode);
 				done();
 			});
@@ -160,7 +160,7 @@ describe('SharedItems', function() {
 			return sharedItems.get(testSharedItemURL, testSharedItemPassword, testQS)
 				.catch(err => {
 					assert.instanceOf(err, Error);
-					assert.propertyVal(err, 'message', 'password_incorrect');
+					assert.propertyVal(err, 'message', 'Incorrect shared link password [403 Forbidden]');
 					assert.propertyVal(err, 'statusCode', response.statusCode);
 				});
 		});

--- a/tests/lib/token-manager-test.js
+++ b/tests/lib/token-manager-test.js
@@ -175,7 +175,7 @@ describe('token-manager', function() {
 			return tokenManager.getTokens({})
 				.catch(err => {
 					assert.instanceOf(err, Error, 'An error is returned');
-					assert.strictEqual(err.message, 'Expired Auth: Auth code or refresh token has expired.');
+					assert.strictEqual(err.message, 'Expired Auth: Auth code or refresh token has expired [403 Forbidden]');
 				});
 		});
 
@@ -223,7 +223,7 @@ describe('token-manager', function() {
 
 				return tokenManager.getTokens({})
 					.catch(err => {
-						assert.strictEqual(err.message, 'Token format from response invalid');
+						assert.strictEqual(err.message, 'Token format from response invalid [200 OK]');
 					});
 			});
 

--- a/tests/lib/util/errors-test.js
+++ b/tests/lib/util/errors-test.js
@@ -25,27 +25,16 @@ var sandbox = sinon.sandbox.create(),
 
 describe('Errors', function() {
 
-	before(function() {
-		// Enable Mockery
-		mockery.enable({ useCleanCache: true });
-		// Register Mocks
-		mockery.registerAllowable('http-status');
-		mockery.registerAllowable('util');
-		// Register Module Under Test
-		mockery.registerAllowable(MODULE_FILE_PATH);
-	});
-
 	beforeEach(function() {
-		// Setup File Under Test
+		mockery.enable({
+			warnOnUnregistered: false
+		});
+		mockery.registerAllowable(MODULE_FILE_PATH, true);
 		errors = require(MODULE_FILE_PATH);
 	});
 
 	afterEach(function() {
 		sandbox.verifyAndRestore();
-		mockery.resetCache();
-	});
-
-	after(function() {
 		mockery.deregisterAll();
 		mockery.disable();
 	});
@@ -58,7 +47,7 @@ describe('Errors', function() {
 			var errObject = errors.buildAuthError(response);
 			assert(errObject.authExpired);
 			assert.strictEqual(errObject.response, response);
-			assert.strictEqual(errObject.message, 'Expired Auth: Auth code or refresh token has expired.');
+			assert.strictEqual(errObject.message, 'Expired Auth: Auth code or refresh token has expired [401 Unauthorized]');
 		});
 
 		it('should use provided message when message argument is passed', function() {
@@ -70,7 +59,7 @@ describe('Errors', function() {
 			var errObject = errors.buildAuthError(response, message);
 			assert(errObject.authExpired);
 			assert.strictEqual(errObject.response, response);
-			assert.strictEqual(errObject.message, message);
+			assert.strictEqual(errObject.message, 'test [401 Unauthorized]');
 		});
 	});
 
@@ -82,7 +71,7 @@ describe('Errors', function() {
 			};
 			var errObject = errors.buildResponseError(response, 'testMessage');
 
-			assert.strictEqual(errObject.message, 'testMessage');
+			assert.strictEqual(errObject.message, 'testMessage [505 HTTP Version not Supported]');
 			assert.strictEqual(errObject.statusCode, 505);
 			assert.strictEqual(errObject.response, response);
 		});
@@ -111,7 +100,7 @@ describe('Errors', function() {
 			};
 
 			var errObject = errors.buildUnexpectedResponseError(response);
-			assert.strictEqual(errObject.message, 'Unexpected API Response [505 HTTP Version not Supported] (error_code: "Bad things happened")');
+			assert.strictEqual(errObject.message, 'Unexpected API Response [505 HTTP Version not Supported] error_code - Bad things happened');
 			assert.strictEqual(errObject.statusCode, 505);
 			assert.strictEqual(errObject.response, response);
 		});


### PR DESCRIPTION
Adding to the standard error messages in the SDK to include common
fields necessary for troubleshooting, and attaching the request
object directly to the error when possible.