### PR TITLE
Change ProxyAgent import to be dynamic

### DIFF
--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -5,7 +5,6 @@
 import assert = require('assert');
 import * as https from 'https';
 import * as url from 'url';
-import ProxyAgent = require('proxy-agent');
 
 // ------------------------------------------------------------------------------
 // Requirements
@@ -199,6 +198,7 @@ function updateRequestAgent(
 		Required<Pick<UserConfigurationOptions, 'proxy'>>
 ) {
 	if (params.proxy.url) {
+		const ProxyAgent = require('proxy-agent');
 		params.request.agentClass = ProxyAgent;
 		params.request.agentOptions = Object.assign(
 			{},


### PR DESCRIPTION
When running [Box CLI @ 2.9.0](https://github.com/box/boxcli/releases/tag/v2.9.0) on Windows some users observed problem related to `proxy-agent` dependency:

```
TypeError: Class extends value undefined is not a constructor or null
at Object.<anonymous> (C:/Program Files/@boxcli/client/node_modules/socks-proxy-agent/dist/agent.js:114:44)
at Object.<anonymous> (C:/Program Files/@boxcli/client/node_modules/socks-proxy-agent/dist/index.js:5:33)
```

This PR makes it so that `proxy-agent` will only be imported if users provides the `url` for `proxy`.