### PR TITLE
ci: add GitHub Actions workflow to auto-generate PR titles using Box AI

### DIFF
--- a/.github/workflows/boxai-pr-title.yml
+++ b/.github/workflows/boxai-pr-title.yml
@@ -1,0 +1,20 @@
+name: Box AI PR Title
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  rename-pr:
+    if: github.event.label.name == 'boxai-rename'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate and apply PR title
+        uses: congminh1254/boxai-rename-pr@main
+        with:
+          box-jwt-config: ${{ secrets.JWT_CONFIG_BASE_64 }}
+          remove-label: boxai-rename

--- a/.github/workflows/boxai-pr-title.yml
+++ b/.github/workflows/boxai-pr-title.yml
@@ -1,7 +1,7 @@
 name: Box AI PR Title
 
 on:
-  pull_request_target:
+  pull_request:
     types: [labeled]
 
 permissions:


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that generates PR titles using Box AI
- Triggered when the `boxai-rename` label is added to a PR
- Uses `congminh1254/boxai-rename-pr` composite action
- Automatically removes the label after renaming

## How it works
1. Add `boxai-rename` label to any PR
2. Workflow fetches PR context (commits, files, diff)
3. Uploads context to Box, calls Box AI `text_gen` to generate a title
4. Updates the PR title (preserving scope like `boxsdkgen`)
5. Removes the `boxai-rename` label

## Secrets required
- `JWT_CONFIG_BASE_64` — already configured for integration tests

## Test plan
- [ ] Add `boxai-rename` label to this PR to test the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)