### PR TITLE
Add getBasicClient alias to BoxSDKNode class

### DIFF
--- a/lib/box-node-sdk.js
+++ b/lib/box-node-sdk.js
@@ -195,10 +195,11 @@ BoxSDKNode.prototype.configure = function(params) {
  * @param {string} accessToken A user's Box API access token
  * @returns {BoxClient} Returns a new Box Client paired to a new BasicAPISession
  */
-BoxSDKNode.prototype.getBasicClient = function(accessToken) {
+BoxSDKNode.getBasicClient = function(accessToken) {
 	var apiSession = new BasicAPISession(accessToken, this.tokenManager);
 	return new BoxClient(apiSession, this.config, this.requestManager);
 };
+BoxSDKNode.prototype.getBasicClient = BoxSDKNode.getBasicClient;
 
 /**
  * Returns a Box Client with a persistent API session. A persistent API session helps manage the user's tokens,

--- a/tests/lib/box-sdk-node-test.js
+++ b/tests/lib/box-sdk-node-test.js
@@ -310,6 +310,11 @@ describe('box-node-sdk', function() {
 			var basicClient = sdk.getBasicClient('abc');
 			assert.ok((basicClient instanceof BasicClient), 'Returned instance of Basic Client');
 		});
+
+		it('should return an instance of a Basic Client when called directly on the class', function() {
+			var basicClient = BoxSDKNode.getBasicClient('abc');
+			assert.ok((basicClient instanceof BasicClient), 'Returned instance of Basic Client');
+		});
 	});
 
 	describe('getPersistentClient()', function() {


### PR DESCRIPTION
This allows for simpler creation of a basic client, without the need to instantiate a dummy SDK first. See #276 for more information.

```
let Box = require('box-node-sdk');
let client = Box.getBasicClient(actualAccessToken);
```
