### PR TITLE
Fix webhook signature validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next Release
+
+**Bug Fixes:**
+
+- Fix webhook signature validation ([#568](https://github.com/box/box-node-sdk/pull/568))
+
 ## 1.36.0 (2020-01-27)
 
 **New Features and Enhancements:**

--- a/lib/managers/webhooks.js
+++ b/lib/managers/webhooks.js
@@ -110,6 +110,17 @@ function validateDeliveryTimestamp(headers, maxMessageAge) {
 	return true;
 }
 
+/**
+ * Stringify JSON with escaped multibyte Unicode characters to ensure computed signatures match PHP's default behavior
+ *
+ * @param {Object} body - The parsed JSON object
+ * @returns {string} - Stringified JSON with escaped multibyte Unicode characters
+ * @private
+ */
+function jsonStringifyWithEscapedUnicode(body) {
+	return JSON.stringify(body).replace(/[\u007f-\uffff]/g, char => `\\u${`0000${char.charCodeAt(0).toString(16)}`.slice(-4)}`);
+}
+
 // -----------------------------------------------------------------------------
 // Public
 // -----------------------------------------------------------------------------
@@ -351,7 +362,8 @@ Webhooks.validateMessage = function(body, headers, primaryKey, secondaryKey, max
 	// For frameworks like Express that automatically parse JSON
 	// bodies into Objects, re-stringify for signature testing
 	if (typeof body === 'object') {
-		body = JSON.stringify(body);
+		// Escape forward slashes to ensure a matching signature
+		body = jsonStringifyWithEscapedUnicode(body).replace(/\//g, '\\/');
 	}
 
 	if (!validateSignature(body, headers, primaryKey, secondaryKey)) {


### PR DESCRIPTION
### Issue Link :link:

- Fixes https://github.com/box/box-node-sdk/issues/533

### Implementation Details :construction:

- PHP's json_encode method escapes slashes & multibyte Unicode characters by default, whereas Node's JSON.parse and JSON.stringify methods do not. This change translates the parsed JSON body back into a string that will correctly match the original body used to compute the webhook signature.