### PR TITLE
Chunked uploader improvements

### DIFF
--- a/docs/files.md
+++ b/docs/files.md
@@ -302,30 +302,63 @@ uploaded, and a `Buffer` or `ReadableStream` of the file to be uploaded.
 ```js
 // Upload a 2GB file "huge.pdf" into folder 12345
 var stream = fs.createReadStream('huge.pdf');
-client.files.getChunkedUploader(
-	'12345',
-	2147483648,
-	'huge.pdf',
-	stream,
-	null,
-	function(err, uploader) {
-
-		if (err) {
-			// handle error
-			return;
-		}
-
-		uploader.on('error', function(err) {
-			// handle unrecoverable upload error
-		});
-
-		uploader.on('uploadComplete', function(file) {
-			console.log('File upload complete!', file);
-		});
-
-		uploader.start();
-	}
-);
+client.files.getChunkedUploader('12345', 2147483648, 'huge.pdf', stream)
+	.then(uploader => uploader.start())
+	.then(file => {
+		/* file -> {
+			total_count: 1,
+			entries: 
+			[ { type: 'file',
+				id: '11111',
+				file_version: 
+					{ type: 'file_version',
+					id: '22222',
+					sha1: '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33' },
+				sequence_id: '0',
+				etag: '0',
+				sha1: '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33',
+				name: 'huge.pdf',
+				description: '',
+				size: 2147483648,
+				path_collection: 
+					{ total_count: 1,
+					entries: 
+					[ { type: 'folder',
+						id: '12345',
+						sequence_id: null,
+						etag: null,
+						name: 'My Folder' } ] },
+				created_at: '2017-05-16T15:18:02-07:00',
+				modified_at: '2017-05-16T15:18:02-07:00',
+				trashed_at: null,
+				purged_at: null,
+				content_created_at: '2017-05-16T15:18:02-07:00',
+				content_modified_at: '2017-05-16T15:18:02-07:00',
+				created_by: 
+					{ type: 'user',
+					id: '33333',
+					name: 'Test User',
+					login: 'test@example.com' },
+				modified_by: 
+					{ type: 'user',
+					id: '33333',
+					name: 'Test User',
+					login: 'test@example.com' },
+				owned_by: 
+					{ type: 'user',
+					id: '33333',
+					name: 'Test User',
+					login: 'test@example.com' },
+				shared_link: null,
+				parent: 
+					{ type: 'folder',
+					id: '12345',
+					sequence_id: null,
+					etag: null,
+					name: 'My Folder' }
+				item_status: 'active' } ] }
+		*/
+	});
 ```
 
 A new version of a file can be uploaded in the same way by calling
@@ -336,29 +369,80 @@ version and a `Buffer` or `ReadableStream` of the new version.
 ```js
 // Upload a new 2GB version of file 98765
 var stream = fs.createReadStream('huge.pdf');
-client.files.getChunkedUploader(
-	'98765',
-	2147483648,
-	stream,
-	null,
-	function(err, uploader) {
+client.files.getNewVersionChunkedUploader('11111', 2147483648, stream)
+	.then(uploader => uploader.start())
+	.then(file => {
+		/* file -> {
+			total_count: 1,
+			entries: 
+			[ { type: 'file',
+				id: '11111',
+				file_version: 
+					{ type: 'file_version',
+					id: '22222',
+					sha1: '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33' },
+				sequence_id: '0',
+				etag: '0',
+				sha1: '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33',
+				name: 'huge.pdf',
+				description: '',
+				size: 2147483648,
+				path_collection: 
+					{ total_count: 1,
+					entries: 
+					[ { type: 'folder',
+						id: '12345',
+						sequence_id: null,
+						etag: null,
+						name: 'My Folder' } ] },
+				created_at: '2017-05-16T15:18:02-07:00',
+				modified_at: '2017-05-21T15:18:02-07:00',
+				trashed_at: null,
+				purged_at: null,
+				content_created_at: '2017-05-16T15:18:02-07:00',
+				content_modified_at: '2017-05-21:18:02-07:00',
+				created_by: 
+					{ type: 'user',
+					id: '33333',
+					name: 'Test User',
+					login: 'test@example.com' },
+				modified_by: 
+					{ type: 'user',
+					id: '33333',
+					name: 'Test User',
+					login: 'test@example.com' },
+				owned_by: 
+					{ type: 'user',
+					id: '33333',
+					name: 'Test User',
+					login: 'test@example.com' },
+				shared_link: null,
+				parent: 
+					{ type: 'folder',
+					id: '12345',
+					sequence_id: null,
+					etag: null,
+					name: 'My Folder' }
+				item_status: 'active' } ] }
+		*/
+	});
+```
 
-		if (err) {
-			// handle error
-			return;
-		}
+File attributes can be set on the newly uploaded file by passing the via the `options.fileAttributes` parameter:
 
-		uploader.on('error', function(err) {
-			// handle unrecoverable upload error
-		});
-
-		uploader.on('uploadComplete', function(file) {
-			console.log('Version upload complete!', file);
-		});
-
-		uploader.start();
+```js
+// Upload a new file and prepopulate the description field
+var stream = fs.createReadStream('huge.pdf');
+var options = {
+	fileAttributes: {
+		description: 'A very large PDF'
 	}
-);
+};
+client.files.getChunkedUploader('12345', 2147483648, 'huge.pdf', stream, options)
+	.then(uploader => uploader.start())
+	.then(file => {
+		// ...
+	});
 ```
 
 ### Manual Process

--- a/lib/chunked-uploader.js
+++ b/lib/chunked-uploader.js
@@ -183,6 +183,7 @@ class ChunkedUploader extends EventEmitter {
 	 * @param {Object} [options] Optional parameters
 	 * @param {int} [options.retryInterval=1000] The number of ms to wait before retrying operations
 	 * @param {int} [options.parallelism=4] The number of concurrent chunks to upload
+	 * @param {Object} [options.fileAttributes] Attributes to set on the file during commit
 	 */
 	constructor(client, uploadSessionInfo, file, size, options) {
 
@@ -351,9 +352,9 @@ class ChunkedUploader extends EventEmitter {
 
 		let hash = this._fileHash.digest('base64');
 		this._isStarted = false;
-		let options = {
+		let options = Object.assign({
 			parts: this._chunks.map(c => c.getData())
-		};
+		}, this._options.fileAttributes);
 		this._client.files.commitUploadSession(this._sessionID, hash, options, (err, file) => {
 
 			// It's not clear what the SDK can do here, so we just return the error and session info

--- a/lib/chunked-uploader.js
+++ b/lib/chunked-uploader.js
@@ -4,6 +4,8 @@
 
 'use strict';
 
+const Promise = require('bluebird');
+
 // -----------------------------------------------------------------------------
 // Typedefs
 // -----------------------------------------------------------------------------
@@ -213,12 +215,12 @@ class ChunkedUploader extends EventEmitter {
 
 	/**
 	 * Start an upload
-	 * @returns {void}
+	 * @returns {Promise<Object>} A promise resolving to the uploaded file
 	 */
 	start() {
 
 		if (this._isStarted) {
-			return;
+			return this._promise;
 		}
 
 		// Create the initial chunks
@@ -226,13 +228,22 @@ class ChunkedUploader extends EventEmitter {
 			this._getNextChunk(chunk => (chunk ? this._uploadChunk(chunk) : this._commit()));
 		}
 		this._isStarted = true;
+
+		/* eslint-disable promise/avoid-new */
+		this._promise = new Promise((resolve, reject) => {
+			this._resolve = resolve;
+			this._reject = reject;
+		});
+		/* eslint-enable promise/avoid-new */
+
+		return this._promise;
 	}
 
 	/**
 	 * Abort a running upload, which cancels all currently uploading chunks,
 	 * attempts to free up held memory, and aborts the upload session.  This
 	 * cannot be undone or resumed.
-	 * @returns {void}
+	 * @returns {Promise} A promise resolving when the upload is aborted
 	 * @emits ChunkedUploader#aborted
 	 * @emits ChunkedUploader#abortFailed
 	 */
@@ -243,15 +254,16 @@ class ChunkedUploader extends EventEmitter {
 		this._file = null;
 		this._stream = null;
 
-		this._client.files.abortUploadSession(this._sessionID, err => {
-
-			if (err) {
+		return this._client.files.abortUploadSession(this._sessionID)
+			/* eslint-disable promise/always-return */
+			.then(() => {
+				this.emit('aborted');
+			})
+			/* eslint-enable promise/always-return */
+			.catch(err => {
 				this.emit('abortFailed', err);
-				return;
-			}
-
-			this.emit('aborted');
-		});
+				throw err;
+			});
 	}
 
 	/**
@@ -351,10 +363,12 @@ class ChunkedUploader extends EventEmitter {
 					uploadSession: this._uploadSessionInfo,
 					error: err
 				});
+				this._reject(err);
 				return;
 			}
 
 			this.emit('uploadComplete', file);
+			this._resolve(file);
 		});
 	}
 

--- a/lib/managers/files.js
+++ b/lib/managers/files.js
@@ -1305,10 +1305,17 @@ Files.prototype.getChunkedUploader = function(folderID, size, name, file, option
  * @param {Object} [options] - Optional parameters for the upload
  * @param {int} [options.parallelism] The number of chunks to upload concurrently
  * @param {int} [options.retryInterval] The amount of time to wait before retrying a failed chunk upload, in ms
+ * @param {Object} [options.fileAttributes] Attributes to set on the updated file object
  * @param {Function} [callback] - Passed the uploader if successful
  * @returns {Promise<ChunkedUploader>} A promise resolving to the chunked uploader
  */
 Files.prototype.getNewVersionChunkedUploader = function(fileID, size, file, options, callback) {
+
+	if (file instanceof Readable) {
+		// Need to pause the stream immediately to prevent certain libraries,
+		// e.g. request from placing the stream into flowing mode and consuming bytes
+		file.pause();
+	}
 
 	return this.createNewVersionUploadSession(fileID, size)
 		.then(sessionInfo => new ChunkedUploader(this.client, sessionInfo, file, size, options))

--- a/lib/managers/files.js
+++ b/lib/managers/files.js
@@ -1275,6 +1275,7 @@ Files.prototype.getUploadSession = function(sessionID, callback) {
  * @param {Object} [options] - Optional parameters for the upload
  * @param {int} [options.parallelism] The number of chunks to upload concurrently
  * @param {int} [options.retryInterval] The amount of time to wait before retrying a failed chunk upload, in ms
+ * @param {Object} [options.fileAttributes] Attributes to set on the newly-uploaded file
  * @param {Function} [callback] - Passed the uploader if successful
  * @returns {Promise<ChunkedUploader>} A promise resolving to the chunked uploader
  */

--- a/tests/integration-test.js
+++ b/tests/integration-test.js
@@ -1054,6 +1054,278 @@ describe('Box Node SDK', function() {
 		});
 	});
 
+	it('should upload file in chunks and return promise when chunked upload is requested and run', function() {
+
+		var folderID = '0',
+			fileSize = 1024,
+			fileName = 'foo.txt',
+			uploadSessionID = '07C4B58DF2D79928A787CCB99A5FF37E',
+			fixturePath = path.resolve(__dirname, 'fixtures/file.txt'),
+			/* eslint-disable no-sync */
+			fileContents = fs.readFileSync(fixturePath),
+			/* eslint-enable no-sync */
+			fileStream = fs.createReadStream(fixturePath),
+			uploadMock = nock('https://upload.box.com');
+
+		var parts = [
+			{
+				part_id: '00000001',
+				size: 210,
+				offset: 0,
+				sha1: 'abc'
+			},
+			{
+				part_id: '00000002',
+				size: 210,
+				offset: 210,
+				sha1: 'bcd'
+			},
+			{
+				part_id: '00000003',
+				size: 210,
+				offset: 420,
+				sha1: 'cde'
+			},
+			{
+				part_id: '00000004',
+				size: 210,
+				offset: 630,
+				sha1: 'def'
+			},
+			{
+				part_id: '00000005',
+				size: 210,
+				offset: 840,
+				sha1: 'efa'
+			}
+		];
+
+		var file = {
+			total_count: 1,
+			entries: [
+				{
+					type: 'file',
+					id: '12348765',
+					name: fileName,
+					size: fileSize
+				}
+			]
+		};
+
+		uploadMock.post('/api/2.0/files/upload_sessions',
+			function(body) {
+
+				assert.deepEqual(body, {
+					folder_id: folderID,
+					file_size: fileSize,
+					file_name: fileName
+				});
+
+				return true;
+			})
+			.matchHeader('Authorization', function(authHeader) {
+				assert.equal(authHeader, `Bearer ${TEST_ACCESS_TOKEN}`);
+				return true;
+			})
+			.reply(201, {
+				total_parts: 5,
+				part_size: 210,
+				session_endpoints: {
+					list_parts: 'https://upload.box.com/api/2.0/files/upload-session/07C4B58DF2D79928A787CCB99A5FF37E/parts',
+					commit: 'https://upload.box.com/api/2.0/files/upload-session/07C4B58DF2D79928A787CCB99A5FF37E/commit',
+					log_event: 'https://upload.box.com/api/2.0/files/upload-session/07C4B58DF2D79928A787CCB99A5FF37E/log',
+					upload_part: 'https://upload.box.com/api/2.0/files/upload-session/07C4B58DF2D79928A787CCB99A5FF37E',
+					status: 'https://upload.box.com/api/2.0/files/upload-session/07C4B58DF2D79928A787CCB99A5FF37E',
+					abort: 'https://upload.box.com/api/2.0/files/upload-session/07C4B58DF2D79928A787CCB99A5FF37E'
+				},
+				session_expires_at: '2017-04-25T05:30:23Z',
+				id: uploadSessionID,
+				type: 'upload_session',
+				num_parts_processed: 0
+			})
+			.put(`/api/2.0/files/upload_sessions/${uploadSessionID}`,
+				function(body) {
+					return body.toString() === fileContents.slice(0, 210).toString();
+				}
+			)
+			.matchHeader('Authorization', function(authHeader) {
+				assert.equal(authHeader, `Bearer ${TEST_ACCESS_TOKEN}`);
+				return true;
+			})
+			.matchHeader('Content-Type', function(contentTypeHeader) {
+				assert.equal(contentTypeHeader, 'application/octet-stream');
+				return true;
+			})
+			.matchHeader('Digest', function(digestHeader) {
+				var expected = crypto.createHash('sha1').update(fileContents.slice(0, 210))
+					.digest('base64');
+				return digestHeader === `SHA=${expected}`;
+			})
+			.matchHeader('Content-Range', function(rangeHeader) {
+				assert.equal(rangeHeader, 'bytes 0-209/1024');
+				return true;
+			})
+			.reply(200, {
+				part: parts[0]
+			})
+			.put(`/api/2.0/files/upload_sessions/${uploadSessionID}`,
+				function(body) {
+					return body.toString() === fileContents.slice(210, 420).toString();
+				}
+			)
+			.matchHeader('Authorization', function(authHeader) {
+				assert.equal(authHeader, `Bearer ${TEST_ACCESS_TOKEN}`);
+				return true;
+			})
+			.matchHeader('Content-Type', function(contentTypeHeader) {
+				assert.equal(contentTypeHeader, 'application/octet-stream');
+				return true;
+			})
+			.matchHeader('Digest', function(digestHeader) {
+				assert.equal(digestHeader, `SHA=${crypto.createHash('sha1').update(fileContents.slice(210, 420))
+					.digest('base64')}`);
+				return true;
+			})
+			.matchHeader('Content-Range', function(rangeHeader) {
+				assert.equal(rangeHeader, 'bytes 210-419/1024');
+				return true;
+			})
+			.reply(200, {
+				part: parts[1]
+			})
+			.put(`/api/2.0/files/upload_sessions/${uploadSessionID}`,
+				function(body) {
+					return body.toString() === fileContents.slice(420, 630).toString();
+				}
+			)
+			.matchHeader('Authorization', function(authHeader) {
+				assert.equal(authHeader, `Bearer ${TEST_ACCESS_TOKEN}`);
+				return true;
+			})
+			.matchHeader('Content-Type', function(contentTypeHeader) {
+				assert.equal(contentTypeHeader, 'application/octet-stream');
+				return true;
+			})
+			.matchHeader('Digest', function(digestHeader) {
+				assert.equal(digestHeader, `SHA=${crypto.createHash('sha1').update(fileContents.slice(420, 630))
+					.digest('base64')}`);
+				return true;
+			})
+			.matchHeader('Content-Range', function(rangeHeader) {
+				assert.equal(rangeHeader, 'bytes 420-629/1024');
+				return true;
+			})
+			.reply(200, {
+				part: parts[2]
+			})
+		// @TODO: Add a failure to the test
+		// // 4th part has an error
+			// .put('/api/2.0/files/upload_sessions/' + uploadSessionID,
+			// 	function(body) {
+			// 		return body.toString() === fileContents.slice(630, 840).toString();
+			// 	}
+			// )
+			// .matchHeader('Authorization', function(authHeader) {
+			// 	assert.equal(authHeader, 'Bearer ' + TEST_ACCESS_TOKEN);
+			// 	return true;
+			// })
+			// .matchHeader('Content-Type', function(contentTypeHeader) {
+			// 	assert.equal(contentTypeHeader, 'application/octet-stream');
+			// 	return true;
+			// })
+			// .matchHeader('Digest', function(digestHeader) {
+			// 	assert.equal(digestHeader, 'SHA=' + crypto.createHash('sha1').update(fileContents.slice(630, 840)).digest('base64'));
+			// 	return true;
+			// })
+			// .matchHeader('Content-Range', function(rangeHeader) {
+			// 	assert.equal(rangeHeader, 'bytes 630-839/1024');
+			// 	return true;
+			// })
+			// .reply(502, 'Server Hung Up')
+			.put(`/api/2.0/files/upload_sessions/${uploadSessionID}`,
+				function(body) {
+					return body.toString() === fileContents.slice(630, 840).toString();
+				}
+			)
+			.matchHeader('Authorization', function(authHeader) {
+				assert.equal(authHeader, `Bearer ${TEST_ACCESS_TOKEN}`);
+				return true;
+			})
+			.matchHeader('Content-Type', function(contentTypeHeader) {
+				assert.equal(contentTypeHeader, 'application/octet-stream');
+				return true;
+			})
+			.matchHeader('Digest', function(digestHeader) {
+				assert.equal(digestHeader, `SHA=${crypto.createHash('sha1').update(fileContents.slice(630, 840))
+					.digest('base64')}`);
+				return true;
+			})
+			.matchHeader('Content-Range', function(rangeHeader) {
+				assert.equal(rangeHeader, 'bytes 630-839/1024');
+				return true;
+			})
+			.reply(200, {
+				part: parts[3]
+			})
+			.put(`/api/2.0/files/upload_sessions/${uploadSessionID}`,
+				function(body) {
+					return body.toString() === fileContents.slice(840).toString();
+				}
+			)
+			.matchHeader('Authorization', function(authHeader) {
+				assert.equal(authHeader, `Bearer ${TEST_ACCESS_TOKEN}`);
+				return true;
+			})
+			.matchHeader('Content-Type', function(contentTypeHeader) {
+				assert.equal(contentTypeHeader, 'application/octet-stream');
+				return true;
+			})
+			.matchHeader('Digest', function(digestHeader) {
+				assert.equal(digestHeader, `SHA=${crypto.createHash('sha1').update(fileContents.slice(840))
+					.digest('base64')}`);
+				return true;
+			})
+			.matchHeader('Content-Range', function(rangeHeader) {
+				assert.equal(rangeHeader, 'bytes 840-1023/1024');
+				return true;
+			})
+			.reply(200, {
+				part: parts[4]
+			})
+			.post(`/api/2.0/files/upload_sessions/${uploadSessionID}/commit`,
+				function(body) {
+					assert.property(body, 'parts');
+					assert.typeOf(body.parts, 'array');
+					assert.sameDeepMembers(body.parts, parts);
+
+					return true;
+				}
+			)
+			.matchHeader('Authorization', function(authHeader) {
+				assert.equal(authHeader, `Bearer ${TEST_ACCESS_TOKEN}`);
+				return true;
+			})
+			.matchHeader('Digest', function(digestHeader) {
+				assert.equal(digestHeader, `SHA=${crypto.createHash('sha1').update(fileContents)
+					.digest('base64')}`);
+				return true;
+			})
+			.reply(201, file);
+
+		var sdk = new BoxSDK({
+			clientID: TEST_CLIENT_ID,
+			clientSecret: TEST_CLIENT_SECRET
+		});
+
+		var client = sdk.getBasicClient(TEST_ACCESS_TOKEN);
+
+		return client.files.getChunkedUploader(folderID, fileSize, fileName, fileStream)
+			.then(uploader => uploader.start())
+			.then(data => {
+				assert.deepEqual(data, file);
+			});
+	});
+
 	it('should send batch request and pass results to individual calls when batch is executed', function() {
 
 		var folderID = '1234',

--- a/tests/integration-test.js
+++ b/tests/integration-test.js
@@ -1054,7 +1054,7 @@ describe('Box Node SDK', function() {
 		});
 	});
 
-	it('should upload file in chunks and return promise when chunked upload is requested and run', function() {
+	it('should upload with file attributes and return promise when chunked upload is executed', function() {
 
 		var folderID = '0',
 			fileSize = 1024,
@@ -1099,6 +1099,11 @@ describe('Box Node SDK', function() {
 				sha1: 'efa'
 			}
 		];
+
+		var fileAttributes = {
+			description: 'My chunked upload',
+			content_created_at: '1988-11-18T09:30:00-06:00'
+		};
 
 		var file = {
 			total_count: 1,
@@ -1298,6 +1303,8 @@ describe('Box Node SDK', function() {
 					assert.typeOf(body.parts, 'array');
 					assert.sameDeepMembers(body.parts, parts);
 
+					assert.deepPropertyVal(body, 'attributes', fileAttributes);
+
 					return true;
 				}
 			)
@@ -1319,7 +1326,7 @@ describe('Box Node SDK', function() {
 
 		var client = sdk.getBasicClient(TEST_ACCESS_TOKEN);
 
-		return client.files.getChunkedUploader(folderID, fileSize, fileName, fileStream)
+		return client.files.getChunkedUploader(folderID, fileSize, fileName, fileStream, { fileAttributes })
 			.then(uploader => uploader.start())
 			.then(data => {
 				assert.deepEqual(data, file);

--- a/tests/lib/chunked-uploader-test.js
+++ b/tests/lib/chunked-uploader-test.js
@@ -15,7 +15,8 @@ const BoxClient = require('../../lib/box-client'),
 	Files = require('../../lib/managers/files'),
 	EventEmitter = require('events').EventEmitter,
 	ReadStream = require('fs').ReadStream,
-	crypto = require('crypto');
+	crypto = require('crypto'),
+	Promise = require('bluebird');
 
 // ------------------------------------------------------------------------------
 // Helpers
@@ -295,6 +296,7 @@ describe('ChunkedUploader', function() {
 				uploader.start();
 			});
 
+
 			it('should upload all chunks and commit when the file fits into fewer than the initial number of chunks', function(done) {
 
 				let smallFile = 'abcdefghijklmnop',
@@ -420,6 +422,7 @@ describe('ChunkedUploader', function() {
 
 				uploader.start();
 			});
+
 
 			it('should upload all chunks and commit when the file fits exactly in chunk boundaries', function(done) {
 
@@ -668,6 +671,204 @@ describe('ChunkedUploader', function() {
 				uploader.start();
 			});
 		});
+
+		it('should resolve to the created file when the file is successfully uploaded', function() {
+
+			let largeFile = 'part1 str.part2 str.part3 str.part4 str.part5 str.part6 str',
+				hash = crypto.createHash('sha1').update(largeFile)
+					.digest('base64');
+
+			uploader = new ChunkedUploader(boxClientFake, TEST_UPLOAD_SESSION_INFO, largeFile, largeFile.length);
+
+			let expectedChunks = [
+				{
+					part_id: '00000001',
+					offset: 0,
+					size: 10
+				},
+				{
+					part_id: '00000002',
+					offset: 10,
+					size: 10
+				},
+				{
+					part_id: '00000003',
+					offset: 20,
+					size: 10
+				},
+				{
+					part_id: '00000004',
+					offset: 30,
+					size: 10
+				},
+				{
+					part_id: '00000005',
+					offset: 40,
+					size: 10
+				},
+				{
+					part_id: '00000006',
+					offset: 50,
+					size: 9
+				}
+			];
+
+			let createdFile = {
+				type: 'file',
+				id: '785692378452345',
+				sha1: hash
+			};
+
+			let filesClientMock = sandbox.mock(boxClientFake.files);
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'part1 str.', 0, 59)
+				.yieldsAsync(null, {part: expectedChunks[0]});
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'part2 str.', 10, 59)
+				.yieldsAsync(null, {part: expectedChunks[1]});
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'part3 str.', 20, 59)
+				.yieldsAsync(null, {part: expectedChunks[2]});
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'part4 str.', 30, 59)
+				.yieldsAsync(null, {part: expectedChunks[3]});
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'part5 str.', 40, 59)
+				.yieldsAsync(null, {part: expectedChunks[4]});
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'part6 str', 50, 59)
+				.yieldsAsync(null, {part: expectedChunks[5]});
+
+			filesClientMock.expects('commitUploadSession').withArgs(TEST_SESSION_ID, hash, {parts: sinon.match(expectedChunks)})
+				.yieldsAsync(null, createdFile);
+
+			return uploader.start()
+				.then(data => {
+					assert.deepEqual(data, createdFile);
+				});
+		});
+
+		it('should return the same promise when start is called multiple times', function() {
+
+			let expectedChunks = [
+				{
+					part_id: '00000001',
+					offset: 0,
+					size: 10
+				},
+				{
+					part_id: '00000002',
+					offset: 10,
+					size: 10
+				},
+				{
+					part_id: '00000003',
+					offset: 20,
+					size: 10
+				},
+				{
+					part_id: '00000004',
+					offset: 10,
+					size: 6
+				}
+			];
+
+			let createdFile = {
+				type: 'file',
+				id: '785692378452345',
+				sha1: TEST_HASH
+			};
+
+			let filesClientMock = sandbox.mock(boxClientFake.files);
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'abcdefghij', 0, 36)
+				.yieldsAsync(null, {part: expectedChunks[0]});
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'klmnopqrst', 10, 36)
+				.yieldsAsync(null, {part: expectedChunks[1]});
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'uvwxyz0123', 20, 36)
+				.yieldsAsync(null, {part: expectedChunks[2]});
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, '456789', 30, 36)
+				.yieldsAsync(null, {part: expectedChunks[3]});
+
+			filesClientMock.expects('commitUploadSession').withArgs(TEST_SESSION_ID, TEST_HASH, {parts: sinon.match(expectedChunks)})
+				.yieldsAsync(null, createdFile);
+
+			var p1 = uploader.start();
+			var p2 = uploader.start();
+
+			assert.equal(p1, p2);
+
+			return Promise.all([
+				p1,
+				p2
+			]);
+		});
+
+		it('should emit error event and reject when commit fails', function() {
+
+			let largeFile = 'part1 str.part2 str.part3 str.part4 str.part5 str.part6 str',
+				hash = crypto.createHash('sha1').update(largeFile)
+					.digest('base64');
+
+			uploader = new ChunkedUploader(boxClientFake, TEST_UPLOAD_SESSION_INFO, largeFile, largeFile.length);
+
+			let expectedChunks = [
+				{
+					part_id: '00000001',
+					offset: 0,
+					size: 10
+				},
+				{
+					part_id: '00000002',
+					offset: 10,
+					size: 10
+				},
+				{
+					part_id: '00000003',
+					offset: 20,
+					size: 10
+				},
+				{
+					part_id: '00000004',
+					offset: 30,
+					size: 10
+				},
+				{
+					part_id: '00000005',
+					offset: 40,
+					size: 10
+				},
+				{
+					part_id: '00000006',
+					offset: 50,
+					size: 9
+				}
+			];
+
+			let commitError = new Error('It failed');
+			let emittedError;
+
+			uploader.on('error', data => {
+				emittedError = data.error;
+			});
+
+			let filesClientMock = sandbox.mock(boxClientFake.files);
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'part1 str.', 0, 59)
+				.yieldsAsync(null, {part: expectedChunks[0]});
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'part2 str.', 10, 59)
+				.yieldsAsync(null, {part: expectedChunks[1]});
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'part3 str.', 20, 59)
+				.yieldsAsync(null, {part: expectedChunks[2]});
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'part4 str.', 30, 59)
+				.yieldsAsync(null, {part: expectedChunks[3]});
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'part5 str.', 40, 59)
+				.yieldsAsync(null, {part: expectedChunks[4]});
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'part6 str', 50, 59)
+				.yieldsAsync(null, {part: expectedChunks[5]});
+
+			filesClientMock.expects('commitUploadSession').withArgs(TEST_SESSION_ID, hash, {parts: sinon.match(expectedChunks)})
+				.yieldsAsync(commitError);
+
+			return uploader.start()
+				.then(() => assert.fail('Expected promise to reject'))
+				.catch(err => {
+					assert.equal(err, commitError, 'Promise shoudl reject with commit error');
+					assert.equal(emittedError, commitError, 'Commit error should have been emitted by uploader');
+				});
+		});
 	});
 
 	describe('abort()', function() {
@@ -713,10 +914,46 @@ describe('ChunkedUploader', function() {
 				.yieldsAsync(uploadAPIError);
 
 			filesClientMock.expects('abortUploadSession').withArgs(TEST_SESSION_ID)
-				.yieldsAsync(null);
+				.returns(Promise.resolve());
 
 			uploader.start();
 			uploader.abort();
+		});
+
+		it('should resolve when abort succeeds', function() {
+
+			let uploadError = new Error('Chunk totally failed!');
+			let uploadAPIError = new Error('Chunk failed in API');
+			uploadAPIError.statusCode = 500;
+
+			let expectedChunks = [
+				{
+					part_id: '00000001',
+					offset: 0,
+					size: 10
+				},
+				{
+					part_id: '00000002',
+					offset: 10,
+					size: 10
+				}
+			];
+
+			let filesClientMock = sandbox.mock(boxClientFake.files);
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'abcdefghij', 0, 36)
+				.yieldsAsync(null, {part: expectedChunks[0]});
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'klmnopqrst', 10, 36)
+				.yieldsAsync(null, {part: expectedChunks[1]});
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'uvwxyz0123', 20, 36)
+				.yieldsAsync(uploadError);
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, '456789', 30, 36)
+				.yieldsAsync(uploadAPIError);
+
+			filesClientMock.expects('abortUploadSession').withArgs(TEST_SESSION_ID)
+				.returns(Promise.resolve());
+
+			uploader.start();
+			return uploader.abort();
 		});
 
 		it('should emit abortFailed event when abort fails', function(done) {
@@ -763,10 +1000,51 @@ describe('ChunkedUploader', function() {
 				.yieldsAsync(uploadAPIError);
 
 			filesClientMock.expects('abortUploadSession').withArgs(TEST_SESSION_ID)
-				.yieldsAsync(abortError);
+				.returns(Promise.reject(abortError));
 
 			uploader.start();
 			uploader.abort();
+		});
+
+		it('should reject when abort fails', function() {
+
+			let uploadError = new Error('Chunk totally failed!');
+			let uploadAPIError = new Error('Chunk failed in API');
+			uploadAPIError.statusCode = 500;
+			let abortError = new Error('Could not delete upload session');
+
+			let expectedChunks = [
+				{
+					part_id: '00000001',
+					offset: 0,
+					size: 10
+				},
+				{
+					part_id: '00000002',
+					offset: 10,
+					size: 10
+				}
+			];
+
+			let filesClientMock = sandbox.mock(boxClientFake.files);
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'abcdefghij', 0, 36)
+				.yieldsAsync(null, {part: expectedChunks[0]});
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'klmnopqrst', 10, 36)
+				.yieldsAsync(null, {part: expectedChunks[1]});
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, 'uvwxyz0123', 20, 36)
+				.yieldsAsync(uploadError);
+			filesClientMock.expects('uploadPart').withArgs(TEST_SESSION_ID, '456789', 30, 36)
+				.yieldsAsync(uploadAPIError);
+
+			filesClientMock.expects('abortUploadSession').withArgs(TEST_SESSION_ID)
+				.returns(Promise.reject(abortError));
+
+			uploader.start();
+			return uploader.abort()
+				.then(() => assert.fail('Expected promise to reject'))
+				.catch(err => {
+					assert.equal(err, abortError);
+				});
 		});
 	});
 


### PR DESCRIPTION
- Return a promise from `uploader.start()` and `uploader.abort()` to simplify use of the basic Chunked Upload operations
- Allow passing file attributes through the chunked uploader options