### PR TITLE
chore: add cron job to run tests

### DIFF
--- a/.github/workflows/build_and_test_browser_daily.yml
+++ b/.github/workflows/build_and_test_browser_daily.yml
@@ -62,5 +62,5 @@ jobs:
           fi
 
           curl -X POST -H "Content-Type: application/json" \
-            --data "{\"text\":\"<${BUILD_URL}|Daily Tests Job> in *${GITHUB_REPOSITORY}* finished with status: $STATUS\"}" \
-            $SLACK_WEBHOOK_TEST_NOTIFICATION_URL
+            --data "{\"text\":\"<${BUILD_URL}|Daily Tests Job> in *${GITHUB_REPOSITORY}* finished with status: ${STATUS}\"}" \
+            "$SLACK_WEBHOOK_TEST_NOTIFICATION_URL"

--- a/.github/workflows/build_and_test_daily.yml
+++ b/.github/workflows/build_and_test_daily.yml
@@ -76,5 +76,5 @@ jobs:
           fi
 
           curl -X POST -H "Content-Type: application/json" \
-            --data "{\"text\":\"<${BUILD_URL}|Daily Tests Job> in *${GITHUB_REPOSITORY}* finished with status: $STATUS\"}" \
-            $SLACK_WEBHOOK_TEST_NOTIFICATION_URL
+            --data "{\"text\":\"<${BUILD_URL}|Daily Tests Job> in *${GITHUB_REPOSITORY}* finished with status: ${STATUS}\"}" \
+            "$SLACK_WEBHOOK_TEST_NOTIFICATION_URL"


### PR DESCRIPTION
- add cron job that runs daily on weekdays at around 00:35 CET (full hours could cause delays). The job runs all the integration tests on sdk-gen branch