### PR TITLE
Add trace ID to API error message

### DIFF
--- a/lib/util/errors.js
+++ b/lib/util/errors.js
@@ -10,7 +10,7 @@
 var qs = require('querystring'),
 	httpStatusCodes = require('http-status');
 
-var TRACE_ID_HEADER_NAME = 'box-request-id';
+const TRACE_ID_HEADER_NAME = 'box-request-id';
 
 // ------------------------------------------------------------------------------
 // Typedefs and Callbacks

--- a/lib/util/errors.js
+++ b/lib/util/errors.js
@@ -10,6 +10,7 @@
 var qs = require('querystring'),
 	httpStatusCodes = require('http-status');
 
+var TRACE_ID_HEADER = 'box-request-id';
 
 // ------------------------------------------------------------------------------
 // Typedefs and Callbacks
@@ -80,23 +81,42 @@ module.exports = {
 		message = message || 'API Response Error';
 
 		var statusCode = response.statusCode;
-		var requestID = '';
-		if (response.body && response.body.request_id) {
-			requestID = ` | ${response.body.request_id}`;
+		var statusMessage = httpStatusCodes[statusCode];
+		var debugID = ''; // Of the form <requestID>.<traceID>, both parts optional
+		var errorCode;
+		var errorDescription;
+
+		if (response.headers && response.headers[TRACE_ID_HEADER]) {
+			// Append trace ID with dot separator — if not present, the dot should be omitted
+			debugID += `.${response.headers[TRACE_ID_HEADER]}`;
 		}
 
-		var apiMessage = '';
 
 		if (response.body) {
 
-			var code = response.body.code || response.body.error;
-			var description = response.body.message || response.body.error_description;
+			if (response.body.request_id) {
+				// Prepend request ID
+				debugID = response.body.request_id + debugID;
+			}
 
-			apiMessage += code ? ` ${code}` : '';
-			apiMessage += description ? ` - ${description}` : '';
+			errorCode = response.body.code || response.body.error;
+			errorDescription = response.body.message || response.body.error_description;
 		}
 
-		var errorMessage = `${message} [${statusCode} ${httpStatusCodes[statusCode]}${requestID}]${apiMessage}`;
+		var errorMessage;
+		if (debugID) {
+			errorMessage = `${message} [${statusCode} ${statusMessage} | ${debugID}]`;
+		} else {
+			errorMessage = `${message} [${statusCode} ${statusMessage}]`;
+		}
+
+		if (errorCode) {
+			errorMessage += ` ${errorCode}`;
+		}
+		if (errorDescription) {
+			errorMessage += ` - ${errorDescription}`;
+		}
+
 		var responseError = new Error(errorMessage);
 
 		responseError.statusCode = response.statusCode;

--- a/lib/util/errors.js
+++ b/lib/util/errors.js
@@ -10,7 +10,7 @@
 var qs = require('querystring'),
 	httpStatusCodes = require('http-status');
 
-var TRACE_ID_HEADER = 'box-request-id';
+var TRACE_ID_HEADER_NAME = 'box-request-id';
 
 // ------------------------------------------------------------------------------
 // Typedefs and Callbacks
@@ -86,9 +86,9 @@ module.exports = {
 		var errorCode;
 		var errorDescription;
 
-		if (response.headers && response.headers[TRACE_ID_HEADER]) {
+		if (response.headers && response.headers[TRACE_ID_HEADER_NAME]) {
 			// Append trace ID with dot separator — if not present, the dot should be omitted
-			debugID += `.${response.headers[TRACE_ID_HEADER]}`;
+			debugID += `.${response.headers[TRACE_ID_HEADER_NAME]}`;
 		}
 
 

--- a/tests/lib/util/errors-test.js
+++ b/tests/lib/util/errors-test.js
@@ -76,6 +76,60 @@ describe('Errors', function() {
 			assert.strictEqual(errObject.response, response);
 		});
 
+		it('should add request ID to error message when present in body', function() {
+
+			var requestID = '98nq34otquhet';
+
+			var response = {
+				statusCode: 505,
+				body: {
+					foo: 'bar',
+					request_id: requestID
+				}
+			};
+			var errObject = errors.buildResponseError(response, 'testMessage');
+
+			assert.strictEqual(errObject.message, `testMessage [505 HTTP Version not Supported | ${requestID}]`);
+		});
+
+		it('should add trace ID to error message when present in headers', function() {
+
+			var traceID = 'KUHFIUYVIYTFIYTF*&^TI&YGIU';
+
+			var response = {
+				statusCode: 505,
+				body: {
+					foo: 'bar'
+				},
+				headers: {
+					'box-request-id': traceID
+				}
+			};
+			var errObject = errors.buildResponseError(response, 'testMessage');
+
+			assert.strictEqual(errObject.message, `testMessage [505 HTTP Version not Supported | .${traceID}]`);
+		});
+
+		it('should add request and trace IDs to error message when both are present in response', function() {
+
+			var requestID = '98nq34otquhet',
+				traceID = 'KUHFIUYVIYTFIYTF*&^TI&YGIU';
+
+			var response = {
+				statusCode: 404,
+				body: {
+					foo: 'bar',
+					request_id: requestID
+				},
+				headers: {
+					'box-request-id': traceID
+				}
+			};
+			var errObject = errors.buildResponseError(response, 'testMessage');
+
+			assert.strictEqual(errObject.message, `testMessage [404 Not Found | ${requestID}.${traceID}]`);
+		});
+
 		it('should attach formatted request object when request context is present', function() {
 
 			var response = {


### PR DESCRIPTION
The Box API now sends back a second request ID (trace ID) in the
BOX-REQUEST-ID header.  When this value is present, it will be
included in SDK response error messages to aid in troubleshooting.