### PR TITLE
Add class level getBasicClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Box supports four different types of client:
 Returns a Box Client with a Basic API Session. The client is able to make requests on behalf of a user. A basic session has no access to a user's refresh token. Because of this, once the session's tokens expire the client cannot recover and a new session will need to be generated.
 
 ```js
-var client = sdk.getBasicClient('ACCESS_TOKEN');
+var client = BoxSDK.getBasicClient('ACCESS_TOKEN');
 ```
 
 ### Persistent Client

--- a/lib/box-node-sdk.js
+++ b/lib/box-node-sdk.js
@@ -201,6 +201,21 @@ BoxSDKNode.prototype.getBasicClient = function(accessToken) {
 };
 
 /**
+ * Returns a Box Client with a Basic API Session. The client is able to make requests on behalf of a user.
+ * A basic session has no access to a user's refresh token. Because of this, once the session's tokens
+ * expire the client cannot recover and a new session will need to be generated.
+ *
+ * @param {string} accessToken A user's Box API access token
+ * @returns {BoxClient} Returns a new Box Client paired to a new BasicAPISession
+ */
+BoxSDKNode.getBasicClient = function(accessToken) {
+	return new BoxSDKNode({
+		clientID: '',
+		clientSecret: ''
+	}).getBasicClient(accessToken);
+};
+
+/**
  * Returns a Box Client with a persistent API session. A persistent API session helps manage the user's tokens,
  * and can refresh them automatically if the access token expires. If a central data-store is given, the session
  * can read & write tokens to it.

--- a/tests/lib/box-sdk-node-test.js
+++ b/tests/lib/box-sdk-node-test.js
@@ -310,6 +310,11 @@ describe('box-node-sdk', function() {
 			var basicClient = sdk.getBasicClient('abc');
 			assert.ok((basicClient instanceof BasicClient), 'Returned instance of Basic Client');
 		});
+
+		it('should return an instance of a Basic Client when called as a static method', function() {
+			var basicClient = BoxSDKNode.getBasicClient('abc');
+			assert.ok((basicClient instanceof BasicClient), 'Returned instance of Basic Client');
+		});
 	});
 
 	describe('getPersistentClient()', function() {


### PR DESCRIPTION
This allows for simpler creation of a basic client, without the need to instantiate a dummy SDK first. See #276 for more information.

```
let Box = require('box-node-sdk');
let client = Box.getBasicClient(actualAccessToken);
```

(Attempt #2 /cc @mattwiller)