### PR TITLE
Allow reconfiguring of request retry strategy

### DIFF
--- a/lib/api-request.js
+++ b/lib/api-request.js
@@ -285,8 +285,27 @@ APIRequest.prototype._retry = function(err) {
 	this.numRetries = this.numRetries || 0;
 
 	if (this.numRetries < this.config.numMaxRetries) {
+		var retryTimeout;
 		this.numRetries += 1;
-		setTimeout(this.execute.bind(this), getRetryTimeout(this.numRetries, this.config.retryIntervalMS));
+		if (this.config.retryStrategy) {
+			var retryOptions = {
+				error: err,
+				numRetries: this.numRetries,
+				numMaxRetries: this.config.numMaxRetries,
+				retryIntervalMS: this.config.retryIntervalMS
+			};
+			retryTimeout = this.config.retryStrategy(retryOptions);
+			if (typeof retryTimeout !== 'number') {
+				if (retryTimeout instanceof Error) {
+					err = retryTimeout;
+				}
+				this._finish(err);
+				return;
+			}
+		} else {
+			retryTimeout = getRetryTimeout(this.numRetries, this.config.retryIntervalMS);
+		}
+		setTimeout(this.execute.bind(this), retryTimeout);
 	} else {
 		err.maxRetriesExceeded = true;
 		this._finish(err);

--- a/lib/api-request.js
+++ b/lib/api-request.js
@@ -86,6 +86,8 @@ var HTTP_STATUS_CODE_SERVER_ERROR_BLOCK_RANGE = [
 	599
 ];
 
+// Timer used to track elapsed time beginning from executing an async request to emitting the response.
+var asyncRequestTimer;
 
 // A map of HTTP status codes and whether or not they can be retried
 var retryableStatusCodes = {};
@@ -205,6 +207,10 @@ APIRequest.prototype.execute = function(callback) {
 
 	// Initiate an async- or stream-based request, based on the presence of the callback.
 	if (this._callback) {
+		// Start the request timer immediately before executing the async request
+		if (!asyncRequestTimer) {
+			asyncRequestTimer = process.hrtime();
+		}
 		this.request = request(this.config.request, this._handleResponse.bind(this));
 	} else {
 		this.request = request(this.config.request);
@@ -287,14 +293,24 @@ APIRequest.prototype._retry = function(err) {
 	if (this.numRetries < this.config.numMaxRetries) {
 		var retryTimeout;
 		this.numRetries += 1;
+		// If the retry strategy is defined, then use it to determine the time (in ms) until the next retry or to
+		// propagate an error to the user.
 		if (this.config.retryStrategy) {
+			// Get the total elapsed time so far since the request was executed
+			var totalElapsedTime = process.hrtime(asyncRequestTimer);
+			var totalElapsedTimeMS = (totalElapsedTime[0] * 1000) + (totalElapsedTime[1] / 1000000);
 			var retryOptions = {
 				error: err,
-				numRetries: this.numRetries,
+				numRetryAttempts: this.numRetries,
 				numMaxRetries: this.config.numMaxRetries,
-				retryIntervalMS: this.config.retryIntervalMS
+				retryIntervalMS: this.config.retryIntervalMS,
+				totalElapsedTimeMS
 			};
+
 			retryTimeout = this.config.retryStrategy(retryOptions);
+
+			// If the retry strategy doesn't return a number/time in ms, then propagate the response error to the user.
+			// However, if the retry strategy returns its own error, this will be propagated to the user instead.
 			if (typeof retryTimeout !== 'number') {
 				if (retryTimeout instanceof Error) {
 					err = retryTimeout;

--- a/lib/util/config.js
+++ b/lib/util/config.js
@@ -57,6 +57,7 @@ var defaults = {
 	uploadRequestTimeoutMS: 60000,
 	retryIntervalMS: 2000,
 	numMaxRetries: 5,
+	retryStrategy: null,
 	expiredBufferMS: 180000,
 	staleBufferMS: 0, // DEPRECATED -- token expiration buffer will be max(expiredBufferMS, staleBufferMS)
 	appAuth: undefined,

--- a/tests/integration-test.js
+++ b/tests/integration-test.js
@@ -263,16 +263,23 @@ describe('Box Node SDK', function() {
 
 				// Retry strategy should be called up to maxNumRetries times
 				sinon.assert.callCount(retryStrategyStub, maxNumRetries);
-				// Retry strategy function should be passed arg object with correct properties
-				var args = retryStrategyStub.getCall(0).args;
+
+				var retryCall = retryStrategyStub.getCall(0);
+				var args = retryCall.args;
+				// Retry strategy should be passed one arg: the retry options object
 				assert.lengthOf(args, 1);
-				assert.hasAllKeys(args[0], [
-					'error',
-					'numMaxRetries',
-					'numRetryAttempts',
-					'retryIntervalMS',
-					'totalElapsedTimeMS'
-				]);
+				// The retry options object should contain the passed in numMaxRetries and retryIntervalMS from the
+				// SDK config as well as the correct retry attempt number.
+				sinon.assert.calledWith(retryCall, sinon.match({
+					numMaxRetries: maxNumRetries,
+					numRetryAttempts: 1,
+					retryIntervalMS
+				}));
+				// The retry options object should contain an Error with the correct status code
+				assert.instanceOf(args[0].error, Error);
+				assert.equal(args[0].error.statusCode, 500);
+				// The retry options object should contain the total elapsed time in MS as a number
+				assert.isNumber(args[0].totalElapsedTimeMS);
 			});
 	});
 


### PR DESCRIPTION
Adds `config.retryStrategy` which is an optional config param. It is a function that takes in an object of options including the error, # of retries made so far, and the `config.numMaxRetries` and `config.retryIntervalMS`.  If the function returns a number, then this will be used as the time (in ms) until the next retry. If the function returns an Error, this will be propagated in the response to the user. If neither of those are returned, the original response error object will be propagated.