### PR TITLE
fix: proper handling of query params in codegen

### DIFF
--- a/codegen/create-method-for-operation.tsx
+++ b/codegen/create-method-for-operation.tsx
@@ -1,8 +1,8 @@
+import { camelCase } from 'lodash';
 import * as ts from 'typescript';
 import { createTypeNodeForSchema } from './create-type-node-for-schema';
 import { OpenAPI, OpenAPIPathItem } from './openapi';
 import * as tsx from './tsx';
-import { camelCase } from 'lodash';
 import {
 	BindingElement,
 	Block,

--- a/codegen/create-method-for-operation.tsx
+++ b/codegen/create-method-for-operation.tsx
@@ -2,7 +2,9 @@ import * as ts from 'typescript';
 import { createTypeNodeForSchema } from './create-type-node-for-schema';
 import { OpenAPI, OpenAPIPathItem } from './openapi';
 import * as tsx from './tsx';
+import { camelCase } from 'lodash';
 import {
+	BindingElement,
 	Block,
 	CallExpression,
 	Identifier,
@@ -10,6 +12,7 @@ import {
 	JSDocParameterTag,
 	JSDocReturnTag,
 	MethodDeclaration,
+	ObjectBindingPattern,
 	ObjectLiteralExpression,
 	ParameterDeclaration,
 	PropertyAccessExpression,
@@ -55,6 +58,7 @@ export function createMethodForOperation({
 
 	const bodySchema = pathItem.requestBody?.content['application/json']?.schema;
 	const bodyId = <Identifier text="body" />;
+	const queryParamsId = <Identifier text="queryParams" />;
 
 	return (
 		<>
@@ -153,6 +157,30 @@ export function createMethodForOperation({
 				<Block multiLine>
 					<VariableStatement flags={ts.NodeFlags.Const}>
 						<VariableDeclaration
+							name={
+								<ObjectBindingPattern>
+									{parameters
+										.filter((parameter) => parameter.in !== 'query')
+										.map((parameter) => {
+											if (parameter.in !== 'path') {
+												throw new Error(
+													`Expected ${parameter.name} to be in path not ${parameter.in}`
+												);
+											}
+
+											return (
+												<BindingElement
+													propertyName={parameter.name}
+													name={camelCase(parameter.name)}
+												/>
+											);
+										})}
+									<BindingElement dotDotDotToken name={queryParamsId} />
+								</ObjectBindingPattern>
+							}
+							initializer={<Identifier text="options" />}
+						/>
+						<VariableDeclaration
 							name="apiPath"
 							initializer={
 								<CallExpression
@@ -177,12 +205,7 @@ export function createMethodForOperation({
 													);
 												}
 
-												return (
-													<PropertyAccessExpression
-														expression={<Identifier text="options" />}
-														name={<Identifier text={param.name} />}
-													/>
-												);
+												return <Identifier text={camelCase(param.name)} />;
 											}
 
 											return <StringLiteral text={part} />;
@@ -194,10 +217,7 @@ export function createMethodForOperation({
 							name="params"
 							initializer={
 								<ObjectLiteralExpression multiLine>
-									<PropertyAssignment
-										name="qs"
-										initializer={<Identifier text="options" />}
-									/>
+									<PropertyAssignment name="qs" initializer={queryParamsId} />
 									{bodySchema && (
 										<PropertyAssignment
 											name="body"

--- a/codegen/tsx.ts
+++ b/codegen/tsx.ts
@@ -29,6 +29,27 @@ export function BinaryExpression({
 	return ts.factory.createBinaryExpression(left, operator, right);
 }
 
+export function BindingElement({
+	dotDotDotToken,
+	propertyName,
+	name,
+	initializer,
+}: {
+	dotDotDotToken?: boolean;
+	propertyName?: string | ts.PropertyName;
+	name: string | ts.BindingName;
+	initializer?: ts.Expression;
+}): ts.BindingElement {
+	return ts.factory.createBindingElement(
+		dotDotDotToken
+			? ts.factory.createToken(ts.SyntaxKind.DotDotDotToken)
+			: undefined,
+		propertyName,
+		name,
+		initializer
+	);
+}
+
 export function Block(
 	{
 		statements,
@@ -333,6 +354,19 @@ export function NamedExports(
 
 export function Null(): ts.NullLiteral {
 	return ts.factory.createNull();
+}
+
+export function ObjectBindingPattern(
+	{
+		elements,
+	}: {
+		elements?: readonly ts.BindingElement[];
+	},
+	...children: readonly ts.BindingElement[]
+): ts.ObjectBindingPattern {
+	return ts.factory.createObjectBindingPattern(
+		(elements || children).flat().filter(Boolean)
+	);
 }
 
 export function ObjectLiteralExpression(

--- a/src/managers/sign-requests.generated.ts
+++ b/src/managers/sign-requests.generated.ts
@@ -30,9 +30,10 @@ class SignRequestsManager {
 		},
 		callback?: Function
 	): Promise<schemas.SignRequest> {
-		const apiPath = urlPath('sign_requests', options.sign_request_id),
+		const { sign_request_id: signRequestId, ...queryParams } = options,
+			apiPath = urlPath('sign_requests', signRequestId),
 			params = {
-				qs: options,
+				qs: queryParams,
 			};
 		return this.client.wrapWithDefaultHandler(this.client.get)(
 			apiPath,
@@ -66,9 +67,10 @@ class SignRequestsManager {
 		},
 		callback?: Function
 	): Promise<schemas.SignRequests> {
-		const apiPath = urlPath('sign_requests'),
+		const { ...queryParams } = options,
+			apiPath = urlPath('sign_requests'),
 			params = {
-				qs: options,
+				qs: queryParams,
 			};
 		return this.client.wrapWithDefaultHandler(this.client.get)(
 			apiPath,
@@ -91,9 +93,10 @@ class SignRequestsManager {
 		options?: {},
 		callback?: Function
 	): Promise<schemas.SignRequest> {
-		const apiPath = urlPath('sign_requests'),
+		const { ...queryParams } = options,
+			apiPath = urlPath('sign_requests'),
 			params = {
-				qs: options,
+				qs: queryParams,
 				body: body,
 			};
 		return this.client.wrapWithDefaultHandler(this.client.post)(
@@ -120,9 +123,10 @@ class SignRequestsManager {
 		},
 		callback?: Function
 	): Promise<schemas.SignRequest> {
-		const apiPath = urlPath('sign_requests', options.sign_request_id, 'cancel'),
+		const { sign_request_id: signRequestId, ...queryParams } = options,
+			apiPath = urlPath('sign_requests', signRequestId, 'cancel'),
 			params = {
-				qs: options,
+				qs: queryParams,
 			};
 		return this.client.wrapWithDefaultHandler(this.client.post)(
 			apiPath,
@@ -148,9 +152,10 @@ class SignRequestsManager {
 		},
 		callback?: Function
 	): Promise<object> {
-		const apiPath = urlPath('sign_requests', options.sign_request_id, 'resend'),
+		const { sign_request_id: signRequestId, ...queryParams } = options,
+			apiPath = urlPath('sign_requests', signRequestId, 'resend'),
 			params = {
-				qs: options,
+				qs: queryParams,
 			};
 		return this.client.wrapWithDefaultHandler(this.client.post)(
 			apiPath,

--- a/tests/lib/managers/sign-requests-test.js
+++ b/tests/lib/managers/sign-requests-test.js
@@ -57,25 +57,25 @@ describe('SignRequests', () => {
 	[
 		{
 			name: 'getById',
-			args: [
+			args: () => [
 				{
 					sign_request_id: '12345',
 				},
 			],
 			expectedMethod: 'get',
 			expectedPath: args => `${BASE_PATH}/${args[0].sign_request_id}`,
-			expectedParams: args => ({ qs: args[0] }),
+			expectedParams: () => ({ qs: {} }),
 		},
 		{
 			name: 'getAll',
-			args: [],
+			args: () => [],
 			expectedMethod: 'get',
 			expectedPath: () => BASE_PATH,
-			expectedParams: () => ({ qs: undefined }),
+			expectedParams: () => ({ qs: {} }),
 		},
 		{
 			name: 'create',
-			args: [
+			args: () => [
 				{
 					signers: [
 						{
@@ -105,39 +105,36 @@ describe('SignRequests', () => {
 		},
 		{
 			name: 'cancelById',
-			args: [
+			args: () => [
 				{
 					sign_request_id: '12345',
 				},
 			],
 			expectedMethod: 'post',
 			expectedPath: args => `${BASE_PATH}/${args[0].sign_request_id}/cancel`,
-			expectedParams: args => ({ qs: args[0] }),
+			expectedParams: () => ({ qs: {} }),
 		},
 		{
 			name: 'resendById',
-			args: [
+			args: () => [
 				{
 					sign_request_id: '12345',
 				},
 			],
 			expectedMethod: 'post',
 			expectedPath: args => `${BASE_PATH}/${args[0].sign_request_id}/resend`,
-			expectedParams: args => ({ qs: args[0] }),
+			expectedParams: () => ({ qs: {} }),
 		},
-	].forEach(testCase => describe(`${testCase.name}()`, () => {
-		const name = testCase.name;
-		it(`should make ${testCase.expectedMethod.toUpperCase()} request when calling ${name}`, () => {
-			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
-			sandbox
-				.mock(boxClientFake)
-				.expects(testCase.expectedMethod)
-				.withArgs(
-					testCase.expectedPath(testCase.args),
-					testCase.expectedParams(testCase.args)
-				);
-			signRequests[name].apply(signRequests, testCase.args);
-		});
-	})
+	].forEach(testCase => describe(`${testCase.name}()`, () => it(`should make ${testCase.expectedMethod.toUpperCase()} request when calling ${
+		testCase.name
+	}`, () => {
+		const args = testCase.args();
+		sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+		sandbox
+			.mock(boxClientFake)
+			.expects(testCase.expectedMethod)
+			.withArgs(testCase.expectedPath(args), testCase.expectedParams(args));
+		signRequests[testCase.name].apply(signRequests, args);
+	}))
 	);
 });


### PR DESCRIPTION
When working on https://github.com/box/boxcli/pull/258 I noticed that path parameters are also included in the query string https://github.com/box/boxcli/blob/fdd9b3c37ff0e18e0db78dd5e39ea7b029e9fd80/test/commands/sign-requests.test.js#L33. This PR fixes that behaviour. We'll be able to update the unit tests in CLI once this gets released