### PR TITLE
fix: Fix error while generate token using OAuth

### DIFF
--- a/src/token-manager.ts
+++ b/src/token-manager.ts
@@ -374,7 +374,7 @@ class TokenManager {
 	 * @returns {Promise<TokenInfo>} Promise resolving to the token info
 	 */
 	getTokensJWTGrant(type: string, id: string, options?: TokenRequestOptions) {
-		if (!this.config.appAuth.keyID) {
+		if (!this.config.appAuth || !this.config.appAuth.keyID) {
 			return Promise.reject(
 				new Error('Must provide app auth configuration to use JWT Grant')
 			);


### PR DESCRIPTION
I am fixing issue [#286](https://github.com/box/boxcli/issues/286) of boxcli.

Error happen when trying to generate token while using OAuth auth, I fixed to it show the correct error message:
```bash
> box tokens:get -u 20111795585
Must provide app auth configuration to use JWT Grant
```