### PR TITLE
Defend against undefined request URI when creating error objects

### DIFF
--- a/lib/util/errors.js
+++ b/lib/util/errors.js
@@ -37,13 +37,17 @@ var qs = require('querystring'),
  */
 function Request(req) {
 	this.method = req.method;
-	this.url = {
-		protocol: req.uri.protocol,
-		host: req.uri.host,
-		path: req.uri.pathname,
-		query: qs.parse(req.uri.query),
-		fragment: req.uri.hash
-	};
+	if (req.uri) {
+		this.url = {
+			protocol: req.uri.protocol,
+			host: req.uri.host,
+			path: req.uri.pathname,
+			query: qs.parse(req.uri.query),
+			fragment: req.uri.hash
+		};
+	} else {
+		this.url = null;
+	}
 	this.httpVersion = req.response.httpVersion;
 	this.headers = req.headers;
 	this.body = req.body;

--- a/tests/lib/util/errors-test.js
+++ b/tests/lib/util/errors-test.js
@@ -75,6 +75,81 @@ describe('Errors', function() {
 			assert.strictEqual(errObject.statusCode, 505);
 			assert.strictEqual(errObject.response, response);
 		});
+
+		it('should attach formatted request object when request context is present', function() {
+
+			var response = {
+				statusCode: 505,
+				body: {foo: 'bar'},
+				httpVersion: '1.1',
+				request: {
+					method: 'GET',
+					uri: {
+						protocol: 'https://',
+						host: 'api.box.com',
+						pathname: '/2.0/users/me',
+						query: 'fields=name',
+						hash: ''
+					},
+					headers: {
+						'as-user': '12345'
+					}
+				}
+			};
+			response.request.response = response;
+
+			var expectedRequest = {
+				method: 'GET',
+				url: {
+					protocol: 'https://',
+					host: 'api.box.com',
+					path: '/2.0/users/me',
+					query: {
+						fields: 'name'
+					},
+					fragment: '',
+				},
+				httpVersion: '1.1',
+				body: undefined,
+				headers: {
+					'as-user': '12345'
+				}
+			};
+
+			var errObject = errors.buildResponseError(response, 'testMessage');
+
+			assert.deepEqual(errObject.request, expectedRequest);
+		});
+
+		it('should not throw when request URI is undefined', function() {
+
+			var response = {
+				statusCode: 505,
+				body: {foo: 'bar'},
+				httpVersion: '1.1',
+				request: {
+					method: 'GET',
+					headers: {
+						'as-user': '12345'
+					}
+				}
+			};
+			response.request.response = response;
+
+			var expectedRequest = {
+				method: 'GET',
+				url: null,
+				httpVersion: '1.1',
+				body: undefined,
+				headers: {
+					'as-user': '12345'
+				}
+			};
+
+			var errObject = errors.buildResponseError(response, 'testMessage');
+
+			assert.deepEqual(errObject.request, expectedRequest);
+		});
 	});
 
 	describe('buildUnexpectedResponseError()', function() {


### PR DESCRIPTION
In some cases, potentially under high load conditions, a request object without a `uri` can apparently be passed through the error flow, which resulted in a `TypeError` when we try to dereference `uri` properties.  Since that exact error condition is so far unreproducible, for now an explicit safety check should suffice to unblock users encountering this issue.

Fixes #351 