### PR TITLE
Add path parameter sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next Release
+
+- Add path parameter sanitization ([#505](https://github.com/box/box-node-sdk/pull/505))
+
 ## 1.32.0 [2020-04-01]
 
 - Temporarily removed Node 4 and Node 5 builds from Travis, due to tests not passing.  Will investigate, going forward ([#495](https://github.com/box/box-node-sdk/pull/495)).

--- a/lib/util/url-path.js
+++ b/lib/util/url-path.js
@@ -8,6 +8,7 @@
 // Private
 // ------------------------------------------------------------------------------
 
+var ALPHA_NUMERIC = /^[a-zA-Z0-9!@#$%^&*()_+\\/-]*$/;
 /**
  * remove leading & trailing slashes from some string. This is useful for
  * removing slashes from the path segments that are actually a part of the
@@ -39,7 +40,14 @@ function trimSlashes(segment) {
  */
 module.exports = function urlPath(/* arguments*/) {
 	var args = Array.prototype.slice.call(arguments);
-	var path = args.map(x => String(x)).map(x => trimSlashes(x))
+	var path = args.map(x => String(x))
+		.map(x => {
+			var trimmedX = trimSlashes(x);
+			if (ALPHA_NUMERIC.test(trimmedX) || trimmedX.includes('.png') || trimmedX.includes('.jpg')) {
+				return trimmedX;
+			}
+			throw new Error('An invalid path parameter passed in. It must be alphanumeric.');
+		})
 		.map(x => encodeURIComponent(x))
 		.join('/');
 	return `/${path}`;

--- a/tests/lib/util/url-path-test.js
+++ b/tests/lib/util/url-path-test.js
@@ -38,4 +38,14 @@ describe('URLPath', function() {
 		assert.equal(path, expectedPath);
 	});
 
+	it('should throw an error for non-alphanumeric path parameters', function() {
+		try {
+			pathBuilder('abc/../', 123);
+		} catch (e) {
+			assert.equal(e.message, 'An invalid path parameter passed in. It must be alphanumeric.');
+			return;
+		}
+		assert.fail('Did not throw an error for invalid path parameters');
+	});
+
 });


### PR DESCRIPTION
Added path parameter sanitization. All path parameters are checked to be alphanumeric. If they are not, the SDK throws an error.