### PR TITLE
chore: Bump `uuid` from 3.3.3 to 9.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2140,9 +2140,9 @@
       "dev": true
     },
     "@types/uuid": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
-      "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
       "dev": true
     },
     "@types/yargs": {
@@ -2469,7 +2469,7 @@
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
     },
     "are-we-there-yet": {
@@ -3544,7 +3544,7 @@
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "compare-func": {
@@ -4078,7 +4078,7 @@
     "default-require-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
-      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+      "integrity": "sha512-B0n2zDIXpzLzKeoEozorDSa1cHc1t0NjmxP0zuAxbizNU2MBqYJJKYXrrFdKuQliojXynrxgd7l4ahfg/+aA5g==",
       "dev": true,
       "requires": {
         "strip-bom": "^3.0.0"
@@ -5138,7 +5138,7 @@
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
           "dev": true
         },
         "pkg-dir": {
@@ -5719,7 +5719,7 @@
     "hasha": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
-      "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+      "integrity": "sha512-w0Kz8lJFBoyaurBiNrIvxPqr/gJ6fOfSkpAPOepN3oECqGJag37xPbOv57izi/KP8auHgNYxn5fXtAb+1LsJ6w==",
       "dev": true,
       "requires": {
         "is-stream": "^1.0.1"
@@ -5728,7 +5728,7 @@
         "is-stream": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
           "dev": true
         }
       }
@@ -9469,7 +9469,7 @@
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
     "lodash.get": {
@@ -11377,7 +11377,7 @@
         "cross-spawn": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "integrity": "sha512-yAXz/pA1tD8Gtg2S98Ekf/sewp3Lcp3YoFKJ4Hkp5h5yLWnKVTDU0kwjKJ8NDCYcfTLfyGkzTikst+jWypT1iA==",
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -11402,7 +11402,7 @@
         "foreground-child": {
           "version": "1.5.6",
           "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+          "integrity": "sha512-3TOY+4TKV0Ml83PXJQY+JFQaHNV38lzQDIzzXYg1kWdBLenGgoZhAs0CKgzI31vi2pWEpQMq/Yi4bpKwCPkw7g==",
           "dev": true,
           "requires": {
             "cross-spawn": "^4",
@@ -11418,7 +11418,7 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
           "dev": true
         },
         "istanbul-lib-coverage": {
@@ -11510,7 +11510,7 @@
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
           "dev": true
         },
         "path-type": {
@@ -11607,6 +11607,12 @@
             "require-main-filename": "^2.0.0"
           }
         },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        },
         "which": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -11636,7 +11642,7 @@
         "yallist": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
           "dev": true
         },
         "yargs": {
@@ -11740,7 +11746,7 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
       "dev": true
     },
     "os-tmpdir": {
@@ -12863,7 +12869,7 @@
     "release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
       "dev": true,
       "requires": {
         "es6-error": "^4.0.1"
@@ -12945,6 +12951,13 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "require-directory": {
@@ -13346,7 +13359,7 @@
         "cross-spawn": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "integrity": "sha512-yAXz/pA1tD8Gtg2S98Ekf/sewp3Lcp3YoFKJ4Hkp5h5yLWnKVTDU0kwjKJ8NDCYcfTLfyGkzTikst+jWypT1iA==",
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -13356,7 +13369,7 @@
         "foreground-child": {
           "version": "1.5.6",
           "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+          "integrity": "sha512-3TOY+4TKV0Ml83PXJQY+JFQaHNV38lzQDIzzXYg1kWdBLenGgoZhAs0CKgzI31vi2pWEpQMq/Yi4bpKwCPkw7g==",
           "dev": true,
           "requires": {
             "cross-spawn": "^4",
@@ -13394,7 +13407,7 @@
         "yallist": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
           "dev": true
         }
       }
@@ -14407,9 +14420,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "proxy-agent": "^5.0.0",
     "request": "^2.88.0",
     "url-template": "^2.0.8",
-    "uuid": "^3.3.3"
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.1.5",
@@ -56,7 +56,7 @@
     "@types/request": "^2.48.5",
     "@types/shelljs": "^0.8.9",
     "@types/url-template": "^2.0.28",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.1",
     "better-docs": "^2.7.2",
     "chai": "^4.2.0",
     "doctoc": "^2.2.1",

--- a/src/token-manager.ts
+++ b/src/token-manager.ts
@@ -9,7 +9,7 @@
 import Promise from 'bluebird';
 import httpStatusCodes from 'http-status';
 import jwt from 'jsonwebtoken';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 import APIRequestManager from './api-request-manager';
 import errors from './util/errors';
 import getRetryTimeout from './util/exponential-backoff';
@@ -389,7 +389,7 @@ class TokenManager {
 			audience: BOX_JWT_AUDIENCE,
 			subject: id,
 			issuer: this.config.clientID,
-			jwtid: uuid.v4(),
+			jwtid: uuidv4(),
 			noTimestamp: !this.config.appAuth.verifyTimestamp,
 			keyid: this.config.appAuth.keyID,
 		};
@@ -486,7 +486,7 @@ class TokenManager {
 			}
 			// Add length of retry timeout to current expiration time to calculate the expiration time for the JTI claim.
 			claims.exp = Math.ceil(time + this.config.appAuth.expirationTime + retryTimeoutinSeconds);
-			jwtOptions.jwtid = uuid.v4();
+			jwtOptions.jwtid = uuidv4();
 
 			try {
 				params.assertion = jwt.sign(claims, keyParams, jwtOptions);
@@ -576,7 +576,7 @@ class TokenManager {
 				algorithm: 'none',
 				expiresIn: '1m',
 				noTimestamp: true,
-				jwtid: uuid.v4(),
+				jwtid: uuidv4(),
 			};
 
 			var token;

--- a/tests/integration_test/lib/utils.js
+++ b/tests/integration_test/lib/utils.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const uuid = require('uuid');
+const { v4: uuidv4 } = require('uuid');
 
-const randomName = () => uuid.v4();
+const randomName = () => uuidv4();
 
-const randomEmail = () => `${uuid.v4()}@box.com`;
+const randomEmail = () => `${uuidv4()}@box.com`;
 
 const deleteFilePermanently = async(client, fileID) => {
 	await client.files.delete(fileID);

--- a/tests/lib/token-manager-test.js
+++ b/tests/lib/token-manager-test.js
@@ -49,7 +49,13 @@ describe('token-manager', function() {
 		// Setup Dependencies
 		requestManagerFake = leche.fake(APIRequestManager.prototype);
 		jwtFake = leche.fake(jwt);
-		uuidFake = leche.fake(uuid);
+
+		// From uuid@7 uses `Object.defineProperty` to export the v4 function, which
+		// causes the function is not able to be stubbed out by sinon. We need to
+		// create a fake function that can be stubbed out.
+		uuidFake = {
+			v4: () => uuid.v4()
+		};
 
 		config = new Config({
 			clientID: BOX_CLIENT_ID,
@@ -440,7 +446,6 @@ describe('token-manager', function() {
 		});
 
 		it('should create JWT assertion with correct parameters when called', function() {
-
 			sandbox.useFakeTimers(100000);
 
 			sandbox.stub(uuidFake, 'v4').returns(TEST_JTI);


### PR DESCRIPTION
Bumping the `uuid` library from this [request](781#issuecomment-1560396419).

See this [answer](https://stackoverflow.com/a/60754348) for the changes in the unit tests.