### PR TITLE
ci: add FOSSA license and dependency scan

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -1,0 +1,22 @@
+name: FOSSA Scan
+
+on:
+  push:
+    branches: [main, combined-sdk]
+  pull_request:
+    branches: [main, combined-sdk]
+
+permissions:
+  contents: read
+
+jobs:
+  fossa:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: fossas/fossa-action@main
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          branch: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## Summary
- Add FOSSA GitHub Action workflow for license and dependency scanning
- Triggers on push to main/combined-sdk and PRs targeting main/combined-sdk

## Test plan
- [ ] Verify FOSSA_API_KEY secret is configured in repo settings
- [ ] Confirm workflow triggers on PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)