### PR TITLE
feat: export error types from the package root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,6 @@ export {
   BoxOAuth,
   OAuthConfig,
 } from './box';
+export { BoxApiError, BoxSdkError } from './box';
+export type { RequestInfo, ResponseInfo } from './box';
 export { BoxClient } from './client';


### PR DESCRIPTION
## Summary

Re-export `BoxApiError`, `BoxSdkError`, and the `RequestInfo` / `ResponseInfo`
types from the package root so consumers can import them directly:

    import { BoxApiError } from 'box-node-sdk';

Today the only way to reach `BoxApiError` is a deep, internal path:

    import { BoxApiError } from 'box-node-sdk/lib/box/errors';

## Motivation

`BoxApiError` is the error every consumer needs in order to handle API
failures — it carries the HTTP status, `responseInfo`, error `code`, request
id, etc. But it isn't exported from the entry point, so callers must reach
into `box-node-sdk/lib/box/errors`, an internal `lib/` path.

Beyond ergonomics, that deep import can be a hazard when the bare package and
its subpaths are resolved differently by a bundler. For example, if
`box-node-sdk` is marked external (resolved at runtime) while a deep subpath
import (`box-node-sdk/lib/box/errors`) is bundled instead, two copies of the
`BoxApiError` class exist at runtime — the one the SDK throws and the one the
consumer's check references — so `error instanceof BoxApiError` silently
returns `false`. Importing from the root, a single specifier, sidesteps that.

## Changes

- `src/index.ts`:
  - `export { BoxApiError, BoxSdkError } from './box';`
  - `export type { RequestInfo, ResponseInfo } from './box';`

  (These are already exported from `./box` via `export * from './errors'`;
  this just surfaces them at the root.)

## Compatibility

Additive, non-breaking — new exports only; no existing signatures change.

## Note for maintainers

If `src/index.ts` is generated by box-codegen rather than hand-maintained,
I'm happy to move this into the generator/templates — please point me at the
right place.
