### PR TITLE
Fix incorrect headers in Zip documentation

### DIFF
--- a/docs/files.md
+++ b/docs/files.md
@@ -1250,7 +1250,7 @@ client.files.getRepresentationContent('12345', '[png?dimensions=1024x1024]', { a
 [get-rep-content]: http://opensource.box.com/box-node-sdk/jsdoc/Files.html#getRepresentationContent
 
 Create a Zip File
-_________________
+-----------------
 
 Calling [`files.createZip(name, items, callback)`][create-a-zip-file] will let you create a new zip file with the specified name and 
 with the specified items and will return a response with the download and status link. This file does not show up in your Box account, but will be temporarily available for download.
@@ -1310,7 +1310,7 @@ client.files.createZip(name, items)
 [create-a-zip-file]: http://opensource.box.com/box-node-sdk/jsdoc/Files.html#createZip
 
 Download a Zip File
-_________________
+-------------------
 
 Calling [`file.download(name, items, stream, callback)`][download-a-zip-file] will let you create a new zip file 
 with the specified name and with the specified items and download it to the stream that is passed in. The return object is status


### PR DESCRIPTION
Headers we're not using correct markdown syntax.