### PR TITLE
test: Adjust tests to work with form-data 4.0.4

### DIFF
--- a/tests/endpoint-test.js
+++ b/tests/endpoint-test.js
@@ -1340,7 +1340,7 @@ describe('Endpoint', () => {
           .post('/2.0/files/content', (body) => {
             // Verify the multi-part form body
             var lines = body.split(/\r?\n/);
-            assert.match(lines[0], /^-+\d+$/);
+            assert.match(lines[0], /^-+[a-f0-9]+$/);
             assert.equal(
               lines[1],
               'Content-Disposition: form-data; name="attributes"'
@@ -1350,14 +1350,14 @@ describe('Endpoint', () => {
             assert.propertyVal(attributes, 'name', filename);
             assert.propertyVal(attributes, 'description', fileDescription);
             assert.nestedPropertyVal(attributes, 'parent.id', folderID);
-            assert.match(lines[4], /^-+\d+$/);
+            assert.match(lines[4], /^-+[a-f0-9]+$/);
             assert.equal(
               lines[5],
               'Content-Disposition: form-data; name="content"; filename="unused"'
             );
             assert.equal(lines[6], '');
             assert.equal(lines[7], fileContent);
-            assert.match(lines[8], /^-+\d+-+$/);
+            assert.match(lines[8], /^-+[a-f0-9]+-+$/);
             return true;
           })
           .matchHeader('Authorization', (authHeader) => {
@@ -1391,7 +1391,7 @@ describe('Endpoint', () => {
           .post('/2.0/files/content', (body) => {
             // Verify the multi-part form body
             var lines = body.split(/\r?\n/);
-            assert.match(lines[0], /^-+\d+$/);
+            assert.match(lines[0], /^-+[a-f0-9]+$/);
             assert.equal(
               lines[1],
               'Content-Disposition: form-data; name="attributes"'
@@ -1401,14 +1401,14 @@ describe('Endpoint', () => {
             assert.propertyVal(attributes, 'name', filename);
             assert.propertyVal(attributes, 'description', fileDescription);
             assert.nestedPropertyVal(attributes, 'parent.id', folderID);
-            assert.match(lines[4], /^-+\d+$/);
+            assert.match(lines[4], /^-+[a-f0-9]+$/);
             assert.equal(
               lines[5],
               'Content-Disposition: form-data; name="content"; filename="unused"'
             );
             assert.equal(lines[6], '');
             assert.equal(lines[7], fileContent);
-            assert.match(lines[8], /^-+\d+-+$/);
+            assert.match(lines[8], /^-+[a-f0-9]+-+$/);
             return true;
           })
           .matchHeader('Authorization', (authHeader) => {
@@ -1453,7 +1453,7 @@ describe('Endpoint', () => {
           .post('/2.0/files/content', (body) => {
             // Verify the multi-part form body
             var lines = body.split(/\r?\n/);
-            assert.match(lines[0], /^-+\d+$/);
+            assert.match(lines[0], /^-+[a-f0-9]+$/);
             assert.equal(
               lines[1],
               'Content-Disposition: form-data; name="attributes"'
@@ -1463,7 +1463,7 @@ describe('Endpoint', () => {
             assert.propertyVal(attributes, 'name', filename);
             assert.propertyVal(attributes, 'description', fileDescription);
             assert.nestedPropertyVal(attributes, 'parent.id', folderID);
-            assert.match(lines[4], /^-+\d+$/);
+            assert.match(lines[4], /^-+[a-f0-9]+$/);
             assert.equal(
               lines[5],
               'Content-Disposition: form-data; name="content"; filename="unused"'
@@ -1471,7 +1471,7 @@ describe('Endpoint', () => {
             assert.equal(lines[6], 'Content-Type: application/octet-stream');
             assert.equal(lines[7], '');
             assert.equal(lines[8], someContent);
-            assert.match(lines[9], /^-+\d+-+$/);
+            assert.match(lines[9], /^-+[a-f0-9]+-+$/);
             return true;
           })
           .matchHeader('Authorization', (authHeader) => {
@@ -1855,7 +1855,7 @@ describe('Endpoint', () => {
           .post(`/2.0/files/${fileID}/content`, (body) => {
             // Verify the multi-part form body
             var lines = body.split(/\r?\n/);
-            assert.match(lines[0], /^-+\d+$/);
+            assert.match(lines[0], /^-+[a-f0-9]+$/);
             assert.equal(
               lines[1],
               'Content-Disposition: form-data; name="attributes"'
@@ -1864,14 +1864,14 @@ describe('Endpoint', () => {
             var attributes = JSON.parse(lines[3]);
             assert.propertyVal(attributes, 'name', name);
             assert.propertyVal(attributes, 'description', fileDescription);
-            assert.match(lines[4], /^-+\d+$/);
+            assert.match(lines[4], /^-+[a-f0-9]+$/);
             assert.equal(
               lines[5],
               'Content-Disposition: form-data; name="content"; filename="unused"'
             );
             assert.equal(lines[6], '');
             assert.equal(lines[7], fileContent);
-            assert.match(lines[8], /^-+\d+-+$/);
+            assert.match(lines[8], /^-+[a-f0-9]+-+$/);
             return true;
           })
           .matchHeader('Authorization', (authHeader) => {
@@ -1900,7 +1900,7 @@ describe('Endpoint', () => {
           .post(`/2.0/files/${fileID}/content`, (body) => {
             // Verify the multi-part form body
             var lines = body.split(/\r?\n/);
-            assert.match(lines[0], /^-+\d+$/);
+            assert.match(lines[0], /^-+[a-f0-9]+$/);
             assert.equal(
               lines[1],
               'Content-Disposition: form-data; name="attributes"'
@@ -1909,14 +1909,14 @@ describe('Endpoint', () => {
             var attributes = JSON.parse(lines[3]);
             assert.propertyVal(attributes, 'name', name);
             assert.propertyVal(attributes, 'description', fileDescription);
-            assert.match(lines[4], /^-+\d+$/);
+            assert.match(lines[4], /^-+[a-f0-9]+$/);
             assert.equal(
               lines[5],
               'Content-Disposition: form-data; name="content"; filename="unused"'
             );
             assert.equal(lines[6], '');
             assert.equal(lines[7], fileContent);
-            assert.match(lines[8], /^-+\d+-+$/);
+            assert.match(lines[8], /^-+[a-f0-9]+-+$/);
             return true;
           })
           .matchHeader('Authorization', (authHeader) => {


### PR DESCRIPTION
The PR https://github.com/box/box-node-sdk/pull/900 which bumping the form-data to version 4.0.4 (because of critical vulnerabilit) breaks the existing tests. This is because they changed the way how the boundary is [calculated](https://github.com/form-data/form-data/commit/3d1723080e6577a66f17f163ecd345a21d8d0fd0#diff-3e43d32fd2883fc8300dbf75f467758665f0be79f3e26f4b2c7dfcfe69496e23L348-R349). 

In order to fix the tests we have to change the boundary regex from `/^-+\d+$/` to `/^-+[a-f0-9]+$/`