### PR TITLE
fix: drop support for Node 6,7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: node_js
 node_js:
-    - "6"
-    - "7"
     - "8"
     - "9"
     - "10"
+    - "12"
+    - "14"
 
 branches:
     only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## 1.39.0 (2021-08-30)
 
+**Breaking changes:**
+
+- Drop support for Node 6,7 ([#670](https://github.com/box/box-node-sdk/pull/670))
+
 **New Features and Enhancements:**
 
 - Add support for Box Sign API ([#658](https://github.com/box/box-node-sdk/pull/658))
 - Enhance TS Imports ([#656](https://github.com/box/box-node-sdk/pull/656))
 - Add support for is_external_collab_restricted User property ([#668](https://github.com/box/box-node-sdk/pull/668))
-- Drop support for Node 6,7 ([#670](https://github.com/box/box-node-sdk/pull/670))
 
 ## 1.38.0 (2021-08-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add support for Box Sign API ([#658](https://github.com/box/box-node-sdk/pull/658))
 - Enhance TS Imports ([#656](https://github.com/box/box-node-sdk/pull/656))
 - Add support for is_external_collab_restricted User property ([#668](https://github.com/box/box-node-sdk/pull/668))
+- Drop support for Node 6,7 ([#670](https://github.com/box/box-node-sdk/pull/670))
 
 ## 1.38.0 (2021-08-05)
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "sdk"
   ],
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 8.0.0"
   },
   "main": "./lib/box-node-sdk.js",
   "scripts": {


### PR DESCRIPTION
Preparing for https://github.com/box/box-node-sdk/pull/664