### PR TITLE
chore: Add integration test massive folder upload compatible with Node 16, 18

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -328,8 +328,8 @@ rules:
         - after
 ### PROMISES
     promise/no-nesting: off
-    # We use Bluebird promises only for consistency/interface
-    promise/no-native: error
+    # Disable as Promise already suppported in native NodeJS
+    # promise/no-native: error
     promise/no-promise-in-callback: error
     promise/no-callback-in-promise: error
     promise/avoid-new: error

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -332,7 +332,7 @@ rules:
     # promise/no-native: error
     promise/no-promise-in-callback: error
     promise/no-callback-in-promise: error
-    promise/avoid-new: error
+    # promise/avoid-new: error
     promise/no-return-in-finally: error
 
 ### UNICORN

--- a/package-lock.json
+++ b/package-lock.json
@@ -1230,15 +1230,6 @@
         }
       }
     },
-    "@jest/schemas": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz",
-      "integrity": "sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==",
-      "dev": true,
-      "requires": {
-        "@sinclair/typebox": "^0.24.1"
-      }
-    },
     "@jest/source-map": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.5.1.tgz",
@@ -1720,12 +1711,6 @@
         "read-package-json-fast": "^2.0.1"
       }
     },
-    "@sinclair/typebox": {
-      "version": "0.24.27",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.27.tgz",
-      "integrity": "sha512-K7C7IlQ3zLePEZleUN21ceBA2aLcMnLHTLph8QWk1JK37L90obdpY+QGY8bXMKxf1ht1Z0MNewvXxWv0oGDYFg==",
-      "dev": true
-    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -1961,126 +1946,13 @@
       }
     },
     "@types/jest": {
-      "version": "28.1.6",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.6.tgz",
-      "integrity": "sha512-0RbGAFMfcBJKOmqRazM8L98uokwuwD5F8rHrv/ZMbrZBwVOWZUyPG6VFNscjYr/vjM3Vu4fRrCPbOs42AfemaQ==",
+      "version": "27.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.2.tgz",
+      "integrity": "sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==",
       "dev": true,
       "requires": {
-        "jest-matcher-utils": "^28.0.0",
-        "pretty-format": "^28.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "diff-sequences": {
-          "version": "28.1.1",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
-          "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "jest-diff": {
-          "version": "28.1.3",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.3.tgz",
-          "integrity": "sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "diff-sequences": "^28.1.1",
-            "jest-get-type": "^28.0.2",
-            "pretty-format": "^28.1.3"
-          }
-        },
-        "jest-get-type": {
-          "version": "28.0.2",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
-          "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
-          "dev": true
-        },
-        "jest-matcher-utils": {
-          "version": "28.1.3",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz",
-          "integrity": "sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "jest-diff": "^28.1.3",
-            "jest-get-type": "^28.0.2",
-            "pretty-format": "^28.1.3"
-          }
-        },
-        "pretty-format": {
-          "version": "28.1.3",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
-          "integrity": "sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==",
-          "dev": true,
-          "requires": {
-            "@jest/schemas": "^28.1.3",
-            "ansi-regex": "^5.0.1",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^18.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
-        },
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
+        "jest-matcher-utils": "^27.0.0",
+        "pretty-format": "^27.0.0"
       }
     },
     "@types/json-schema": {
@@ -4835,9 +4707,9 @@
       }
     },
     "eslint-plugin-promise": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
-      "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.3.1.tgz",
+      "integrity": "sha512-bY2sGqyptzFBDLh/GMbAxfdJC+b0f23ME63FOE4+Jao0oZ3E1LEwFtWJX/1pGMJLiTtrSSern2CRM/g+dfc0eQ==",
       "dev": true
     },
     "eslint-plugin-unicorn": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "uuid": "^3.3.3"
   },
   "devDependencies": {
-    "@types/jest": "^28.1.6",
+    "@types/jest": "^27.1.5",
     "@types/jsonwebtoken": "^8.5.1",
     "@types/lodash": "^4.14.172",
     "@types/prettier": "^2.3.2",
@@ -63,7 +63,7 @@
     "eslint": "^6.8.0",
     "eslint-plugin-jest": "^23.20.0",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^6.1.1",
+    "eslint-plugin-promise": "^4.3.1",
     "eslint-plugin-unicorn": "^4.0.3",
     "istanbul": "^0.4.3",
     "jest": "^27.5.1",

--- a/tests/integration_test/__tests__/mass-upload.test.js
+++ b/tests/integration_test/__tests__/mass-upload.test.js
@@ -60,37 +60,30 @@ async function uploadFile(client, folderId, path) {
 	expect(preflight).toBeDefined();
 	var stream = fs.createReadStream(path);
 	if (stats.size < CHUNKED_UPLOAD_MINIMUM) {
-		console.log(`Uploading ${path} with normal upload`);
 		const result = await client.files.uploadFile(folderId, filename, stream);
 		expect(result.entries).toBeDefined();
 		expect(result.entries.length).toBe(1);
 		return result.entries[0];
 	}
-	console.log(`Uploading ${path} with chunked upload`);
 	/* eslint-disable promise/avoid-new */
 	return new Promise((resolve, reject) => {
 		client.files
 			.getChunkedUploader(folderId, stats.size, filename, stream)
 			.then(chunkedUploader => {
 				chunkedUploader.on('error', err => {
-					console.log(`Error uploading ${path}: ${err}`);
 					reject(err);
 				});
 				chunkedUploader.on('chunkUploaded', part => {
-					console.log(`Chunk ${part.part.part_id} uploaded for ${path}`);
 					expect(part.part.part_id).toBeDefined();
 				});
 				chunkedUploader.on('uploadComplete', file => {
-					console.log(`Upload complete for ${path}`);
 					expect(file.entries).toBeDefined();
 					expect(file.entries.length).toBe(1);
 					resolve(file.entries[0]);
 				});
-				console.log(`Starting upload for ${path}`);
 				chunkedUploader.start();
 			})
 			.catch(err => {
-				console.log(`Error uploading ${path}: ${err}`);
 				reject(err);
 			});
 	});
@@ -107,7 +100,6 @@ async function uploadFolderTree(client, folderId, path) {
 		} else {
 			await uploadFile(client, folderId, itemPath)
 				.then(file => {
-					console.log(`Uploaded file ${file.name} (${file.id})`);
 					const hash = crypto
 						.createHash('sha1')
 						.update(fs.readFileSync(itemPath))
@@ -120,7 +112,6 @@ async function uploadFolderTree(client, folderId, path) {
 					}
 				})
 				.catch(err => {
-					console.log(`Error while uploading file: ${err}`);
 					throw err;
 				});
 		}

--- a/tests/integration_test/__tests__/mass-upload.test.js
+++ b/tests/integration_test/__tests__/mass-upload.test.js
@@ -1,0 +1,146 @@
+'use strict';
+/* eslint-disable no-sync */
+
+const fs = require('fs');
+const crypto = require('crypto');
+const utils = require('../lib/utils');
+const systemPath = require('path');
+const { getAppClient, getUserClient } = require('../context');
+const { createBoxTestFolder } = require('../objects/box-test-folder');
+const { createBoxTestUser, clearUserContent } = require('../objects/box-test-user');
+const context = {};
+
+const CHUNKED_UPLOAD_MINIMUM = 20000000;
+
+beforeAll(async() => {
+	let appClient = getAppClient();
+	let user = await createBoxTestUser(appClient);
+	let userClient = getUserClient(user.id);
+	let folder = await createBoxTestFolder(userClient);
+	context.user = user;
+	context.appClient = appClient;
+	context.client = userClient;
+	context.folder = folder;
+});
+
+afterAll(async() => {
+	await context.folder.dispose();
+	await clearUserContent(context.client);
+	await context.user.dispose();
+	context.folder = null;
+	context.user = null;
+});
+
+function writeToStream(bytesToWrite, stream) {
+	const buffer = crypto.randomBytes(bytesToWrite);
+	stream.write(buffer);
+}
+
+async function createFolderTree(path, tree) {
+	await Promise.all(tree.map(async node => {
+		const nodePath = `${path}/${node.name}`;
+		if (node.type === 'folder') {
+			fs.mkdirSync(nodePath);
+			await createFolderTree(nodePath, node.items);
+		} else {
+			const stream = fs.createWriteStream(nodePath);
+			writeToStream(node.size, stream);
+			stream.end();
+		}
+	}));
+}
+
+async function uploadFile(client, folderId, path) {
+	const stats = fs.statSync(path);
+	const filename = path.split('/').pop();
+	const preflight = await client.files.preflightUploadFile(folderId, {
+		name: filename,
+		size: stats.size,
+	});
+	expect(preflight).toBeDefined();
+	var stream = fs.createReadStream(path);
+	if (stats.size < CHUNKED_UPLOAD_MINIMUM) {
+		console.log(`Uploading ${path} with normal upload`);
+		const result = await client.files.uploadFile(folderId, filename, stream);
+		expect(result.entries).toBeDefined();
+		expect(result.entries.length).toBe(1);
+		return result.entries[0];
+	}
+	console.log(`Uploading ${path} with chunked upload`);
+	/* eslint-disable promise/avoid-new */
+	return new Promise((resolve, reject) => {
+		client.files
+			.getChunkedUploader(folderId, stats.size, filename, stream)
+			.then(chunkedUploader => {
+				chunkedUploader.on('error', err => {
+					console.log(`Error uploading ${path}: ${err}`);
+					reject(err);
+				});
+				chunkedUploader.on('chunkUploaded', part => {
+					console.log(`Chunk ${part.part.part_id} uploaded for ${path}`);
+					expect(part.part.part_id).toBeDefined();
+				});
+				chunkedUploader.on('uploadComplete', file => {
+					console.log(`Upload complete for ${path}`);
+					expect(file.entries).toBeDefined();
+					expect(file.entries.length).toBe(1);
+					resolve(file.entries[0]);
+				});
+				console.log(`Starting upload for ${path}`);
+				chunkedUploader.start();
+			})
+			.catch(err => {
+				console.log(`Error uploading ${path}: ${err}`);
+				reject(err);
+			});
+	});
+}
+
+async function uploadFolderTree(client, folderId, path) {
+	const items = fs.readdirSync(path);
+	await Promise.all(items.map(async item => {
+		const itemPath = `${path}/${item}`;
+		const stats = fs.statSync(itemPath);
+		if (stats.isDirectory()) {
+			const folder = await client.folders.create(folderId, item);
+			await uploadFolderTree(client, folder.id, itemPath);
+		} else {
+			await uploadFile(client, folderId, itemPath)
+				.then(file => {
+					console.log(`Uploaded file ${file.name} (${file.id})`);
+					const hash = crypto
+						.createHash('sha1')
+						.update(fs.readFileSync(itemPath))
+						.digest('hex');
+					if (file.sha1 !== hash) {
+						throw new Error(`SHA1 mismatch for ${file.name}`);
+					}
+					if (file.size !== stats.size) {
+						throw new Error(`Size mismatch for ${file.name}`);
+					}
+				})
+				.catch(err => {
+					console.log(`Error while uploading file: ${err}`);
+					throw err;
+				});
+		}
+	}));
+}
+
+// Max timeout for this test is 1 hour
+jest.setTimeout(3600000);
+// Skip this long-running test by default
+test.skip('test massive folder upload', async() => {
+	const folderName = `./${utils.randomName()}`;
+	if (!fs.statSync(folderName, { throwIfNoEntry: false })) {
+		fs.mkdirSync(folderName);
+	}
+	const folderPath = systemPath.join(__dirname, '../resources/mass-folder-structure.json');
+	try {
+		const folderStructure = JSON.parse(fs.readFileSync(folderPath));
+		await createFolderTree(folderName, folderStructure);
+		await uploadFolderTree(context.client, context.folder.id, folderName);
+	} finally {
+		fs.rmSync(folderName, { recursive: true, force: true });
+	}
+});

--- a/tests/integration_test/__tests__/mass-upload.test.js
+++ b/tests/integration_test/__tests__/mass-upload.test.js
@@ -114,7 +114,7 @@ async function uploadFolderTree(client, folderId, path) {
 jest.setTimeout(3600000);
 // Skip this long-running test by default, to avoid running it in CI
 // to run this test, replace 'skip' with 'only' and run normally
-test.only('test massive folder upload', async() => {
+test.skip('test massive folder upload', async() => {
 	const folderName = `./${utils.randomName()}`;
 	if (!fs.statSync(folderName, { throwIfNoEntry: false })) {
 		fs.mkdirSync(folderName);

--- a/tests/integration_test/resources/mass-folder-structure.json
+++ b/tests/integration_test/resources/mass-folder-structure.json
@@ -1,0 +1,82 @@
+[
+    {
+        "type": "folder",
+        "name": "folder1",
+        "items": [
+            {
+                "type": "folder",
+                "name": "folder2",
+                "items": [
+                    {
+                        "type": "file",
+                        "name": "file1.data",
+                        "size": 1000
+                    },
+                    {
+                        "type": "file",
+                        "name": "file2.data",
+                        "size": 2000
+                    }
+                ]
+            },
+            {
+                "type": "folder",
+                "name": "folder3",
+                "items": [
+                    {
+                        "type": "file",
+                        "name": "file1.data",
+                        "size": 300000
+                    },
+                    {
+                        "type": "file",
+                        "name": "file2.data",
+                        "size": 500000
+                    }
+                ]
+            },
+            {
+                "type": "folder",
+                "name": "folder4",
+                "items": [
+                    {
+                        "type": "file",
+                        "name": "file1.data",
+                        "size": 1000000
+                    },
+                    {
+                        "type": "file",
+                        "name": "file2.data",
+                        "size": 5000000
+                    },
+                    {
+                        "type": "folder",
+                        "name": "folder5",
+                        "items": [
+                            {
+                                "type": "file",
+                                "name": "file1.dat",
+                                "size": 100000000
+                            },
+                            {
+                                "type": "file",
+                                "name": "file2.file",
+                                "size": 500000000
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "type": "file",
+                "name": "file3.dat",
+                "size": 100000000
+            },
+            {
+                "type": "file",
+                "name": "file4.dat",
+                "size": 2147483000
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Closes: SDK-2825

- Update `package.json` to compatible with Node 16, 18.
- Integration test which upload a massive folder structure (skipped by default).