### PR TITLE
docs: link to CHANGELOG.md (for npm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Getting Started Docs: https://developer.box.com/guides/tooling/sdks/node/
   - [Constructing API Calls Manually](#constructing-api-calls-manually)
 - [Questions, Bugs, and Feature Requests?](#questions-bugs-and-feature-requests)
 - [Contributing to the Box Node.js SDK](#contributing-to-the-box-nodejs-sdk)
+- [Changelog](#changelog)
 - [Copyright and License](#copyright-and-license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -237,7 +238,7 @@ in the `tests/` directory!
 
 For more information, please see [the Contribution guidelines](./CONTRIBUTING.md).
 
-Change Log
+Changelog
 ----------
 
 See [CHANGELOG.md](./CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ For more information, please see [the Contribution guidelines](./CONTRIBUTING.md
 Change Log
 ----------
 
-See [CHANGELOG.md](/CHANGELOG.md).
+See [CHANGELOG.md](./CHANGELOG.md).
 
 Copyright and License
 ---------------------

--- a/README.md
+++ b/README.md
@@ -237,6 +237,11 @@ in the `tests/` directory!
 
 For more information, please see [the Contribution guidelines](./CONTRIBUTING.md).
 
+Change Log
+----------
+
+See [CHANGELOG.md](/CHANGELOG.md).
+
 Copyright and License
 ---------------------
 


### PR DESCRIPTION
There's no clear way to view the CHANGELOG from npm, which is where most searches will lead.

Since you just bumped to v2.0.0, I thought it might help others like myself to get to the necessary information faster.

(and for those finding this comment via a search for `2.0.0`, it's a small breaking change - removing node v6.0 support to fix a security vuln)