### PR TITLE
fix: return empty object when `tos` status is not present

### DIFF
--- a/src/managers/terms-of-service.ts
+++ b/src/managers/terms-of-service.ts
@@ -274,7 +274,9 @@ class TermsOfService {
 				if (response.statusCode !== 200) {
 					throw errors.buildUnexpectedResponseError(response);
 				}
-				return response.body.entries[0];
+				return response.body.entries.length != 0
+					? response.body.entries[0]
+					: {};
 			})
 			.asCallback(callback);
 	}
@@ -350,18 +352,20 @@ class TermsOfService {
 			.post(apiPath, params)
 			.then((response: any /* FIXME */) => {
 				switch (response.statusCode) {
-					// 200 - A user status has been successfully created on terms of service
+					// 200/201 - A user status has been successfully updated/created on terms of service
 					// return the terms of service user status object
 					case httpStatusCodes.OK:
+					case httpStatusCodes.CREATED:
 						return response.body;
 
 					// 409 - Conflict
 					// Terms of Service already exists. Update the existing terms of service object
 					case httpStatusCodes.CONFLICT:
 						var getOptions = Object.assign({ fields: 'id' }, options);
-						return this.getUserStatus(termsOfServicesID, getOptions).then((
-							userStatus: any /* FIXME */
-						) => this.updateUserStatus(userStatus.id, isAccepted));
+						return this.getUserStatus(termsOfServicesID, getOptions).then(
+							(userStatus: any /* FIXME */) =>
+								this.updateUserStatus(userStatus.id, isAccepted)
+						);
 
 					default:
 						throw errors.buildUnexpectedResponseError(response);

--- a/src/managers/terms-of-service.ts
+++ b/src/managers/terms-of-service.ts
@@ -274,9 +274,7 @@ class TermsOfService {
 				if (response.statusCode !== 200) {
 					throw errors.buildUnexpectedResponseError(response);
 				}
-				return response.body.entries.length != 0
-					? response.body.entries[0]
-					: {};
+				return response.body.entries[0] ?? {};
 			})
 			.asCallback(callback);
 	}

--- a/tests/lib/managers/terms-of-service-test.js
+++ b/tests/lib/managers/terms-of-service-test.js
@@ -573,6 +573,24 @@ describe('TermsOfService', function() {
 			});
 		});
 
+		it('should return a promise resolving to empty object when a empty terms of service status response is returned', function() {
+			var response = {
+				statusCode: 200,
+				body: {
+					total_count: 0,
+					entries: [],
+				},
+			};
+			sandbox.stub(boxClientFake, 'get').returns(Promise.resolve(response));
+			return termsOfService.getUserStatus(TERMS_OF_SERVICE_ID)
+				.then(termsOfServiceUserStatusObject => {
+					assert.isTrue(
+						Object.keys(termsOfServiceUserStatusObject).length === 0,
+						'empty terms of service user status object is returned'
+					);
+				});
+		});
+
 		it('should return a promise resolving to requested terms of service user status object when a 200 response is returned', function() {
 			var response = {
 				statusCode: 200,
@@ -807,6 +825,19 @@ describe('TermsOfService', function() {
 		it('should return a promise resolving to created terms of service user status object when a 200 response is returned', function() {
 			var response = {
 				statusCode: 200,
+				body: {}
+			};
+			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);
+			sandbox.stub(boxClientFake, 'post').returns(Promise.resolve(response));
+			return termsOfService.setUserStatus(TERMS_OF_SERVICE_ID, true, options)
+				.then(termsOfServiceUserStatusObject => {
+					assert.strictEqual(termsOfServiceUserStatusObject, response.body, 'terms of service user status object is returned');
+				});
+		});
+
+		it('should return a promise resolving to created terms of service user status object when a 201 response is returned', function() {
+			var response = {
+				statusCode: 201,
 				body: {}
 			};
 			sandbox.stub(boxClientFake, 'wrapWithDefaultHandler').returnsArg(0);


### PR DESCRIPTION
return empty object when tos status is not present
handle 201 code correctly in `setUserStatus`