### PR TITLE
fix: Add `fields` query parameter to file and folder update

### DIFF
--- a/src/managers/files.ts
+++ b/src/managers/files.ts
@@ -460,6 +460,12 @@ class Files {
 			delete updates.etag;
 		}
 
+		if (updates && updates.shared_link) {
+			params.qs = {
+				fields: 'shared_link',
+			};
+		}
+
 		var apiPath = urlPath(BASE_PATH, fileID);
 		return this.client.wrapWithDefaultHandler(this.client.put)(
 			apiPath,

--- a/src/managers/files.ts
+++ b/src/managers/files.ts
@@ -437,6 +437,7 @@ class Files {
 	 * @param {string} fileID - Box ID of the file being requested
 	 * @param {Object} updates - File fields to update
 	 * @param {string} [updates.etag] Only apply the updates if the file etag matches
+	 * @param {string} [updates.fields] Comma-separated list of fields to return
 	 * @param {Function} [callback] - Passed the updated file information if it was acquired successfully
 	 * @returns {Promise<Object>} A promise resolving to the update file object
 	 */
@@ -446,6 +447,7 @@ class Files {
 			[key: string]: any;
 			etag?: string;
 			shared_link?: FileSharedLink;
+			fields?: string;
 		},
 		callback?: Function
 	) {
@@ -460,10 +462,11 @@ class Files {
 			delete updates.etag;
 		}
 
-		if (updates && updates.shared_link) {
+		if (updates && updates.fields) {
 			params.qs = {
-				fields: 'shared_link',
+				fields: updates.fields,
 			};
+			delete updates.fields;
 		}
 
 		var apiPath = urlPath(BASE_PATH, fileID);

--- a/src/managers/folders.ts
+++ b/src/managers/folders.ts
@@ -271,6 +271,12 @@ class Folders {
 			delete updates.etag;
 		}
 
+		if (updates && updates.shared_link) {
+			params.qs = {
+				fields: 'shared_link',
+			};
+		}
+
 		var apiPath = urlPath(BASE_PATH, folderID);
 		return this.client.wrapWithDefaultHandler(this.client.put)(
 			apiPath,

--- a/src/managers/folders.ts
+++ b/src/managers/folders.ts
@@ -248,6 +248,7 @@ class Folders {
 	 * @param {string} folderID - The Box ID of the folder being requested
 	 * @param {Object} updates - Folder fields to update
 	 * @param {string} [updates.etag] Only update the folder if the ETag matches
+	 * @param {string} [updates.fields] Comma-separated list of fields to return
 	 * @param {Function} [callback] - Passed the updated folder information if it was acquired successfully
 	 * @returns {Promise<Object>} A promise resolving to the updated folder object
 	 */
@@ -257,6 +258,7 @@ class Folders {
 			[key: string]: any;
 			etag?: string;
 			shared_link?: FolderSharedLink;
+			fields?: string;
 		},
 		callback?: Function
 	) {
@@ -271,10 +273,11 @@ class Folders {
 			delete updates.etag;
 		}
 
-		if (updates && updates.shared_link) {
+		if (updates && updates.fields) {
 			params.qs = {
-				fields: 'shared_link',
+				fields: updates.fields,
 			};
+			delete updates.fields;
 		}
 
 		var apiPath = urlPath(BASE_PATH, folderID);

--- a/tests/endpoint-test.js
+++ b/tests/endpoint-test.js
@@ -1081,6 +1081,48 @@ describe('Endpoint', () => {
 				};
 				const fixture = getFixture('files/put_files_shared_link_200');
 				apiMock
+					.put(`/2.0/files/${fileID}`, updates)
+					.matchHeader('Authorization', authHeader => {
+						assert.equal(authHeader, `Bearer ${TEST_ACCESS_TOKEN}`);
+						return true;
+					})
+					.matchHeader('User-Agent', uaHeader => {
+						assert.include(uaHeader, 'Box Node.js SDK v');
+						return true;
+					})
+					.reply(200, fixture);
+				basicClient.files.update(
+					fileID,
+					{
+						shared_link: {
+							access: 'open',
+							password: 'do-not-use-this-password',
+							unshared_at: '2022-12-12T10:53:43-08:00',
+							permissions: {
+								can_edit: true
+							}
+						}
+					},
+					(err, data) => {
+						assert.isNull(err);
+						assert.deepEqual(data, JSON.parse(fixture));
+						done();
+					});
+			});
+			it('should create a shared link with custom return params', done => {
+				const fileID = '1234567890';
+				const updates = {
+					shared_link: {
+						access: 'open',
+						password: 'do-not-use-this-password',
+						unshared_at: '2022-12-12T10:53:43-08:00',
+						permissions: {
+							can_edit: true
+						}
+					}
+				};
+				const fixture = getFixture('files/put_files_shared_link_custom_params_200');
+				apiMock
 					.put(`/2.0/files/${fileID}?fields=shared_link`, updates)
 					.matchHeader('Authorization', authHeader => {
 						assert.equal(authHeader, `Bearer ${TEST_ACCESS_TOKEN}`);

--- a/tests/endpoint-test.js
+++ b/tests/endpoint-test.js
@@ -1101,7 +1101,8 @@ describe('Endpoint', () => {
 							permissions: {
 								can_edit: true
 							}
-						}
+						},
+						fields: 'shared_link'
 					},
 					(err, data) => {
 						assert.isNull(err);

--- a/tests/endpoint-test.js
+++ b/tests/endpoint-test.js
@@ -1081,7 +1081,7 @@ describe('Endpoint', () => {
 				};
 				const fixture = getFixture('files/put_files_shared_link_200');
 				apiMock
-					.put(`/2.0/files/${fileID}`, updates)
+					.put(`/2.0/files/${fileID}?fields=shared_link`, updates)
 					.matchHeader('Authorization', authHeader => {
 						assert.equal(authHeader, `Bearer ${TEST_ACCESS_TOKEN}`);
 						return true;

--- a/tests/fixtures/endpoints/files/put_files_shared_link_200.json
+++ b/tests/fixtures/endpoints/files/put_files_shared_link_200.json
@@ -1,23 +1,59 @@
 {
-  "type": "file",
-  "id": "1234567890",
-  "etag": "4",
-  "shared_link": {
-	"url": "https://someurl.box.com/s/2mgkgxe98et1li2w0lslbqv9wa724m3b",
-	"download_url": "https://someurl.box.com/shared/static/2mgkgxe98et1li2w0lslbqv9wa724m3b",
-	"vanity_url": null,
-	"vanity_name": null,
-	"effective_access": "open",
-	"effective_permission": "can_edit",
-	"is_password_enabled": true,
-	"unshared_at": "2022-12-12T10:53:43-08:00",
-	"download_count": 0,
-	"preview_count": 0,
-	"access": "open",
-	"permissions": {
-	  "can_preview": true,
-	  "can_download": true,
-	  "can_edit": true
+	"type": "file",
+	"id": "1234567890",
+	"etag": "4",
+	"path_collection": {
+		"total_count": 1,
+		"entries": [
+			{
+				"type": "folder",
+				"id": "0",
+				"sequence_id": null,
+				"etag": null,
+				"name": "All Files"
+			}
+		]
+	},
+	"created_at": "2016-12-07T15:56:54-08:00",
+	"modified_at": "2016-12-07T15:56:54-08:00",
+	"trashed_at": null,
+	"purged_at": null,
+	"content_created_at": "2016-12-07T15:53:59-08:00",
+	"content_modified_at": "2016-12-07T15:53:59-08:00",
+	"created_by": {
+		"type": "user",
+		"id": "33333",
+		"name": "Test User",
+		"login": "testuser@example.com"
+	},
+	"modified_by": {
+		"type": "user",
+		"id": "33333",
+		"name": "Test User",
+		"login": "testuser@example.com"
+	},
+	"owned_by": {
+		"type": "user",
+		"id": "33333",
+		"name": "Test User",
+		"login": "testuser@example.com"
+	},
+	"shared_link": {
+		"url": "https://someurl.box.com/s/2mgkgxe98et1li2w0lslbqv9wa724m3b",
+		"download_url": "https://someurl.box.com/shared/static/2mgkgxe98et1li2w0lslbqv9wa724m3b",
+		"vanity_url": null,
+		"vanity_name": null,
+		"effective_access": "open",
+		"effective_permission": "can_edit",
+		"is_password_enabled": true,
+		"unshared_at": "2022-12-12T10:53:43-08:00",
+		"download_count": 0,
+		"preview_count": 0,
+		"access": "open",
+		"permissions": {
+			"can_preview": true,
+			"can_download": true,
+			"can_edit": true
+		}
 	}
-  }
 }

--- a/tests/fixtures/endpoints/files/put_files_shared_link_custom_params_200.json
+++ b/tests/fixtures/endpoints/files/put_files_shared_link_custom_params_200.json
@@ -1,0 +1,23 @@
+{
+  "type": "file",
+  "id": "1234567890",
+  "etag": "4",
+  "shared_link": {
+	"url": "https://someurl.box.com/s/2mgkgxe98et1li2w0lslbqv9wa724m3b",
+	"download_url": "https://someurl.box.com/shared/static/2mgkgxe98et1li2w0lslbqv9wa724m3b",
+	"vanity_url": null,
+	"vanity_name": null,
+	"effective_access": "open",
+	"effective_permission": "can_edit",
+	"is_password_enabled": true,
+	"unshared_at": "2022-12-12T10:53:43-08:00",
+	"download_count": 0,
+	"preview_count": 0,
+	"access": "open",
+	"permissions": {
+	  "can_preview": true,
+	  "can_download": true,
+	  "can_edit": true
+	}
+  }
+}


### PR DESCRIPTION
Part of SDK-2713, we need to limit the response if we are updating the `shared_link` only.