### PR TITLE
fix: stop double-JSON-encoding scalar error fields in Box API errors

### DIFF
--- a/src/networking/boxNetworkClient.ts
+++ b/src/networking/boxNetworkClient.ts
@@ -17,6 +17,7 @@ import {
   SerializedData,
   jsonToSerializedData,
   sdIsMap,
+  sdIsString,
   sdToJson,
   sdToUrlParams,
 } from '../serialization/json';
@@ -436,15 +437,31 @@ export class BoxNetworkClient implements NetworkClient {
       errorDescription,
     ] = sdIsMap(fetchResponse.data)
       ? [
-          sdToJson(fetchResponse.data['code']),
+          // Read the scalar error fields as raw strings. `sdToJson` JSON-encodes its
+          // input, which wraps strings in quotes (e.g. `storage_limit_exceeded`
+          // becomes `"storage_limit_exceeded"`), corrupting both `responseInfo.code`
+          // and the composed error message.
+          sdIsString(fetchResponse.data['code'])
+            ? fetchResponse.data['code']
+            : undefined,
           sdIsMap(fetchResponse.data['context_info'])
             ? fetchResponse.data['context_info']
             : undefined,
-          sdToJson(fetchResponse.data['request_id']),
-          sdToJson(fetchResponse.data['help_url']),
-          sdToJson(fetchResponse.data['message']),
-          sdToJson(fetchResponse.data['error']),
-          sdToJson(fetchResponse.data['error_description']),
+          sdIsString(fetchResponse.data['request_id'])
+            ? fetchResponse.data['request_id']
+            : undefined,
+          sdIsString(fetchResponse.data['help_url'])
+            ? fetchResponse.data['help_url']
+            : undefined,
+          sdIsString(fetchResponse.data['message'])
+            ? fetchResponse.data['message']
+            : undefined,
+          sdIsString(fetchResponse.data['error'])
+            ? fetchResponse.data['error']
+            : undefined,
+          sdIsString(fetchResponse.data['error_description'])
+            ? fetchResponse.data['error_description']
+            : undefined,
         ]
       : [];
     if (fetchResponse.status === 0) {


### PR DESCRIPTION
## Summary

When building a `BoxApiError` for a 4xx/5xx response, the scalar error fields
(`code`, `request_id`, `help_url`, `message`, `error`, `error_description`)
are passed through `sdToJson`, which JSON-encodes its input. For string
values that adds a layer of quotes: `responseInfo.code` comes back as
`"\"storage_limit_exceeded\""` instead of `storage_limit_exceeded`, and the
composed `error.message` inherits the stray quotes.

## Reproduction

Box returns this (clean) response body for a storage-limit 403:

    {
      "type": "error",
      "status": 403,
      "code": "storage_limit_exceeded",
      "help_url": "http://developers.box.com/docs/#errors",
      "message": "Account storage limit reached",
      "request_id": "<request-id>"
    }

The resulting `BoxApiError` (relevant fields only):

**Before**
```json
{
  "message": "403 \"storage_limit_exceeded\" \"Account storage limit reached\"; Request ID: \"<request-id>\"",
  "responseInfo": {
    "statusCode": 403,
    "body": {
      "type": "error",
      "status": 403,
      "code": "storage_limit_exceeded",
      "help_url": "http://developers.box.com/docs/#errors",
      "message": "Account storage limit reached",
      "request_id": "<request-id>"
    },
    "code": "\"storage_limit_exceeded\"",
    "requestId": "\"<request-id>\"",
    "helpUrl": "\"http://developers.box.com/docs/#errors\""
  }
}
```

**After**
```json
{
  "message": "403 storage_limit_exceeded Account storage limit reached; Request ID: <request-id>",
  "responseInfo": {
    "statusCode": 403,
    "body": {
      "type": "error",
      "status": 403,
      "code": "storage_limit_exceeded",
      "help_url": "http://developers.box.com/docs/#errors",
      "message": "Account storage limit reached",
      "request_id": "<request-id>"
    },
    "code": "storage_limit_exceeded",
    "requestId": "<request-id>",
    "helpUrl": "http://developers.box.com/docs/#errors"
  }
}
```

Note how `responseInfo.code` carries embedded quotes (`"\"storage_limit_exceeded\""`)
while `responseInfo.body.code` — the raw parsed payload — is already correct.
The fix makes the two agree.

## Root cause

`src/networking/boxNetworkClient.ts` extracts these fields with
`sdToJson(fetchResponse.data['code'])`. `sdToJson` serializes to a JSON
string, so a string value gains surrounding quotes.

## Fix

Read each scalar field with an `sdIsString` guard, which yields the raw
string and is safe on absent keys (unlike `getSdValueByKey`, which throws on
a missing key). `context_info` (a map) is untouched.

## Tests

The repository's tests are the generated integration suites under `src/test/`,
so I've left those untouched rather than add an out-of-pattern unit test under
`src/networking/`.

Verified locally with a throwaway test that mocks `nodeFetch` and drives a 403
through `BoxNetworkClient.fetch`: it fails against the current implementation
(`responseInfo.code` === `"\"storage_limit_exceeded\""`) and passes after this
change (`responseInfo.code` === `storage_limit_exceeded`), with `error.message`
losing its stray quotes. Happy to contribute that as a proper test if you can
point me at where error-path coverage belongs in the generated layout.

## Breaking change

No type signatures change, so consumer code continues to compile. But the
runtime values of `responseInfo.code`, `responseInfo.requestId`,
`responseInfo.helpUrl`, and `error.message` change — they lose the erroneous
quotes. Anyone who worked around the previous quoting will need to adjust;
anyone doing the natural `code === 'storage_limit_exceeded'` comparison starts
working correctly. Additionally, a present-but-non-string field now yields
`undefined` rather than a JSON-encoded string (Box's error schema always
sends strings for these). Suggest an appropriate version bump / changelog
note.

## Note for maintainers

Same codegen question as the companion export PR (#1558) — if
`boxNetworkClient.ts` is generated, point me at the generator source and I'll
move it there.
