### PR TITLE
Update webhooks.md

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -189,6 +189,7 @@ When you receive a webhook message from Box, you should validate it by calling
 [`BoxSDK.validateWebhookMessage(body, headers, primarySignatureKey, secondarySignatureKey, maxMessageAge)`](http://opensource.box.com/box-node-sdk/jsdoc/Webhooks.html#.validateMessage),
 also available as `webhooks.validateMessage(body, headers, primarySignatureKey, secondarySignatureKey, maxMessageAge)`.
 
+<!-- sample x_webhooks validate_signatures -->
 ```js
 const BoxSDK = require('box-node-sdk');
 let body = '{"type":"webhook_event","webhook":{"id":"1234567890"},"trigger":"FILE.UPLOADED","source":{"id":"1234567890","type":"file","name":"Test.txt"}}',


### PR DESCRIPTION
Add a sample tag for verifying signatures.

Decided to use a new syntax of `x_tagname variant` for a SDK feature that does not directly match an endpoint. In this case, `x_webhooks validate_signatures` signifies the `validate_signatures` sample for the `webhooks` category.

This can be used in a guide, but won't risk appearing in the API reference.