### PR TITLE
Split get_folders_id sample

### DIFF
--- a/docs/folders.md
+++ b/docs/folders.md
@@ -26,17 +26,10 @@ Get a Folder's Information
 
 Folder information can be retrieved by calling the
 [`folders.get(folderID, options, callback)`](http://opensource.box.com/box-node-sdk/jsdoc/Folders.html#get)
-method. Use the `fields` option to specify the desired fields. Requesting
-information for only the fields you need can improve performance and reduce the
-size of the network request.
+method. Use the `fields` option to specify the desired fields. 
 
 <!-- sample get_folders_id -->
 ```js
-client.folders.get(
-    '12345',
-    {fields: 'name,shared_link,permissions,collections,sync_state'},
-    callback
-);
 client.folders.get('11111')
     .then(folder => {
         /* folder -> {
@@ -93,6 +86,19 @@ client.folders.get('11111')
                 limit: 100 } }
         */
     });
+```
+
+Requesting
+information for only the fields you need can improve performance and reduce the
+size of the network request.
+
+```js
+client.folders.get(
+    '12345',
+    { fields: 'name,shared_link,permissions,collections,sync_state' }
+).then(folder => {
+    // ...
+});
 ```
 
 The user's root folder can be accessed by calling the


### PR DESCRIPTION
This sample had two samples within the code block, which was a problem for the dev docs.

I've updated it to a generic sample, followed by a sample showing how to limit fields.

I also turned this second sample into one using promises, as we don't seem to use callbacks in any of the other samples.