### PR TITLE
Deeply freeze Config except Buffers and Readable streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next Release
+
+**Bug Fixes:**
+
+- Deeply freeze Config except Buffers and Readable streams ([#651](https://github.com/box/box-node-sdk/pull/651))
+
 ## 1.37.2 (2021-05-20)
 
 **Bug Fixes:**


### PR DESCRIPTION
Following up on https://github.com/box/box-node-sdk/pull/146 which got reverted, I'm using the same approach but while also avoiding freezing `Readable` streams. Added unit tests from the original PR and also another one to cover the `Readable` stream case.

I created an external Node application that was using SDK with this change applied to perform several common tasks:
- fetching a folder
- getting retention policy assignments
- getting files under retention for an assignment
- getting file versions under retention for an assignment
- deleting a file
- uploading a file (here's where `Readable` stream was used)

Closes #142.