### PR TITLE
feat: Add request option to skip `PassThrough`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,17 @@ sdk.configure({
 });
 ```
 
+## Disable stream PassThrough for streaming responses
+
+By default the SDK uses `PassThrough` stream to handle streaming responses. It helps to support delayed reading of the response body, but in some cases it can cause memory leaks or not fully works. To disable `PassThrough` stream use the `disableStreamPassThrough` method:
+
+```javascript
+sdk = BoxSDKNode.getPreconfiguredInstance(APP_SETTINGS);
+sdk.configure({
+    disableStreamPassThrough: true
+});
+```
+
 ## Configure Base URL
 
 The Base Url is the URL that is used by the SDK to access Box. The default base URL are already defined

--- a/src/api-request-manager.ts
+++ b/src/api-request-manager.ts
@@ -83,7 +83,7 @@ class APIRequestManager {
 		// available before we can pipe it to the pass-through stream.
 		// If the stream is undefined, then the request failed and we should
 		// propagate the error.
-		if (stream) {
+		if (stream && options.disableStreamPassthrough !== true) {
 			var passThrough = new PassThrough();
 			stream.pipe(passThrough);
 			return passThrough;

--- a/src/api-request-manager.ts
+++ b/src/api-request-manager.ts
@@ -83,7 +83,11 @@ class APIRequestManager {
 		// available before we can pipe it to the pass-through stream.
 		// If the stream is undefined, then the request failed and we should
 		// propagate the error.
-		if (stream && options.disableStreamPassthrough !== true) {
+		if (
+			stream &&
+			requestConfig.disableStreamPassThrough !== true &&
+			!options.disableStreamPassThrough
+		) {
 			var passThrough = new PassThrough();
 			stream.pipe(passThrough);
 			return passThrough;

--- a/src/api-request-manager.ts
+++ b/src/api-request-manager.ts
@@ -86,7 +86,7 @@ class APIRequestManager {
 		if (
 			stream &&
 			requestConfig.disableStreamPassThrough !== true &&
-			!options.disableStreamPassThrough
+			options.disableStreamPassThrough !== true
 		) {
 			var passThrough = new PassThrough();
 			stream.pipe(passThrough);

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -94,6 +94,7 @@ var defaults = {
 	iterators: false,
 	enterpriseID: undefined,
 	analyticsClient: null,
+	disableStreamPassThrough: false,
 	proxy: {
 		url: null,
 		username: null,

--- a/tests/lib/api-request-manager-test.js
+++ b/tests/lib/api-request-manager-test.js
@@ -228,6 +228,21 @@ describe('APIRequestManager', function() {
 				.withExactArgs()
 				.returns(expectedResponse);
 			response = requestManager.makeStreamingRequest({});
+			assert.instanceOf(response, Stream.PassThrough);
+			assert.equal(typeof response, typeof expectedResponse);
+		});
+
+		it('should return the Stream directly when `disableStreamPassthrough` is true', function() {
+			var requestManager = new APIRequestManager(config, eventBusFake),
+				expectedResponse = new Stream(),
+				response;
+
+			sandbox.stub(apiRequestFake, 'execute');
+			sandbox.mock(apiRequestFake).expects('getResponseStream')
+				.withExactArgs()
+				.returns(expectedResponse);
+			response = requestManager.makeStreamingRequest({ disableStreamPassthrough: true });
+			assert.notInstanceOf(response, Stream.PassThrough);
 			assert.equal(typeof response, typeof expectedResponse);
 		});
 	});

--- a/tests/lib/api-request-manager-test.js
+++ b/tests/lib/api-request-manager-test.js
@@ -232,7 +232,7 @@ describe('APIRequestManager', function() {
 			assert.equal(typeof response, typeof expectedResponse);
 		});
 
-		it('should return the Stream directly when `disableStreamPassthrough` is true', function() {
+		it('should return the Stream directly when `disableStreamPassThrough` is true', function() {
 			var requestManager = new APIRequestManager(config, eventBusFake),
 				expectedResponse = new Stream(),
 				response;
@@ -241,7 +241,7 @@ describe('APIRequestManager', function() {
 			sandbox.mock(apiRequestFake).expects('getResponseStream')
 				.withExactArgs()
 				.returns(expectedResponse);
-			response = requestManager.makeStreamingRequest({ disableStreamPassthrough: true });
+			response = requestManager.makeStreamingRequest({ disableStreamPassThrough: true });
 			assert.notInstanceOf(response, Stream.PassThrough);
 			assert.equal(typeof response, typeof expectedResponse);
 		});


### PR DESCRIPTION
The `PassThrough` is causing us a few issues, and I can't figure out why it was added - this PR adds an option which avoids the usage of it optionally while leaving the default behavior as PassThrough.