### PR TITLE
Fix retry error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## Next Release
+
+- Fixed an issue where an error is thrown during a retry when a response is not returned by the previous call (#476).
+
 ## 1.31.0 [2020-02-13]
 
-- Fix Authentication Request Retries
+- Fixed Authentication Request Retries
 - Added marker-based paging for users endpoints
 - Added `getNextMarker()` to PagingIterator to get the next marker
 

--- a/lib/api-request.js
+++ b/lib/api-request.js
@@ -224,7 +224,7 @@ APIRequest.prototype.getResponseStream = function() {
  * @private
  */
 APIRequest.prototype._handleResponse = function(err, response) {
-
+	
 	// Clean sensitive headers here to prevent the user from accidentily using/logging them in prod
 	cleanSensitiveHeaders(this.request);
 
@@ -305,7 +305,7 @@ APIRequest.prototype._retry = function(err) {
 				this._finish(err);
 				return;
 			}
-		} else if (err.response.hasOwnProperty('headers') && err.response.headers.hasOwnProperty('retry-after')) {
+		} else if (err.hasOwnProperty('response') && err.response.hasOwnProperty('headers') && err.response.headers.hasOwnProperty('retry-after')) {
 			retryTimeout = err.response.headers['retry-after'] * 1000;
 		} else {
 			retryTimeout = getRetryTimeout(this.numRetries, this.config.retryIntervalMS);

--- a/lib/token-manager.js
+++ b/lib/token-manager.js
@@ -404,7 +404,7 @@ TokenManager.prototype = {
 					}
 					throw error;
 				}
-			} else if (error.response.headers.hasOwnProperty('retry-after')) {
+			} else if (error.hasOwnProperty('response') && error.response.hasOwnProperty('headers') && error.response.headers.hasOwnProperty('retry-after')) {
 				retryTimeout = error.response.headers['retry-after'] * 1000;
 			} else {
 				retryTimeout = getRetryTimeout(numRetries, this.config.retryIntervalMS);


### PR DESCRIPTION
When we changed the retry logic in #461, we introduced a check that would pull off the `retry-after` header and retry after the amount of time specified by the header. However, in doing this check, we assumed that the response is always returned. This is incorrect in that the response is sometimes not returned. When it is not returned, our check breaks and causes the error shown in issue #476.