### PR TITLE
ci: notify `npm-box` on new SDK release

### DIFF
--- a/.github/workflows/notify-changelog.yml
+++ b/.github/workflows/notify-changelog.yml
@@ -27,3 +27,11 @@ jobs:
           repository: box/box-developer-changelog
           event-type: new-release-note
           client-payload: '{"ref": "${{ github.ref }}", "repository": "${{github.repository}}", "labels": "sdks,typescript", "repo_display_name": "Box Node SDK"}'
+
+      - name: Notify npm-box of new release
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
+          repository: box/npm-box
+          event-type: sdk-release
+          client-payload: '{"version": "${{ github.event.release.tag_name }}", "repository": "${{ github.repository }}"}'


### PR DESCRIPTION
## Summary
- Adds a `repository_dispatch` step to the release workflow that notifies `box/npm-box` when a new SDK version is released
- This triggers npm-box to auto-bump its `box-node-sdk` dependency and open a PR

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Confirm dispatch fires on next release (or test with `gh api`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)